### PR TITLE
Fixes #4450 - authorize the tasks

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -26,7 +26,7 @@ module ForemanTasks
       class BadRequest < Apipie::ParamError
       end
 
-      before_filter :find_task, :only => [:show]
+      before_filter :find_resource, :only => [:show]
 
       api :GET, "/tasks/:id", "Show task details"
       param :id, :identifier, desc: "UUID of the task"
@@ -79,7 +79,7 @@ module ForemanTasks
       private
 
       def search_tasks(search_params)
-        scope = ::ForemanTasks::Task.select('DISTINCT foreman_tasks_tasks.*')
+        scope = resource_scope_for_index.select('DISTINCT foreman_tasks_tasks.*')
         scope = ordering_scope(scope, search_params)
         scope = search_scope(scope, search_params)
         scope = active_scope(scope, search_params)
@@ -157,8 +157,17 @@ module ForemanTasks
 
       private
 
-      def find_task
-        @task = Task.find_by_id(params[:id])
+      def resource_scope(options = {})
+        @resource_scope ||= ForemanTasks::Task.authorized("#{action_permission}_foreman_tasks")
+      end
+
+      def action_permission
+        case params[:action]
+        when 'bulk_search'
+          :view
+        else
+          super
+        end
       end
     end
   end

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -1,26 +1,27 @@
 <p>
   <%= link_to(_('Auto Reload'), '', class: %w(btn btn-sm btn-default reload-button hidden)) %>
+  <% if authorized_for(:permission => :edit_foreman_tasks, :auth_object => @task) %>
+    <%= link_to(_('Dynflow console'),
+                format((defined?(Rails) ? request.script_name : '') + '/foreman_tasks/dynflow/%s', @task.external_id),
+                class: %w(btn btn-sm btn-default)) if Setting['dynflow_enable_console'] %>
 
-  <%= link_to(_('Dynflow console'),
-              format((defined?(Rails) ? request.script_name : '') + '/foreman_tasks/dynflow/%s', @task.external_id),
-              class: %w(btn btn-sm btn-default)) if Setting['dynflow_enable_console'] %>
+    <%= link_to(_('Resume'),
+                resume_foreman_tasks_task_path(@task),
+                class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.resumable?)].compact,
+                method: :post) %>
 
-  <%= link_to(_('Resume'),
-              resume_foreman_tasks_task_path(@task),
-              class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.resumable?)].compact,
-              method: :post) %>
+    <%= link_to(_('Unlock'),
+                '',
+                class:         ['btn', 'btn-sm', 'btn-warning', 'reload-button-stop', ('disabled' unless @task.state == 'paused')].compact,
+                :'data-toggle' => "modal",
+                :'data-target' => "#unlock_modal") %>
 
-  <%= link_to(_('Unlock'),
-              '',
-              class:         ['btn', 'btn-sm', 'btn-warning', 'reload-button-stop', ('disabled' unless @task.state == 'paused')].compact,
-              :'data-toggle' => "modal",
-              :'data-target' => "#unlock_modal") %>
-
-  <%= link_to(_('Force Unlock'),
-              '',
-              class:         ['btn', 'btn-sm', 'btn-danger', 'reload-button-stop', ('disabled' if @task.state == 'stopped')].compact,
-              :'data-toggle' => "modal",
-              :'data-target' => "#force_unlock_modal") %>
+    <%= link_to(_('Force Unlock'),
+                '',
+                class:         ['btn', 'btn-sm', 'btn-danger', 'reload-button-stop', ('disabled' if @task.state == 'stopped')].compact,
+                :'data-toggle' => "modal",
+                :'data-target' => "#force_unlock_modal") %>
+  <% end %>
 </p>
 
 <div class="modal fade" id="unlock_modal" tabindex="-1" role="dialog" aria-labelledby="Deploy" aria-hidden="true">

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -3,6 +3,7 @@ require 'foreman_tasks/task_error'
 require 'foreman_tasks/engine'
 require 'foreman_tasks/dynflow'
 require 'foreman_tasks/triggers'
+require 'foreman_tasks/authorizer_ext'
 
 module ForemanTasks
   extend Algebrick::TypeCheck

--- a/lib/foreman_tasks/authorizer_ext.rb
+++ b/lib/foreman_tasks/authorizer_ext.rb
@@ -1,0 +1,19 @@
+module ForemanTasks
+  # Monkey path until http://projects.theforeman.org/issues/8919 is
+  # resolved and released
+  module AuthorizerExt
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :resource_name, :authorized_resource_name
+    end
+
+    def resource_name_with_authorized_resource_name(klass)
+      if klass.respond_to?(:authorized_resource_name)
+        return klass.authorized_resource_name
+      else
+        resource_name_without_authorized_resource_name(klass)
+      end
+    end
+  end
+end

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -33,6 +33,11 @@ module ForemanTasks
     # what rake tasks should run their own executor, not depending on the external one
     attr_accessor :rake_tasks_with_executor
 
+    # if true, the ForemanTasks::Concerns::ActionTriggering will make
+    # no effect. Useful for testing, where we mignt not want to execute
+    # the orchestration tied to the models.
+    attr_accessor :disable_active_record_actions
+
     def initialize
       self.action_logger            = Rails.logger
       self.dynflow_logger           = Rails.logger

--- a/lib/foreman_tasks/dynflow/console_authorizer.rb
+++ b/lib/foreman_tasks/dynflow/console_authorizer.rb
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+module ForemanTasks
+  class Dynflow::ConsoleAuthorizer
+    def initialize(env)
+      @rack_request          = Rack::Request.new(env)
+      @user_id, @expires_at = @rack_request.session.values_at('user', 'expires_at')
+      @user                 = User.find_by_id(@user_id) unless session_expired?
+    end
+
+    def allow?
+      @user && (unlimited_edit? || authorized_for_task?)
+    end
+
+    private
+
+    def session_expired?
+      Time.now.to_i > @expires_at.to_i
+    end
+
+    def unlimited_edit?
+      return true if @user.admin?
+      # users with unlimited edit_foreman_tasks can operate with the
+      # console no matter what task it is…
+      edit_permission = Permission.where(:name => :edit_foreman_tasks, :resource_type => ForemanTasks::Task.name).first
+      if @user.filters.joins(:filterings).unlimited.where('filterings.permission_id' => edit_permission).first
+        return true
+      end
+    end
+
+    def authorized_for_task?
+      if task = extract_task
+        begin
+          original_user = User.current
+          User.current = @user
+          return Authorizer.new(@user).can?(:edit_foreman_tasks, task)
+        ensure
+          User.current = original_user
+        end
+      else
+        return false
+      end
+    end
+
+    def extract_task
+      dynflow_id = @rack_request.path_info[/^\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})/,1]
+      unless dynflow_id.empty?
+        ForemanTasks::Task::DynflowTask.where(:external_id => dynflow_id).first
+      end
+    end
+
+  end
+end

--- a/lib/foreman_tasks/tasks/test.rake
+++ b/lib/foreman_tasks/tasks/test.rake
@@ -1,13 +1,22 @@
 namespace :test do
-  namespace :foreman_tasks do
-    task :test => 'db:test:prepare' do
-      test_task = Rake::TestTask.new('foreman_tasks_test_task') do |t|
-        t.libs << ["test", "#{ForemanTasks::Engine.root}/test"]
-        t.test_files = ["#{ForemanTasks::Engine.root}/test/**/*_test.rb"]
-        t.verbose = true
-      end
-
-      Rake::Task[test_task.name].invoke
+  task :foreman_tasks => 'db:test:prepare' do
+    test_task = Rake::TestTask.new('foreman_tasks_test_task') do |t|
+      t.libs << ["test", "#{ForemanTasks::Engine.root}/test"]
+      t.test_files = ["#{ForemanTasks::Engine.root}/test/**/*_test.rb"]
+      t.verbose = true
     end
+
+    Rake::Task[test_task.name].invoke
+  end
+end
+
+Rake::Task[:test].enhance do
+  Rake::Task['test:foreman_tasks'].invoke
+end
+
+load 'tasks/jenkins.rake'
+if Rake::Task.task_defined?(:'jenkins:unit')
+  Rake::Task["jenkins:unit"].enhance do
+    Rake::Task['test:foreman_tasks'].invoke
   end
 end

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -3,16 +3,16 @@ require "foreman_tasks_test_helper"
 module ForemanTasks
   class Api::TasksControllerTest < ActionController::TestCase
     describe 'tasks api controller' do
+      tests ForemanTasks::Api::TasksController
 
       before do
         User.current = User.where(:login => 'apiadmin').first
         @request.env['HTTP_ACCEPT'] = 'application/json'
         @request.env['CONTENT_TYPE'] = 'application/json'
-        @task = FactoryGirl.build(:user_create_task)
+        @task = FactoryGirl.create(:dynflow_task, :user_create_task)
       end
 
       it 'searches for task on GET' do
-        Task.expects(:find_by_id).returns(@task)
         get(:show, :id => @task.id)
         assert_response :success
         assert_template 'api/tasks/show'

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -1,4 +1,8 @@
 require 'test_helper'
+require_relative './support/dummy_dynflow_action'
 
 FactoryGirl.definition_file_paths = ["#{ForemanTasks::Engine.root}/test/factories"]
 FactoryGirl.find_definitions
+
+ForemanTasks.dynflow.require!
+ForemanTasks.dynflow.config.disable_active_record_actions = true

--- a/test/helpers/foreman_tasks/tasks_helper_test.rb
+++ b/test/helpers/foreman_tasks/tasks_helper_test.rb
@@ -5,7 +5,7 @@ module ForemanTasks
 
     describe 'when formatting simple input' do
       before do
-        @task = FactoryGirl.build(:user_create_task)
+        @task = FactoryGirl.build(:dynflow_task, :user_create_task)
         humanized = {:action=>"Create", :input=>[[:user, {:text=>"user 'Anonymous Admin'", :link=>nil}]], :output=>"", :errors=>[]}
         @task.stubs(:input).returns({"user"=>{"id"=>1, "name"=>"Anonymous Admin"}, "locale"=>"en"})
         @task.stubs(:humanized).returns(humanized)
@@ -22,7 +22,7 @@ module ForemanTasks
 
     describe 'when formatting input' do
       before do
-        @task = FactoryGirl.build(:product_create_task)
+        @task = FactoryGirl.build(:dynflow_task, :product_create_task)
         humanized = {:action=>"Create",
                      :input=>[[:product, {:text=>"product 'product-2'", :link=>"#/products/3/info"}], [:organization, {:text=>"organization 'test-0'", :link=>"/organizations/3/edit"}]],
                      :output=>"",

--- a/test/support/dummy_dynflow_action.rb
+++ b/test/support/dummy_dynflow_action.rb
@@ -1,0 +1,4 @@
+module Support
+  class DummyDynflowAction < Dynflow::Action
+  end
+end

--- a/test/unit/dynflow_console_authorizer_test.rb
+++ b/test/unit/dynflow_console_authorizer_test.rb
@@ -1,0 +1,79 @@
+require "foreman_tasks_test_helper"
+
+module ForemanTasks
+  class DynflowConsoleAuthorizerTest <  ActiveSupport::TestCase
+    include Rack::Test::Methods
+
+    before do
+      User.current = User.where(:login => 'apiadmin').first
+    end
+
+    let(:own_task)     { FactoryGirl.create(:dynflow_task, :set_owner => user) }
+    let(:foreign_task) { FactoryGirl.create(:dynflow_task) }
+
+    let(:edit_foreman_tasks_permission) do
+      FactoryGirl.build(:permission).tap do |permission|
+        permission.name = :edit_foreman_tasks
+        permission.resource_type = ForemanTasks::Task.name
+        permission.save!
+      end
+    end
+
+    def dynflow_console_authorized?(task = nil)
+      dynflow_path = '/'
+      dynflow_path += task.external_id.to_s if task
+      dynflow_rack_env = { "rack.session" => { "user" => user.id, "expires_at" => Time.now + 100 },
+                           "PATH_INFO"     => dynflow_path}
+      ForemanTasks::Dynflow::ConsoleAuthorizer.new(dynflow_rack_env).allow?
+    end
+
+    describe 'admin user' do
+      let(:user) { FactoryGirl.create(:user, :admin) }
+      it 'can see all tasks' do
+        assert dynflow_console_authorized?
+        assert dynflow_console_authorized?(own_task)
+        assert dynflow_console_authorized?(foreign_task)
+      end
+    end
+
+    describe 'user with unlimited edit_foreman_tasks permissions' do
+      let(:user) do
+        user_role = FactoryGirl.create(:user_user_role)
+        FactoryGirl.create(:filter,
+                           :role => user_role.role, :permissions => [edit_foreman_tasks_permission])
+        user_role.owner
+      end
+
+      it 'can see all tasks' do
+        assert dynflow_console_authorized?
+        assert dynflow_console_authorized?(own_task)
+        assert dynflow_console_authorized?(foreign_task)
+      end
+    end
+
+    describe 'user with limited edit_foreman_tasks permissions' do
+      let(:user) do
+        user_role = FactoryGirl.create(:user_user_role)
+        FactoryGirl.create(:filter,
+                           :search => 'owner.id = current_user',
+                           :role => user_role.role, :permissions => [edit_foreman_tasks_permission])
+        user_role.owner
+      end
+
+      it 'can see only the tasks he has permissions on' do
+        refute dynflow_console_authorized?
+        assert dynflow_console_authorized?(own_task)
+        refute dynflow_console_authorized?(foreign_task)
+      end
+    end
+
+    describe 'user without edit_foreman_tasks permissions' do
+      let(:user) { FactoryGirl.create(:user) }
+      it 'can not see any tasks' do
+        refute dynflow_console_authorized?
+        refute dynflow_console_authorized?(own_task)
+        refute dynflow_console_authorized?(foreign_task)
+      end
+    end
+  end
+end

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -1,0 +1,37 @@
+require 'foreman_tasks_test_helper'
+
+class TasksTest < ActiveSupport::TestCase
+  describe 'filtering by current user' do
+    before { @original_current_user = User.current }
+    after  { User.current = @original_current_user }
+
+    test "can search the tasks by current_user" do
+      user_one = FactoryGirl.create(:user)
+      user_two = FactoryGirl.create(:user)
+
+      task_one = FactoryGirl.create(:some_task, :set_owner => user_one)
+      task_two = FactoryGirl.create(:some_task, :set_owner => user_two)
+
+      User.current = user_one
+      assert_equal [task_one], ForemanTasks::Task.search_for("owner.id = current_user")
+    end
+  end
+
+  describe 'authorization filtering' do
+    it 'can filter by the task subject' do
+      user_role  = FactoryGirl.create(:user_user_role)
+      user       = user_role.owner
+      role       = user_role.role
+      permission = FactoryGirl.build(:permission)
+      permission.resource_type = 'ForemanTasks::Task'
+      permission.save!
+      FactoryGirl.create(:filter, :role => role, :permissions => [permission])
+
+      User.current = user
+      task = FactoryGirl.create(:dynflow_task)
+
+      auth       = Authorizer.new(user)
+      assert auth.can?(permission.name.to_sym, task)
+    end
+  end
+end


### PR DESCRIPTION
There are two permissions: view_foreman_tasks for viewing and 
edit_foreman_tasks for controlling them.

Two default roles are pre-seeded: Tasks Reader and Tasks Manager. Also the
Anonymous role is added a permission to see user's own tasks, to prevent the
awkward moment when a user triggers a task and can't see the progress or
status.