### PR TITLE
Daemonization support for dynflow executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ Dynflow is set to use external process in production mode by default
 The executor process needs to be executed before the web server. You
 can run it by:
 
-```ruby
+```
 RAILS_ENV=production bundle exec rake foreman_tasks:dynflow:executor
 ```
+
+Also, there is a possibility to run the executor in daemonized mode
+using the `dynflow-executor`. It expects to be executed from Foreman
+rails root directory. See `-h` for more details and options
 
 Documentation
 -------------

--- a/bin/dynflow-executor
+++ b/bin/dynflow-executor
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+options = { foreman_root: Dir.pwd }
+
+opts = OptionParser.new do |opts|
+  opts.banner = <<BANNER
+Run Dynflow executor for Foreman tasks.
+
+Usage: #{File.basename($0)} [options] ACTION"
+
+ACTION can be one of:
+
+  * start   - start the executor on background. It creates these files
+              in tmp/pid directory:
+
+                * dynflow_executor_monitor.pid - pid of monitor ensuring
+                                                 the executor keeps running
+                * dynflow_executor.pid         - pid of the executor itself
+                * dynflow_executor.output      - stdout of the executor
+  * stop    - stops the running executor
+  * restart - restarts the running executor
+  * run     - run the executor in foreground
+
+BANNER
+
+  opts.on('-h', '--help', 'Show this message') do
+    puts opts
+    exit 1
+  end
+  opts.on('-f', '--foreman-root=PATH', "Path to Foreman Rails root path. By default '#{options[:foreman_root]}'") do |path|
+    options[:foreman_root] = path
+  end
+end
+
+args = opts.parse!(ARGV)
+command = args.first || 'run'
+
+app_file = File.expand_path('./config/application', options[:foreman_root])
+require app_file
+
+ForemanTasks::Dynflow::Daemon.new.run_background(command, options)

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -27,4 +27,5 @@ DESC
   s.add_dependency "dynflow"
   s.add_dependency "sequel" # for Dynflow process persistence
   s.add_dependency "sinatra" # for Dynflow web console
+  s.add_dependency "daemons" # for running remote executor
 end

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -36,7 +36,7 @@ module ForemanTasks
       self.dynflow_logger      = Rails.logger
       self.pool_size           = 5
       self.remote              = Rails.env.production?
-      self.remote_socket_path  = File.join(Rails.root, "tmp", "dynflow_socket")
+      self.remote_socket_path  = File.join(Rails.root, "tmp", "sockets", "dynflow_socket")
       self.persistence_adapter = default_persistence_adapter
       self.transaction_adapter = ::Dynflow::TransactionAdapters::ActiveRecord.new
       self.eager_load_paths    = []

--- a/lib/foreman_tasks/dynflow/daemon.rb
+++ b/lib/foreman_tasks/dynflow/daemon.rb
@@ -1,7 +1,68 @@
 module ForemanTasks
   class Dynflow::Daemon
-    def run
-      ::Dynflow::Daemon.new(listener, world, lock_file).run
+
+    # load the Rails environment and initialize the executor and listener
+    # in this thread.
+    def run(foreman_root = Dir.pwd)
+      STDERR.puts("Starting Rails environment")
+      foreman_env_file = File.expand_path("./config/environment.rb", foreman_root)
+      unless File.exists?(foreman_env_file)
+        raise "#{foreman_root} doesn't seem to be a foreman root directory"
+      end
+      ForemanTasks.dynflow.executor!
+      require foreman_env_file
+      STDERR.puts("Starting listener")
+      daemon = ::Dynflow::Daemon.new(listener, world, lock_file)
+      STDERR.puts("Everything ready")
+      daemon.run
+    end
+
+    # run the executor as a daemon
+    def run_background(command = "start", options = {})
+      default_options = { foreman_root: Dir.pwd,
+                          process_name: 'dynflow_executor',
+                          pid_dir: "#{Rails.root}/tmp/pids",
+                          wait_attempts: 300,
+                          wait_sleep: 1 }
+      options = default_options.merge(options)
+      begin
+        require 'daemons'
+      rescue LoadError
+        raise "You need to add gem 'daemons' to your Gemfile if you wish to use it."
+      end
+
+      unless %w[start stop restart run].include?(command)
+        raise "Command exptected to be 'start', 'stop', 'restart', 'run', was #{command.inspect}"
+      end
+
+      STDERR.puts("Dynflow Executor: #{command} in progress")
+
+      Daemons.run_proc(options[:process_name],
+                       :dir => options[:pid_dir],
+                       :dir_mode => :normal,
+                       :monitor => true,
+                       :log_output => true,
+                       :ARGV => [command]) do |*args|
+        begin
+          run(options[:foreman_root])
+        rescue => e
+          STDERR.puts e.message
+          Rails.logger.fatal e
+          exit 1
+        end
+      end
+      if command == "start" || command == "restart"
+        STDERR.puts('Waiting for the executor to be ready...')
+        options[:wait_attempts].times do |i|
+          STDERR.print('.')
+          if File.exists?(lock_file)
+            STDERR.puts('executor started successfully')
+            break
+          else
+            sleep options[:wait_sleep]
+          end
+        end
+      end
     end
 
     protected

--- a/lib/foreman_tasks/tasks/dynflow.rake
+++ b/lib/foreman_tasks/tasks/dynflow.rake
@@ -1,10 +1,6 @@
 namespace :foreman_tasks do
   namespace :dynflow do
     task :executor  do
-      ForemanTasks.dynflow.executor!
-      puts 'Loading Rails environment...'
-      Rake::Task[:environment].invoke
-      puts 'Executor is ready'
       ForemanTasks::Dynflow::Daemon.new.run
     end
   end


### PR DESCRIPTION
One can use `bin/dynflow-executor` from the Foreman rails root
to run dynflow executor. Supported commands:

```
start - start executor on background, waits till the executor is ready
stop - stop the executor
restart - restarts the executor
run - run the executor in foreground
```
