### PR TITLE
Separate planning and execution phase of the action from ActiveRecord hook

### DIFF
--- a/app/models/foreman_tasks/concerns/architecture_action_subject.rb
+++ b/app/models/foreman_tasks/concerns/architecture_action_subject.rb
@@ -1,27 +1,19 @@
 module ForemanTasks
   module Concerns
     module ArchitectureActionSubject
-      extend ActiveSupport::Concern
       include ForemanTasks::Concerns::ActionSubject
 
-      included do
-        after_create :trigger_create_action
-        after_update :trigger_update_action
-        after_destroy :trigger_destroy_action
+      def create_action
+        ::Actions::Foreman::Architecture::Create
       end
 
-      def trigger_create_action
-        ForemanTasks.trigger(::Actions::Foreman::Architecture::Create, self)
+      def update_action
+        ::Actions::Foreman::Architecture::Update
       end
 
-      def trigger_update_action
-        ForemanTasks.trigger(::Actions::Foreman::Architecture::Update, self)
+      def destroy_action
+        ::Actions::Foreman::Architecture::Destroy
       end
-
-      def trigger_destroy_action
-        ForemanTasks.trigger(::Actions::Foreman::Architecture::Destroy, self)
-      end
-
     end
   end
 end


### PR DESCRIPTION
When entering run/finalize phase, it's expected the transaction of
planning phase to be committed, which is to guaranteed when starting
the execution from withing the transaction.
