### PR TITLE
Fixes #6193 - make sure we increase the AR db pool soon enough

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -58,6 +58,8 @@ module ForemanTasks
         ForemanTasks.dynflow.eager_load_actions!
       end
 
+      ForemanTasks.dynflow.config.increase_db_pool_size
+
       unless ForemanTasks.dynflow.config.lazy_initialization
         if defined?(PhusionPassenger)
           PhusionPassenger.on_event(:starting_worker_process) do |forked|


### PR DESCRIPTION
With lazy loading of the world, we tried to increase the pool
(and reconnect the pool) while some other parts already used that, causing db
seed to fail
