### PR TITLE
Don't precalculate the progress in persistence

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -81,6 +81,17 @@ module ForemanTasks
       return {:conditions => condition, :joins => joins }
     end
 
+    def progress
+      case self.state.to_s
+      when "running", "paused"
+        0.5
+      when "stopped"
+        1
+      else
+        0
+      end
+    end
+
     protected
 
     def generate_id

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -17,13 +17,12 @@ module ForemanTasks
         unless self.label
           self.label = main_action.class.name
         end
-        update_progress
       end
       self.save!
     end
 
-    def update_progress
-      self.progress = execution_plan.progress
+    def progress
+      execution_plan.progress
     end
 
     def execution_plan

--- a/db/migrate/20140324104010_remove_foreman_tasks_progress.rb
+++ b/db/migrate/20140324104010_remove_foreman_tasks_progress.rb
@@ -1,0 +1,5 @@
+class RemoveForemanTasksProgress < ActiveRecord::Migration
+  def change
+    remove_column :foreman_tasks_tasks, :progress
+  end
+end

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -27,7 +27,9 @@ module ForemanTasks
         Lock.owner!(::User.current, task.id) if ::User.current
       elsif data[:state] != :planning
         if task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
-          task.update_from_dynflow(data, true)
+	  unless task.state.to_s == data[:state].to_s
+            task.update_from_dynflow(data, true)
+	  end
         end
       end
     end


### PR DESCRIPTION
Dynflow now precalculates the progress while running the task so these
is not needed to be done here. This makes the execution much
effective, eliminating unnecessary calls for loading all the actions
every time something changes.

We can do this partly thanks to this PR https://github.com/Dynflow/dynflow/pull/110
