### PR TITLE
Refs #6180 - make sure the task label is set before the planning starts

### DIFF
--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -5,21 +5,13 @@ module ForemanTasks
 
     scope :for_action, ->(action_class) { where(label: action_class.name) }
 
-    def update_from_dynflow(data, planned)
+    def update_from_dynflow(data)
       self.external_id = data[:id]
       self.started_at  = data[:started_at]
       self.ended_at    = data[:ended_at]
       self.state       = data[:state].to_s
       self.result      = data[:result].to_s
-
-      if planned
-        # for now, this part needs to laod the execution_plan to
-        # load extra data, there is place for optimization on Dynflow side
-        # if needed (getting more keys into the data value)
-        unless self.label
-          self.label = main_action.class.name
-        end
-      end
+      self.label       ||= main_action.class.name
       self.save!
     end
 

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -21,14 +21,14 @@ module ForemanTasks
     def on_execution_plan_save(execution_plan_id, data)
       # We can load the data unless the execution plan was properly planned and saved
       # including its steps
-      if data[:state] == :pending
+      if data[:state] == :planning
         task = ::ForemanTasks::Task::DynflowTask.new
-        task.update_from_dynflow(data, false)
+        task.update_from_dynflow(data)
         Lock.owner!(::User.current, task.id) if ::User.current
-      elsif data[:state] != :planning
+      elsif data[:state] != :pending
         if task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
           unless task.state.to_s == data[:state].to_s
-            task.update_from_dynflow(data, true)
+            task.update_from_dynflow(data)
           end
         end
       end


### PR DESCRIPTION
With this fix, we can rely on the label not being nil until the planning
finishes.
