### PR TITLE
Delay world initialization when using PhusionPassenger

### DIFF
--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -31,6 +31,10 @@ module ForemanTasks
     def initialize!
       return unless @required
       return @world if @world
+
+      if config.lazy_initialization && defined? PhusionPassenger
+        config.dynflow_logger.warn("ForemanTasks: lazy loading with PhusionPassenger might lead to unexpected results")
+      end
       config.initialize_world.tap do |world|
         @world = world
 

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -40,7 +40,17 @@ module ForemanTasks
     end
 
     initializer "foreman_tasks.initialize_dynflow" do
-      ForemanTasks.dynflow.initialize! unless ForemanTasks.dynflow.config.lazy_initialization
+      unless ForemanTasks.dynflow.config.lazy_initialization
+        if defined?(PhusionPassenger)
+          PhusionPassenger.on_event(:starting_worker_process) do |forked|
+            if forked
+              ForemanTasks.dynflow.initialize!
+            end
+          end
+        else
+          ForemanTasks.dynflow.initialize!
+        end
+      end
     end
 
     rake_tasks do


### PR DESCRIPTION
Otherwise, the connections might be lost after initialization.
