### PR TITLE
Fix loading web console with lazy world initialization

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Foreman::Application.routes.draw do
       end
     end
 
-    if ForemanTasks.dynflow.initialized?
+    if ForemanTasks.dynflow.required?
       require 'dynflow/web_console'
       mount ForemanTasks.dynflow.web_console => "/dynflow"
     end

--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -20,6 +20,10 @@ module ForemanTasks
       @required = true
     end
 
+    def required?
+      @required
+    end
+
     def initialized?
       !@world.nil?
     end


### PR DESCRIPTION
With lazy loading, the world doesn't have to be initialized yet, but we want to mount the web console there.
