### PR TITLE
Hammer task plugin

### DIFF
--- a/foreman-tasks-hammer.gemspec
+++ b/foreman-tasks-hammer.gemspec
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "foreman_tasks/hammer/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = "foreman-tasks-hammer"
+  s.version     = ForemanTasks::Hammer::VERSION
+  s.authors     = ["Ivan Nečas"]
+  s.email       = ["inecas@redhat.com"]
+  s.homepage    = "https://github.com/iNecas/foreman-tasks"
+  s.summary     = "Foreman CLI plugin for showing tasks information for resoruces and users"
+  s.description = <<DESC
+Contains the code for showing of the tasks (results and progress) in the Hammer CLI.
+DESC
+
+  s.files = Dir["lib/foreman_tasks/hammer/**/*", "MIT-LICENSE", "README.md"]
+
+  s.add_dependency "powerbar"
+  s.add_dependency "hammer_cli_foreman"
+end

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -19,7 +19,9 @@ to resources. The locking allows dealing with preventing multiple colliding task
 same resource. It also optionally provides Dynflow infrastructure for using it for managing the tasks.
 DESC
 
-  s.files = Dir["{app,bin,config,db,lib}/**/*", "MIT-LICENSE", "README.md"]
+  s.files = Dir["{app,bin,config,db,lib}/**/*", "MIT-LICENSE", "README.md"].reject do |file|
+    file.start_with? "lib/foreman_tasks/hammer"
+  end
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 3.2.0"

--- a/lib/foreman_tasks/hammer.rb
+++ b/lib/foreman_tasks/hammer.rb
@@ -1,0 +1,8 @@
+module ForemanTasks
+  module Hammer
+    require 'foreman_tasks/hammer/helper'
+    require 'foreman_tasks/hammer/task_progress'
+    require 'foreman_tasks/hammer/async_command'
+    require 'foreman_tasks/hammer/task'
+  end
+end

--- a/lib/foreman_tasks/hammer/async_command.rb
+++ b/lib/foreman_tasks/hammer/async_command.rb
@@ -1,0 +1,22 @@
+module ForemanTasks
+  module Hammer
+
+    class AsyncCommand < HammerCLIForeman::WriteCommand
+      include ForemanTasks::Hammer::Helper
+
+      option '--async', :flag, 'Do not wait for the task'
+
+      def execute
+        if option_async?
+          super
+        else
+          task_progress(send_request)
+          HammerCLI::EX_OK
+        end
+      end
+
+      apipie_options
+    end
+
+  end
+end

--- a/lib/foreman_tasks/hammer/helper.rb
+++ b/lib/foreman_tasks/hammer/helper.rb
@@ -1,0 +1,36 @@
+module ForemanTasks
+  module Hammer
+    module Helper
+      # render the progress of the task using polling to the task API
+      def task_progress(task_or_id)
+        task_id = task_or_id.is_a?(Hash) ? task_or_id['id'] : task_or_id
+        ForemanTasks::Hammer::TaskProgress.new(task_id) { |id| load_task(id) }.tap do |task_progress|
+          task_progress.render
+        end
+      end
+
+      def load_task(id)
+        options = resource_config.merge(resource_config[:credentials].to_params)
+        client = ForemanApi::Base.new(options)
+        flatten_task(client.http_call(:get, "/foreman_tasks/api/tasks/#{id}").first)
+      end
+
+      def send_request
+        flatten_task(super)
+      end
+
+      # make sure to flatten the nested data, to use it easily in
+      # success_message, such as
+      #
+      #   success_messasge "Repository is being synchronized in task %{id}s"
+      #
+      def flatten_task(task)
+        if task.key?('id')
+          return task
+        else
+          return task.values.first
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_tasks/hammer/task.rb
+++ b/lib/foreman_tasks/hammer/task.rb
@@ -1,0 +1,25 @@
+module ForemanTasks
+  module Hammer
+    class Task < HammerCLI::AbstractCommand
+      class ProgressCommand < HammerCLIForeman::ReadCommand
+
+        include ForemanTasks::Hammer::Helper
+
+        command_name "progress"
+        desc "Show the progress of the task"
+        option '--id', "UUID", "UUID of the task", :required => true
+
+        def execute
+          task_progress(option_id)
+          HammerCLI::EX_OK
+        end
+
+      end
+
+      autoload_subcommands
+    end
+
+    HammerCLI::MainCommand.subcommand 'task', "Tasks related actions.", Task
+  end
+end
+

--- a/lib/foreman_tasks/hammer/task_progress.rb
+++ b/lib/foreman_tasks/hammer/task_progress.rb
@@ -1,0 +1,71 @@
+require 'powerbar'
+module ForemanTasks
+  module Hammer
+    class TaskProgress
+      attr_accessor :interval, :task
+
+      def initialize(task_id, &block)
+        @update_block = block
+        @task_id      = task_id
+        @interval     = 2
+      end
+
+      def render
+        update_task
+        if task_pending?
+          render_progress
+        else
+          render_result
+        end
+      end
+
+      private
+
+      def render_progress
+        progress_bar do |bar|
+          begin
+            while true
+              bar.show(:msg => "Task #{@task_id} progress", :done => @task['progress'].to_f, :total => 1)
+              if task_pending?
+                sleep interval
+                update_task
+              else
+                break
+              end
+            end
+          rescue Interrupt
+            # Inerrupting just means we stop rednering the progress bar
+          end
+        end
+      end
+
+      def render_result
+        puts "Task %{uuid}: %{result}" % { :uuid => @task_id, :result => @task['result'] }
+        unless @task['humanized']['output'].to_s.empty?
+          puts @task['humanized']['output']
+        end
+      end
+
+      def update_task
+        @task = @update_block.call(@task_id)
+      end
+
+      def task_pending?
+        !%w[paused stopped].include?(@task['state'])
+      end
+
+      def progress_bar
+        bar                                      = PowerBar.new
+        @closed = false
+        bar.settings.tty.finite.template.main    = '[${<bar>}] [${<percent>%}]'
+        bar.settings.tty.finite.template.padchar = ' '
+        bar.settings.tty.finite.template.barchar = '.'
+        bar.settings.tty.finite.output           = Proc.new { |s| $stderr.print s }
+        yield bar
+      ensure
+        bar.close
+        render_result
+      end
+    end
+  end
+end

--- a/lib/foreman_tasks/hammer/version.rb
+++ b/lib/foreman_tasks/hammer/version.rb
@@ -1,0 +1,5 @@
+module ForemanTasks
+  module Hammer
+    VERSION = '0.0.1' unless defined? VERSION
+  end
+end


### PR DESCRIPTION
Allows waiting for async task after the task was triggered.

Usage:

``` ruby
class MyAsyncCommand < ForemanTasks::Hammer::AsyncCommand
  action "run"
  command_name "run"

  success_message "Task started with id %{id}s"
  failure_message "Could not run the task"

  apipie_options
end
```

Also, there is `ForemanTasks::Hammer::Helper` with helper methods, if
the `AsyncCommand` class doesn't fit for the case.

The `AsyncCommand` comes with `--async` option so that the command
doesn't wait for the task to finish.

Also, there is a `task` command with `progress` action, showing the
progress for action based on id.
