### PR TITLE
Fixes #9727 - trim action details on index page

### DIFF
--- a/app/helpers/foreman_tasks/tasks_helper.rb
+++ b/app/helpers/foreman_tasks/tasks_helper.rb
@@ -10,7 +10,7 @@ module ForemanTasks
           part.to_s
         end
       end.join('; ')
-      h(parts.join(" "))
+      parts.join(" ")
     end
   end
 end

--- a/app/views/foreman_tasks/tasks/index.html.erb
+++ b/app/views/foreman_tasks/tasks/index.html.erb
@@ -2,9 +2,6 @@
 <% title_actions help_path%>
 
 <style>
-  .task-id {
-    white-space: nowrap;
-  }
   .param-name {
     display: inline-block;
     width: 10em;
@@ -37,7 +34,7 @@ $(document).on('click', ".table-two-pane td.two-pane-link", function(e) {
   <% for task in @tasks %>
     <tr>
       <td class="task-id two-pane-link">
-        <%= link_to_if_authorized(format_task_input(task, true),
+        <%= link_to_if_authorized(trunc_with_tooltip(format_task_input(task, true), 80),
         hash_for_foreman_tasks_task_path(:id => task)) %>
       </td>
       <td><%= task.state %></td>

--- a/test/helpers/foreman_tasks/tasks_helper_test.rb
+++ b/test/helpers/foreman_tasks/tasks_helper_test.rb
@@ -12,10 +12,8 @@ module ForemanTasks
       end
 
       it 'formats the task input properly' do
-        expects(:h).with("user 'Anonymous Admin'")
-        format_task_input(@task)
-        expects(:h).with("Create user 'Anonymous Admin'")
-        format_task_input(@task, true)
+        format_task_input(@task).must_equal("user 'Anonymous Admin'")
+        format_task_input(@task, true).must_equal("Create user 'Anonymous Admin'")
       end
 
     end
@@ -38,10 +36,8 @@ module ForemanTasks
 
       it 'formats the task input properly' do
         response = "product 'product-2'; organization 'test-0'"
-        expects(:h).with(response)
-        format_task_input(@task)
-        expects(:h).with("Create #{response}")
-        format_task_input(@task, true)
+        format_task_input(@task).must_equal(response)
+        format_task_input(@task, true).must_equal("Create #{response}")
       end
     end
   end


### PR DESCRIPTION
otherwise actions with a lot of inputs cause the table column to
be very wide