### PR TITLE
enforce local executor in rake tasks

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -54,6 +54,8 @@ module ForemanTasks
     end
 
     rake_tasks do
+      # enforce local executor in rake tasks
+      ForemanTasks.dynflow.executor!
       load File.expand_path('../tasks/dynflow.rake', __FILE__)
     end
   end


### PR DESCRIPTION
Because the remote executor might not be ready yet (e.g. db:migrate)
