### PR TITLE
Fixes #9508 - extract the triggering and waiting for sub plans from bulk actions

### DIFF
--- a/app/lib/actions/action_with_sub_plans.rb
+++ b/app/lib/actions/action_with_sub_plans.rb
@@ -1,0 +1,162 @@
+module Actions
+
+  class Actions::ActionWithSubPlans < Actions::EntryAction
+
+    middleware.use Actions::Middleware::KeepCurrentUser
+
+    SubPlanFinished = Algebrick.type do
+      fields! :execution_plan_id => String,
+              :success           => type { variants TrueClass, FalseClass }
+    end
+
+    def plan(*args)
+      raise NotImplementedError
+    end
+
+    def run(event = nil)
+      case(event)
+      when nil
+        if output[:total_count]
+          resume
+        else
+          sub_plans = create_sub_plans
+          sub_plans = Array[sub_plans] unless sub_plans.is_a? Array
+          wait_for_sub_plans(sub_plans)
+        end
+      when SubPlanFinished
+        mark_as_done(event.execution_plan_id, event.success)
+        if done?
+          check_for_errors!
+          on_finish
+        else
+          suspend
+        end
+      end
+    end
+
+    # @api override when the logic for the initiation of the subtasks
+    #      is different from the default one.
+    # @returns a triggered task or array of triggered tasks
+    # @example
+    #
+    #        def create_sub_plans
+    #          trigger(MyAction, "Hello")
+    #        end
+    #
+    # @example
+    #
+    #        def create_sub_plans
+    #          [trigger(MyAction, "Hello 1"), trigger(MyAction, "Hello 2")]
+    #        end
+    #
+    def create_sub_plans
+      raise NotImplementedError
+    end
+
+    # @api method to be called after all the sub tasks finished
+    def on_finish
+    end
+
+    def humanized_output
+      return unless counts_set?
+      _("%{total} tasks, %{success} success, %{failed} fail") %
+          { total:   output[:total_count],
+            success: output[:success_count],
+            failed:  output[:failed_count] }
+    end
+
+    # Helper for creating sub plans
+    def trigger(*args)
+      ForemanTasks.trigger(*args)
+    end
+
+    def wait_for_sub_plans(sub_plans)
+      output.update(total_count: 0,
+                    failed_count: 0,
+                    success_count: 0)
+
+      planned, failed = sub_plans.partition(&:planned?)
+
+      sub_plan_ids = ((planned + failed).map(&:execution_plan_id))
+      set_parent_task_id(sub_plan_ids)
+
+      output[:total_count] = sub_plan_ids.size
+      output[:failed_count] = failed.size
+
+      if planned.any?
+        notify_on_finish(planned)
+      else
+        check_for_errors!
+      end
+    end
+
+    def resume
+      if task.sub_tasks.active.any?
+        fail _("Some sub tasks are still not finished")
+      end
+    end
+
+    def rescue_strategy
+      Dynflow::Action::Rescue::Skip
+    end
+
+    def notify_on_finish(plans)
+      suspend do |suspended_action|
+        plans.each do |plan|
+          plan.finished.do_then do |value|
+            suspended_action << SubPlanFinished[plan.execution_plan_id,
+                                                value.result == :success]
+          end
+        end
+      end
+    end
+
+    def mark_as_done(plan_id, success)
+      if success
+        output[:success_count] += 1
+      else
+        output[:failed_count] += 1
+      end
+    end
+
+    def done?
+      if counts_set?
+        output[:total_count] - output[:success_count] - output[:failed_count] <= 0
+      else
+        false
+      end
+    end
+
+    def run_progress
+      if counts_set? && output[:total_count] > 0
+        (output[:success_count] + output[:failed_count]).to_f / output[:total_count]
+      else
+        0.1
+      end
+    end
+
+    def counts_set?
+      output[:total_count] && output[:success_count] && output[:failed_count]
+    end
+
+    def set_parent_task_id(sub_plan_ids)
+      ForemanTasks::Task::DynflowTask.
+          where(external_id: sub_plan_ids).
+          update_all(parent_task_id: task.id)
+    end
+
+    def check_targets!(targets)
+      if targets.empty?
+        fail _("Empty bulk action")
+      end
+      if targets.map(&:class).uniq.length > 1
+        fail _("The targets are of different types")
+      end
+    end
+
+    def check_for_errors!
+      fail _("A sub task failed") if output[:failed_count] > 0
+    end
+
+  end
+end

--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -1,14 +1,6 @@
 module Actions
 
-  class BulkAction < Actions::EntryAction
-
-    middleware.use Actions::Middleware::KeepCurrentUser
-
-    SubPlanFinished = Algebrick.type do
-      fields! :execution_plan_id => String,
-              :success           => type { variants TrueClass, FalseClass }
-    end
-
+  class BulkAction < Actions::ActionWithSubPlans
     # == Parameters:
     # actions_class::
     #   Class of action to trigger on targets
@@ -36,32 +28,6 @@ module Actions
       end
     end
 
-    def humanized_output
-      return unless counts_set?
-      _("%{total} tasks, %{success} success, %{failed} fail") %
-          { total:   output[:total_count],
-            success: output[:success_count],
-            failed:  output[:failed_count] }
-    end
-
-    def run(event = nil)
-      case(event)
-      when nil
-        if output[:total_count]
-          resume
-        else
-          initiate_sub_plans
-        end
-      when SubPlanFinished
-        mark_as_done(event.execution_plan_id, event.success)
-        if done?
-          check_for_errors!
-        else
-          suspend
-        end
-      end
-    end
-
     # @api override when the logic for the initiation of the subtasks
     #      is different from the default one
     def create_sub_plans
@@ -70,83 +36,8 @@ module Actions
       targets = target_class.where(:id => input[:target_ids])
 
       targets.map do |target|
-        ForemanTasks.trigger(action_class, target, *input[:args])
+        trigger(action_class, target, *input[:args])
       end
-    end
-
-    def initiate_sub_plans
-      output.update(total_count: 0,
-                    failed_count: 0,
-                    success_count: 0)
-
-      planned, failed = create_sub_plans.partition(&:planned?)
-
-      sub_plan_ids = ((planned + failed).map(&:execution_plan_id))
-      set_parent_task_id(sub_plan_ids)
-
-      output[:total_count] = sub_plan_ids.size
-      output[:failed_count] = failed.size
-
-      if planned.any?
-        wait_for_sub_plans(planned)
-      else
-        check_for_errors!
-      end
-    end
-
-    def resume
-      if task.sub_tasks.active.any?
-        fail _("Some sub tasks are still not finished")
-      end
-    end
-
-    def rescue_strategy
-      Dynflow::Action::Rescue::Skip
-    end
-
-    def wait_for_sub_plans(plans)
-      suspend do |suspended_action|
-        plans.each do |plan|
-          plan.finished.do_then do |value|
-            suspended_action << SubPlanFinished[plan.execution_plan_id,
-                                                value.result == :success]
-          end
-        end
-      end
-    end
-
-    def mark_as_done(plan_id, success)
-      if success
-        output[:success_count] += 1
-      else
-        output[:failed_count] += 1
-      end
-    end
-
-    def done?
-      if counts_set?
-        output[:total_count] - output[:success_count] - output[:failed_count] <= 0
-      else
-        false
-      end
-    end
-
-    def run_progress
-      if counts_set?
-        (output[:success_count] + output[:failed_count]).to_f / output[:total_count]
-      else
-        0.1
-      end
-    end
-
-    def counts_set?
-      output[:total_count] && output[:success_count] && output[:failed_count]
-    end
-
-    def set_parent_task_id(sub_plan_ids)
-      ForemanTasks::Task::DynflowTask.
-          where(external_id: sub_plan_ids).
-          update_all(parent_task_id: task.id)
     end
 
     def check_targets!(targets)
@@ -156,10 +47,6 @@ module Actions
       if targets.map(&:class).uniq.length > 1
         fail _("The targets are of different types")
       end
-    end
-
-    def check_for_errors!
-      fail _("A sub task failed") if output[:failed_count] > 0
     end
 
   end

--- a/app/lib/actions/middleware/set_current_task_id.rb
+++ b/app/lib/actions/middleware/set_current_task_id.rb
@@ -1,0 +1,44 @@
+
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Middleware
+
+    # Save the information about the current task id so that we can
+    # add it as parent_task_id in child tasks.
+    class SetCurrentTaskId < Dynflow::Middleware
+      def plan(*args)
+        set_current_task_id { pass(*args) }
+      end
+
+      def run(*args)
+        set_current_task_id { pass(*args) }
+      end
+
+      def finalize
+        set_current_task_id { pass }
+      end
+
+      private
+
+      def set_current_task_id
+        previous_task_id = Thread.current[:current_task_id]
+        Thread.current[:current_task_id] = action.task.id
+        yield
+      ensure
+        Thread.current[:current_task_id] = previous_task_id
+      end
+
+    end
+  end
+end

--- a/app/models/foreman_tasks/lock.rb
+++ b/app/models/foreman_tasks/lock.rb
@@ -57,7 +57,8 @@ module ForemanTasks
 
     # returns a scope of the locks colliding with this one
     def colliding_locks
-      colliding_locks_scope = Lock.active.where(Lock.arel_table[:task_id].not_eq(task_id))
+      task_ids = task.with_parents.map(&:id)
+      colliding_locks_scope = Lock.active.where(Lock.arel_table[:task_id].not_in(task_ids))
       colliding_locks_scope = colliding_locks_scope.where(name:          name,
                                                           resource_id:   resource_id,
                                                           resource_type: resource_type)

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -77,6 +77,14 @@ module ForemanTasks
       self.state == 'paused'
     end
 
+    def with_parents
+      [self].tap do |ret|
+        if parent_task
+          ret.concat(parent_task.with_parents)
+        end
+      end
+    end
+
     def self.search_by_generic_resource(key, operator, value)
       key =  "resource_type" if key.blank?
       key_name = self.connection.quote_column_name(key.sub(/^.*\./,''))

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -23,6 +23,7 @@ module ForemanTasks
       # including its steps
       if data[:state] == :planning
         task = ::ForemanTasks::Task::DynflowTask.new
+        task.parent_task_id = Thread.current[:current_task_id]
         task.update_from_dynflow(data)
         Lock.owner!(::User.current, task.id) if ::User.current
       elsif data[:state] != :pending

--- a/test/unit/actions/action_with_sub_plans_test.rb
+++ b/test/unit/actions/action_with_sub_plans_test.rb
@@ -1,0 +1,58 @@
+require "foreman_tasks_test_helper"
+
+module ForemanTasks
+  class ActionWithSubPlansTest <  ActiveSupport::TestCase
+    self.use_transactional_fixtures = false
+
+    before do
+      User.current = User.where(:login => 'apiadmin').first
+    end
+
+    # to be able to use the locking
+    class ::User < User.parent
+      include ForemanTasks::Concerns::ActionSubject
+    end
+
+    class ParentAction < Actions::ActionWithSubPlans
+      def plan(user)
+        action_subject(user)
+        plan_self(user_id: user.id)
+      end
+
+      def create_sub_plans
+        user = User.find(input[:user_id])
+        trigger(ChildAction, user)
+      end
+    end
+
+    class ChildAction < Actions::EntryAction
+      def plan(user)
+        action_subject(user)
+        plan_self(user_id: user.id)
+      end
+      def run
+      end
+    end
+
+    describe Actions::ActionWithSubPlans do
+      let(:task) do
+        user = FactoryGirl.create(:user)
+        triggered = ForemanTasks.trigger(ParentAction, user)
+        raise triggered.error if triggered.respond_to?(:error)
+        triggered.finished.wait(2)
+        ForemanTasks::Task.find_by_external_id(triggered.id)
+      end
+
+      specify "the sub-plan stores the information about its parent" do
+        task.sub_tasks.size.must_equal 1
+        task.sub_tasks.first.label.must_equal ChildAction.name
+      end
+
+      specify "the locks of the sub-plan don't colide with the locks of its parent" do
+        child_task = task.sub_tasks.first
+        assert(child_task.locks.any? { |lock| lock.name == 'write' }, "it's locks don't conflict with parent's")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Bulk actions is just one of the use-cases for using sub-plans. This patch
extract the common code to be used for triggering external tasks in general.

The usage is as follows: one needs to inherit it's action from the
``Actions::ActionWithSubPlans`` and override the
``create_sub_plans`` method. The ``create_sub_plans`` will be executed in run
phase and the rest of the action will make sure that the execution of the
action will wait till the sub plan is done. It also tracks the relation
between parent and child tasks, as it already did in bulk actions.

An example code could look like this (taken from real Katello actions):

    class SyncAsSubPlan < Actions::ActionWithSubPlans
     input_format do
       param :id, Integer
     end

      def plan(repository)
       plan_self(:id => repository.id)
     end

      def create_sub_plans
       trigger(Repository::Sync, ::Katello::Repository.find(input[:id]))
     end
   end