### PR TITLE
Fixes #7301 - infrastructure for bulk actions via dynflow

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -8,9 +8,13 @@ module ForemanTasks
 
     def index
       params[:order] ||= 'started_at DESC'
-      @tasks         = Task.
-          search_for(params[:search], :order => params[:order]).
-          paginate(:page => params[:page])
+      @tasks         = filter(Task)
+    end
+
+    def sub_tasks
+      task   = Task.find(params[:id])
+      @tasks = filter(task.sub_tasks)
+      render :index
     end
 
     def cancel_step
@@ -60,6 +64,11 @@ module ForemanTasks
 
     def find_task
       ForemanTasks::Task::DynflowTask.find(params[:id])
+    end
+
+    def filter(scope)
+      scope.search_for(params[:search], :order => params[:order]).
+          paginate(:page => params[:page])
     end
 
   end

--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -1,6 +1,10 @@
 module Actions
   class Base < Dynflow::Action
 
+    def task
+      @task ||= ::ForemanTasks::Task::DynflowTask.find_by_external_id!(execution_plan_id)
+    end
+
     # This method says what data form input gets into the task details in Rest API
     # By default, it sends the whole input there.
     def task_input

--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -1,0 +1,166 @@
+module Actions
+
+  class BulkAction < Actions::EntryAction
+
+    middleware.use Actions::Middleware::KeepCurrentUser
+
+    SubPlanFinished = Algebrick.type do
+      fields! :execution_plan_id => String,
+              :success           => type { variants TrueClass, FalseClass }
+    end
+
+    # == Parameters:
+    # actions_class::
+    #   Class of action to trigger on targets
+    # targets::
+    #   Array of objects on which the action_class should be triggered
+    # *args::
+    #   Arguments that all the targets share
+    def plan(action_class, targets, *args)
+      check_targets!(targets)
+      plan_self(:action_class => action_class.to_s,
+                :target_ids => targets.map(&:id),
+                :target_class => targets.first.class.to_s,
+                :args => args)
+    end
+
+    def humanized_name
+      _("Bulk action")
+    end
+
+    def humanized_input
+      a_sub_task = task.sub_tasks.first
+      if a_sub_task
+        [a_sub_task.humanized[:action].to_s.downcase] +
+            Array(a_sub_task.humanized[:input]) + ['...']
+      end
+    end
+
+    def humanized_output
+      return unless counts_set?
+      _("%{total} tasks, %{success} success, %{failed} fail") %
+          { total:   output[:total_count],
+            success: output[:success_count],
+            failed:  output[:failed_count] }
+    end
+
+    def run(event = nil)
+      case(event)
+      when nil
+        if output[:total_count]
+          resume
+        else
+          initiate_sub_plans
+        end
+      when SubPlanFinished
+        mark_as_done(event.execution_plan_id, event.success)
+        if done?
+          check_for_errors!
+        else
+          suspend
+        end
+      end
+    end
+
+    # @api override when the logic for the initiation of the subtasks
+    #      is different from the default one
+    def create_sub_plans
+      action_class = input[:action_class].constantize
+      target_class = input[:target_class].constantize
+      targets = target_class.where(:id => input[:target_ids])
+
+      targets.map do |target|
+        ForemanTasks.trigger(action_class, target, *input[:args])
+      end
+    end
+
+    def initiate_sub_plans
+      output.update(total_count: 0,
+                    failed_count: 0,
+                    success_count: 0)
+
+      planned, failed = create_sub_plans.partition(&:planned?)
+
+      sub_plan_ids = ((planned + failed).map(&:execution_plan_id))
+      set_parent_task_id(sub_plan_ids)
+
+      output[:total_count] = sub_plan_ids.size
+      output[:failed_count] = failed.size
+
+      if planned.any?
+        wait_for_sub_plans(planned)
+      else
+        check_for_errors!
+      end
+    end
+
+    def resume
+      if task.sub_tasks.active.any?
+        fail _("Some sub tasks are still not finished")
+      end
+    end
+
+    def rescue_strategy
+      Dynflow::Action::Rescue::Skip
+    end
+
+    def wait_for_sub_plans(plans)
+      suspend do |suspended_action|
+        plans.each do |plan|
+          plan.finished.do_then do |value|
+            suspended_action << SubPlanFinished[plan.execution_plan_id,
+                                                value.result == :success]
+          end
+        end
+      end
+    end
+
+    def mark_as_done(plan_id, success)
+      if success
+        output[:success_count] += 1
+      else
+        output[:failed_count] += 1
+      end
+    end
+
+    def done?
+      if counts_set?
+        output[:total_count] - output[:success_count] - output[:failed_count] <= 0
+      else
+        false
+      end
+    end
+
+    def run_progress
+      if counts_set?
+        (output[:success_count] + output[:failed_count]).to_f / output[:total_count]
+      else
+        0.1
+      end
+    end
+
+    def counts_set?
+      output[:total_count] && output[:success_count] && output[:failed_count]
+    end
+
+    def set_parent_task_id(sub_plan_ids)
+      ForemanTasks::Task::DynflowTask.
+          where(external_id: sub_plan_ids).
+          update_all(parent_task_id: task.id)
+    end
+
+    def check_targets!(targets)
+      if targets.empty?
+        fail _("Empty bulk action")
+      end
+      if targets.map(&:class).uniq.length > 1
+        fail _("The targets are of different types")
+      end
+    end
+
+    def check_for_errors!
+      fail _("A sub task failed") if output[:failed_count] > 0
+    end
+
+  end
+end

--- a/app/lib/actions/helpers/lock.rb
+++ b/app/lib/actions/helpers/lock.rb
@@ -1,10 +1,6 @@
 module Actions
   module Helpers
     module Lock
-      def task
-        ::ForemanTasks::Task::DynflowTask.find_by_external_id!(execution_plan_id)
-      end
-
       # @see Lock.exclusive!
       def exclusive_lock!(resource)
         phase! Dynflow::Action::Plan

--- a/app/lib/actions/middleware/keep_current_user.rb
+++ b/app/lib/actions/middleware/keep_current_user.rb
@@ -1,0 +1,41 @@
+
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Middleware
+
+    class KeepCurrentUser < Dynflow::Middleware
+      def plan(*args)
+        pass(*args).tap { action.input[:current_user_id] = User.current.id }
+      end
+
+      def run(*args)
+        restore_curent_user { pass(*args) }
+      end
+
+      def finalize
+        restore_curent_user { pass }
+      end
+
+      private
+
+      def restore_curent_user
+        User.current = User.find(action.input[:current_user_id])
+        yield
+      ensure
+        User.current = nil
+      end
+
+    end
+  end
+end

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -8,6 +8,8 @@ module ForemanTasks
     self.primary_key = :id
     before_create :generate_id
 
+    belongs_to :parent_task, :class_name => 'ForemanTasks::Task'
+    has_many :sub_tasks, :class_name => 'ForemanTasks::Task', :foreign_key => :parent_task_id
     has_many :locks
 
     # in fact, the task has only one owner but Rails don't let you to

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -101,6 +101,16 @@
   <span class="param-name"><%= _("Params") %>:</span>
   <span class="param-value"><%= format_task_input(@task) %></span>
 </div>
+<% if @task.parent_task %>
+<div>
+  <span class="param-name"><%= link_to(_("Parent task"), foreman_tasks_task_path(@task.parent_task)) %></span>
+</div>
+<% end %>
+<% if @task.sub_tasks.any? %>
+<div>
+  <span class="param-name"><%= link_to(_("Sub tasks"), sub_tasks_foreman_tasks_task_path(@task)) %></span>
+</div>
+<% end %>
 <div class="row">
   <div class="col-xs-11">
     <div class="progress progress-striped <%= 'active' if @task.state == 'running' %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Foreman::Application.routes.draw do
         get 'auto_complete_search'
       end
       member do
+        get :sub_tasks
         post :resume
         post :unlock
         post :force_unlock

--- a/db/migrate/20140813215942_add_parent_task_id.rb
+++ b/db/migrate/20140813215942_add_parent_task_id.rb
@@ -1,0 +1,5 @@
+class AddParentTaskId < ActiveRecord::Migration
+  def change
+    add_column :foreman_tasks_tasks, :parent_task_id, :string, index: true
+  end
+end


### PR DESCRIPTION
Usage:

```
plan_action(::Actions::BulkAction, ActionToTriggerPerTarget, targets, *args)
```

This will plan the ActionToTriggerPerTarget on every target from the targets.
By default, it uses the targets class and the id of the targets for
serializing the data into the input and loading the objects back in the run
phase. The *args are also passed as arguments to the ActionToTriggerPerTarget.

To customize the logic around serialization/deserialization of the input
targets and args, one can override the `plan` and
`create_sub_plans` method.
