### PR TITLE
Fixes #8144 - cleanup mechanism for tasks

### DIFF
--- a/app/lib/actions/foreman/host/import_facts.rb
+++ b/app/lib/actions/foreman/host/import_facts.rb
@@ -35,6 +35,11 @@ module Actions
           input[:host] && input[:host][:name]
         end
 
+        # default value for cleaning up the tasks, it can be overriden by settings
+        def self.cleanup_after
+          '30d'
+        end
+
       end
     end
   end

--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -1,9 +1,26 @@
+:foreman-tasks:
+#
 # Logging configuration can be changed by uncommenting the loggers
 # section and the logger configuration desired.
 #
-# :foreman-tasks:
 #   :loggers:
 #     :dynflow:
 #       :enabled: true
 #     :action:
 #       :enabled: true
+
+
+# Cleaning configuration: how long should the actions be kept before deleted
+# by `rake foreman_tasks:clean` task
+#
+#  :cleanup:
+#
+# the period after which to delete all the tasks (by default all tasks are not being deleted after some period)
+#
+#    :after: 365d
+#
+# per action settings to override the default defined in the actions (self.cleanup_after method)
+#
+#    :actions:
+#      - :name: Actions::Foreman::Host::ImportFacts
+#        :after: 10d

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -4,6 +4,7 @@ require 'foreman_tasks/engine'
 require 'foreman_tasks/dynflow'
 require 'foreman_tasks/triggers'
 require 'foreman_tasks/authorizer_ext'
+require 'foreman_tasks/cleaner'
 
 module ForemanTasks
   extend Algebrick::TypeCheck

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -1,0 +1,152 @@
+module ForemanTasks
+  # Represents the cleanup mechanism for tasks
+  class Cleaner
+
+    def self.run(options)
+      if options.key?(:filter)
+        self.new(options).delete
+      else
+        [:after, :states].each do |invalid_option|
+          if options.key?(invalid_option)
+            raise "The option #{invalid_option} is not valid unless the filter specified"
+          end
+        end
+        if cleanup_settings[:after]
+          self.new(options.merge(:filter => "", :after  => cleanup_settings[:after])).delete
+        end
+        actions_with_default_cleanup.each do |action_class, period|
+          self.new(options.merge(:filter => "label = #{action_class.name}", :after  => period)).delete
+        end
+      end
+    end
+
+    def self.actions_with_default_cleanup
+      actions_with_periods = {}
+      if cleanup_settings[:actions]
+        cleanup_settings[:actions].each do |action|
+          begin
+            action_class = action[:name].constantize
+            actions_with_periods[action_class] = action[:after]
+          rescue => e
+            Foreman::Logging.exception("Error handling #{action} cleanup settings", e)
+          end
+        end
+      end
+      (ForemanTasks.dynflow.world.action_classes - actions_with_periods.keys).each do |action_class|
+        if action_class.respond_to?(:cleanup_after)
+          actions_with_periods[action_class] = action_class.cleanup_after
+        end
+      end
+      return actions_with_periods
+    end
+
+    def self.cleanup_settings
+      return @cleanup_settings if @cleanup_settings
+      @cleanup_settings = SETTINGS[:'foreman-tasks'] && SETTINGS[:'foreman-tasks'][:cleanup] || {}
+    end
+
+    attr_reader :filter, :after , :states, :verbose, :batch_size, :noop, :full_filter
+
+    # @param filter [String] scoped search matching the tasks to be deleted
+    # @param after [String|nil] delete the tasks after they are older
+    #                           than the value: the number in string is expected
+    #                           to be followed by time unit specification one of s,h,d,y for
+    #        seconds ago. If not specified, no implicit filtering on the date.
+    def initialize(options = {})
+      default_options = { :after        => '0s',
+                          :verbose      => false,
+                          :batch_size   => 1000,
+                          :noop         => false,
+                          :states       => ["stopped"] }
+      options         = default_options.merge(options)
+
+      @filter         = options[:filter]
+      @after          = parse_time_interval(options[:after])
+      @states         = options[:states]
+      @verbose        = options[:verbose]
+      @batch_size     = options[:batch_size]
+      @noop           = options[:noop]
+
+      raise ArgumentError, 'filter not speficied' if @filter.nil?
+
+      @full_filter    = prepare_filter
+    end
+
+    # Delete the filtered tasks, including the dynflow execution plans
+    def delete
+      if noop
+        say "[noop] deleting all tasks matching filter #{full_filter}"
+        say "[noop] #{ForemanTasks::Task.search_for(full_filter).size} tasks would be deleted"
+      else
+        start_tracking_progress
+        while (chunk = ForemanTasks::Task.search_for(full_filter).limit(batch_size)).any?
+          delete_tasks(chunk)
+          delete_dynflow_plans(chunk)
+          report_progress(chunk)
+        end
+      end
+    end
+
+    def tasks
+      ForemanTasks::Task.search_for(full_filter).select('DISTINCT foreman_tasks_tasks.id, foreman_tasks_tasks.type, foreman_tasks_tasks.external_id')
+    end
+
+    def delete_tasks(chunk)
+      ForemanTasks::Task.where(:id => chunk.map(&:id)).delete_all
+    end
+
+    def delete_dynflow_plans(chunk)
+      dynflow_ids = chunk.find_all { |task| task.is_a? Task::DynflowTask }.map(&:external_id)
+      ForemanTasks.dynflow.world.persistence.delete_execution_plans({ 'uuid' => dynflow_ids }, batch_size)
+    end
+
+    def prepare_filter
+      filter_parts = [filter]
+      filter_parts << %{started_at < "#{after.ago.to_s(:db)}"} if after > 0
+      filter_parts << states.map { |s| "state = #{s}" }.join(" OR ") if states.any?
+      filter_parts.select(&:present?).join(' AND ')
+    end
+
+    def start_tracking_progress
+      if verbose
+        @current, @total = 0, tasks.size
+        say "#{@current}/#{@total}", false
+      end
+    end
+
+    def report_progress(chunk)
+      if verbose
+        @current += chunk.size
+        say "#{@current}/#{@total}", false
+      end
+    end
+
+    def say(message, log = true)
+      puts message
+      if log
+        Foreman::Logging.logger('foreman-tasks').info(message)
+      end
+    end
+
+    def parse_time_interval(string)
+      matched_string = string.gsub(' ','').match(/\A(\d+)(\w)\Z/)
+      unless matched_string
+        raise ArgumentError, "String #{string} isn't an expected specification of time in format of \"{number}{time_unit}\""
+      end
+      number = matched_string[1].to_i
+      value = case matched_string[2]
+              when 's'
+                number.seconds
+              when 'h'
+                number.hours
+              when 'd'
+                number.days
+              when 'y'
+                number.years
+              else
+                raise ArgumentError, "Unexpected time unit in #{string}, expected one of [s,h,d,y]"
+              end
+      return value
+    end
+  end
+end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -94,7 +94,7 @@ module ForemanTasks
 
 
     rake_tasks do
-      %w[dynflow.rake test.rake export_tasks.rake].each do |rake_file|
+      %w[dynflow.rake test.rake export_tasks.rake cleanup.rake].each do |rake_file|
         full_path = File.expand_path("../tasks/#{rake_file}", __FILE__)
         load full_path if File.exists?(full_path)
       end

--- a/lib/foreman_tasks/tasks/cleanup.rake
+++ b/lib/foreman_tasks/tasks/cleanup.rake
@@ -1,0 +1,67 @@
+namespace :foreman_tasks do
+  namespace :cleanup do
+    desc <<DESC
+Clean tasks based on filter and age. ENV variables:
+
+  * FILTER     : scoped search filter (example: 'label = "Actions::Foreman::Host::ImportFacts"')
+  * AFTER      : delete tasks created after *AFTER* period. Expected format is a number followed by the time unit (s,h,m,y), such as '10d' for 10 days
+  * STATES     : comma separated list of task states to touch with the cleanup, by default only stopped tasks are covered
+  * NOOP       : set to "true" if the task should not actuall perform the deletion
+  * VERBOSE    : set to "true" for more verbose output
+  * BATCH_SIZE : the size of batches the tasks get processed in (1000 by default)
+
+If none of FILTER, BEFORE, STATES is specified, the tasks will be cleaned based
+configuration in settings
+DESC
+    task :run => 'environment' do
+      options = {}
+
+      if ENV['FILTER']
+        options[:filter] = ENV['FILTER']
+      end
+
+      if ENV['AFTER']
+        options[:after] = ENV['AFTER']
+      end
+
+      if ENV['STATES']
+        options[:states] = ENV['STATES'].to_s.split(',')
+      end
+
+      if ENV['NOOP']
+        options[:noop] = true
+      end
+
+      if ENV['VERBOSE']
+        options[:verbose] = true
+      end
+
+      if ENV['BATCH_SIZE']
+        options[:batch_size] = ENV['BATCH_SIZE'].to_i
+      end
+
+      ForemanTasks::Cleaner.run(options)
+    end
+
+    desc 'Show the current configuration for auto-cleanup'
+    task :config => 'environment' do
+      if ForemanTasks::Cleaner.cleanup_settings[:after]
+        puts _('The tasks will be deleted after %{after}') % ForemanTasks::Cleaner.cleanup_settings[:after]
+      else
+        puts _('Global period for cleaning up tasks is not set')
+      end
+
+      if ForemanTasks::Cleaner.actions_with_default_cleanup.empty?
+        puts _('No actions are configured to be cleaned automatically')
+      else
+        puts _('The following actions are configured to be deleted automatically after some time:')
+        printf("%-50s %s\n", _('name'), _('delete after'))
+        ForemanTasks::Cleaner.actions_with_default_cleanup.each do |action, after|
+          printf("%-50s %s\n", action.name, after)
+        end
+      end
+    end
+  end
+
+  task :cleanup => 'cleanup:run'
+end

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -1,0 +1,74 @@
+require 'foreman_tasks_test_helper'
+
+class TasksTest < ActiveSupport::TestCase
+  describe ForemanTasks::Cleaner do
+    it 'is able to delete tasks (including the dynflow plans) based on filter' do
+      cleaner = ForemanTasks::Cleaner.new(:filter => 'label = "Actions::User::Create"', :after => '10d')
+
+      tasks_to_delete = [FactoryGirl.create(:dynflow_task, :user_create_task),
+                         FactoryGirl.create(:dynflow_task, :user_create_task)]
+      tasks_to_keep   = [FactoryGirl.create(:dynflow_task, :user_create_task) do |task|
+                           task.started_at = task.ended_at = Time.now
+                           task.save
+                         end,
+                         FactoryGirl.create(:dynflow_task, :product_create_task)]
+      cleaner.delete
+      ForemanTasks::Task.where(id: tasks_to_delete).must_be_empty
+      ForemanTasks::Task.where(id: tasks_to_keep).must_equal tasks_to_keep
+
+      ForemanTasks.dynflow.world.persistence.
+          find_execution_plans(filters: {'uuid' => tasks_to_delete.map(&:external_id)}).size.must_equal 0
+
+      ForemanTasks.dynflow.world.persistence.
+          find_execution_plans(filters: {'uuid' => tasks_to_keep.map(&:external_id)}).size.must_equal tasks_to_keep.size
+    end
+
+    it 'deletes all tasks matching the filter when the time limit is not specified' do
+      cleaner = ForemanTasks::Cleaner.new(:filter => 'label = "Actions::User::Create"')
+      tasks_to_delete = [FactoryGirl.create(:dynflow_task, :user_create_task),
+                         FactoryGirl.create(:dynflow_task, :user_create_task) do |task|
+                           task.started_at = task.ended_at = Time.now
+                           task.save
+                         end]
+
+      tasks_to_keep   = [FactoryGirl.create(:dynflow_task, :product_create_task)]
+      cleaner.delete
+      ForemanTasks::Task.where(id: tasks_to_delete).must_be_empty
+      ForemanTasks::Task.where(id: tasks_to_keep).must_equal tasks_to_keep
+    end
+
+    it 'supports passing empty filter (just delete all)' do
+      cleaner = ForemanTasks::Cleaner.new(:filter => '', :after => '10d')
+      tasks_to_delete = [FactoryGirl.create(:dynflow_task, :user_create_task),
+                         FactoryGirl.create(:dynflow_task, :product_create_task)]
+
+      tasks_to_keep   = [FactoryGirl.create(:dynflow_task, :user_create_task) do |task|
+                           task.started_at = task.ended_at = Time.now
+                           task.save
+                         end]
+      cleaner.delete
+      ForemanTasks::Task.where(id: tasks_to_delete).must_be_empty
+      ForemanTasks::Task.where(id: tasks_to_keep).must_equal tasks_to_keep
+    end
+
+    class ActionWithCleanup < Actions::Base
+      def self.cleanup_after
+        '15d'
+      end
+    end
+
+    describe "default behaviour" do
+      it "searches for the actions that have the cleanup_after defined" do
+        ForemanTasks::Cleaner.stubs(:cleanup_settings => {})
+        ForemanTasks::Cleaner.actions_with_default_cleanup[ActionWithCleanup].must_equal '15d'
+      end
+
+      it "searches for the actions that have the cleanup_after defined" do
+        ForemanTasks::Cleaner.stubs(:cleanup_settings =>
+                                     { :actions => [{:name => ActionWithCleanup.name, :after => '5d'}]})
+        ForemanTasks::Cleaner.actions_with_default_cleanup[ActionWithCleanup].must_equal '5d'
+      end
+
+    end
+  end
+end

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -37,7 +37,7 @@ class TasksTest < ActiveSupport::TestCase
 
   describe 'consistency check' do
 
-    let(:consistent_task) { FactoryGirl.create(:dynflow_task) }
+    let(:consistent_task) { FactoryGirl.create(:dynflow_task, :sync_with_dynflow => true) }
     let(:inconsistent_task) { FactoryGirl.create(:dynflow_task, :inconsistent_dynflow_task) }
 
     it 'ensures the tasks marked as running are really running in Dynflow' do


### PR DESCRIPTION
This adds a rake task for cleaning tasks based on filter and age.
Example:

   # delete all the tasks of
   rake foreman_tasks:cleanup FILTER='label = "Actions::Foreman::Host::ImportFacts"'

   # delete all tasks older than 30 days
   rake foreman_tasks:cleanup AFTER=30d

   # delete all tasks that have the auto-cleanup specified in code or settings
   rake foreman_tasks:cleanup

By default, it only touches tasks in stopped state, this behaviour can be
customized by setting the `STATES` parameter.

To see the current configuration for the auto-cleanup, one can see
that with:

   rake foreman_tasks:cleanup:config
- [x] merge and release Dynflow/dynflow#141
- [x] don't touch paused tasks by default (and add force option to do so)
- [x] dry run mode