### PR TITLE
Additional scopes for searching getting tasks for actions and resources

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -22,8 +22,12 @@ module ForemanTasks
     scoped_search :in => :owners,  :on => :login, :complete_value => true, :rename => "owner.login", :ext_method => :search_by_owner
     scoped_search :in => :owners,  :on => :firstname, :complete_value => true, :rename => "owner.firstname", :ext_method => :search_by_owner
 
-
     scope :active, -> {  where('state != ?', :stopped) }
+    scope :for_resource,
+        (lambda do |resource|
+           joins(:locks).where(:"foreman_tasks_locks.resource_id" => resource.id,
+                               :"foreman_tasks_locks.resource_type" => resource.class.name)
+         end)
 
     def input
       {}

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -1,6 +1,8 @@
 module ForemanTasks
   class Task::DynflowTask < ForemanTasks::Task
 
+    scope :for_action, ->(action_class) { where(label: action_class.name) }
+
     def update_from_dynflow(data, planned)
       self.external_id = data[:id]
       self.started_at  = data[:started_at]
@@ -47,8 +49,6 @@ module ForemanTasks
         main_action.cli_example
       end
     end
-
-    protected
 
     def main_action
       return @main_action if @main_action


### PR DESCRIPTION
Also make `DynflowTask#main_action` unprotected, as it might be useful
for getting the data from the action.
