### PR TITLE
Fix logging

### DIFF
--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -24,10 +24,11 @@ module ForemanTasks
       if data[:state] == :pending
         task = ::ForemanTasks::Task::DynflowTask.new
         task.update_from_dynflow(data, false)
-        Lock.owner!(::User.current, task.id)
+        Lock.owner!(::User.current, task.id) if ::User.current
       elsif data[:state] != :planning
-        task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
-        task.update_from_dynflow(data, true)
+        if task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
+          task.update_from_dynflow(data, true)
+        end
       end
     end
 


### PR DESCRIPTION
There was a problem in the rescuing from exception (due to changed way of accessing to the logger), that might cause breaking Dynfow executor, possibly leading to deadlocks when waiting for the plan to finish (for example when exiting a web server in development mode)
