### PR TITLE
Use separate database when running on sqlite3

### DIFF
--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -71,7 +71,16 @@ module ForemanTasks
     def default_sequel_adapter_options
       db_config            = ActiveRecord::Base.configurations[Rails.env].dup
       db_config['adapter'] = 'postgres' if db_config['adapter'] == 'postgresql'
-      db_config['adapter'] = 'sqlite' if db_config['adapter'] == 'sqlite3'
+
+      if db_config['adapter'] == 'sqlite3'
+        db_config['adapter'] = 'sqlite'
+        database = db_config['database']
+        unless database == ':memory:'
+          # We need to create separate database for sqlite
+          # to avoid lock conflicts on the database
+          db_config['database'] = "#{File.dirname(database)}/dynflow-#{File.basename(database)}"
+        end
+      end
       return db_config
     end
 


### PR DESCRIPTION
To avoid ugly SQLite3::BusyException: database is locked when sharing
the database with ActiveRecord

To have cleaner look on what's it about, see http://ci.theforeman.org/job/test_katello_core/1030/database=sqlite3,ruby=1.9.3/testReport/(root)/Katello__ActivationKey__in invalid state/test_0004_should_be_invalid_if_environment_in_another_org_is_specified/
