### PR TITLE
Fixes #10418 - hide the unlock buttons behind a setting

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -2,6 +2,8 @@ module ForemanTasks
   class TasksController < ::ApplicationController
     include Foreman::Controller::AutoCompleteSearch
 
+    before_filter :restrict_dangerous_actions, :only => [:unlock, :force_unlock]
+
     def show
       @task = find_resource
     end
@@ -61,6 +63,10 @@ module ForemanTasks
     end
 
     private
+
+    def restrict_dangerous_actions
+      render_403 unless Setting['dynflow_allow_dangerous_actions']
+    end
 
     def controller_permission
       'foreman_tasks'

--- a/app/models/setting/foreman_tasks.rb
+++ b/app/models/setting/foreman_tasks.rb
@@ -6,6 +6,7 @@ class Setting::ForemanTasks < Setting
 
     self.transaction do
       [
+          self.set('dynflow_allow_dangerous_actions', N_("Allow unlocking actions which can have dangerous consequences."), false),
           self.set('dynflow_enable_console', N_("Enable the dynflow console (/foreman_tasks/dynflow) for debugging"), true),
           self.set('dynflow_console_require_auth', N_("Require user to be authenticated as user with admin rights when accessing dynflow console"), true)
       ].each { |s| self.create! s.update(:category => "Setting::ForemanTasks")}

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -9,18 +9,19 @@
                 resume_foreman_tasks_task_path(@task),
                 class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.resumable?)].compact,
                 method: :post) %>
+    <% if Setting['dynflow_allow_dangerous_actions'] %>
+      <%= link_to(_('Unlock'),
+                  '',
+                  class:         ['btn', 'btn-sm', 'btn-warning', 'reload-button-stop', ('disabled' unless @task.state == 'paused')].compact,
+                  :'data-toggle' => "modal",
+                  :'data-target' => "#unlock_modal") %>
 
-    <%= link_to(_('Unlock'),
-                '',
-                class:         ['btn', 'btn-sm', 'btn-warning', 'reload-button-stop', ('disabled' unless @task.state == 'paused')].compact,
-                :'data-toggle' => "modal",
-                :'data-target' => "#unlock_modal") %>
-
-    <%= link_to(_('Force Unlock'),
-                '',
-                class:         ['btn', 'btn-sm', 'btn-danger', 'reload-button-stop', ('disabled' if @task.state == 'stopped')].compact,
-                :'data-toggle' => "modal",
-                :'data-target' => "#force_unlock_modal") %>
+      <%= link_to(_('Force Unlock'),
+                  '',
+                  class:         ['btn', 'btn-sm', 'btn-danger', 'reload-button-stop', ('disabled' if @task.state == 'stopped')].compact,
+                  :'data-toggle' => "modal",
+                  :'data-target' => "#force_unlock_modal") %>
+    <% end %>
   <% end %>
 </p>
 
@@ -35,11 +36,15 @@
         </h2>
       </div>
       <div class="modal-body">
-        <%= _("This will unlock the resources that the task is running against. Please note that this might lead to inconsistent state and should be used with caution, after making sure that the task can't be resumed") %>
+        <%= _("This will unlock the resources that the task is running against. Please note that this might lead to inconsistent state and should be used with caution, after making sure that the task can't be resumed.") %>
+        <div>
+          <input class="disable-unlock" type="checkbox"/>
+          <%= _("I understand that this may cause harm and have working database backups of all backend services.") %>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= _("Cancel") %></button>
-        <%= link_to(_("Unlock"), unlock_foreman_tasks_task_path(@task), method: :post, class: 'btn btn-warning') %>
+        <%= link_to(_("Unlock"), unlock_foreman_tasks_task_path(@task), method: :post, class: 'btn btn-warning modal-submit disabled') %>
       </div>
     </div>
   </div>
@@ -57,10 +62,14 @@
       </div>
       <div class="modal-body">
         <%= _("Resources will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck") %>
+        <div>
+          <input class="disable-unlock" type="checkbox"/>
+          <%= _("I understand that this may cause harm and have working database backups of all backend services.") %>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= _("Cancel") %></button>
-        <%= link_to(_("Force Unlock"), force_unlock_foreman_tasks_task_path(@task), method: :post, class: 'btn btn-danger') %>
+        <%= link_to(_("Force Unlock"), force_unlock_foreman_tasks_task_path(@task), method: :post, class: 'btn btn-danger modal-submit disabled') %>
       </div>
     </div>
   </div>

--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -41,6 +41,22 @@
   };
 
   $(document).ready(function () {
+    $('.modal-submit').click(function(e){
+      if($(this).hasClass('disabled')){
+        e.preventDefault();
+      }
+    });
+    $('.disable-unlock').click(function() {
+      var button = $(this).parents('.modal').find('.modal-submit');
+
+      if($(this).is(':checked')){
+        button.removeClass('disabled')
+      }
+      else{
+        button.addClass('disabled')
+      }
+    });
+
     $('.reload-button').click(function (event) {
       taskProgressReloader.toggle();
       event.preventDefault();


### PR DESCRIPTION
also make the confirm button disabled until the user checks a
checkbox confirming they understand