### PR TITLE
Make dynflow, sequel and sinatra foreman-tasks deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Put the following to your Foreman's bundle.d/Gemfile.local.rb:
 
 ```ruby
 gem 'dynflow', :git => 'git@github.com:iNecas/dynflow.git'
-gem 'sinatra' # we use the dynflow web console
-gem 'sequel'  # we use the dynflow default Dynflow persistence adapter
 gem 'foreman-tasks', :git => 'git@github.com:iNecas/foreman-tasks.git'
 ```
 

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -24,4 +24,7 @@ DESC
 
   s.add_dependency "rails", "~> 3.2.15"
   s.add_dependency "uuidtools"
+  s.add_dependency "dynflow"
+  s.add_dependency "sequel" # for Dynflow process persistence
+  s.add_dependency "sinatra" # for Dynflow web console
 end

--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -1,3 +1,5 @@
+require 'dynflow'
+
 module ForemanTasks
   # Class for configuring and preparing the Dynflow runtime environment.
   class Dynflow


### PR DESCRIPTION
As they are needed for dynflow to work properly. It doesn't mean any
of that will be used when dynflow is not used by the Foreman instance
