### PR TITLE
Refs #10741 - Support for smart_proxy_dynflow

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -26,6 +26,16 @@ module ForemanTasks
       redirect_to foreman_tasks_task_path(task)
     end
 
+    def cancel
+      task = find_dynflow_task
+      if task.cancel
+        flash[:notice] = _('Trying to cancel the task')
+      else
+        flash[:warning] = _('The task is not cancellable at the moment.')
+      end
+      redirect_to :back
+    end
+
     def resume
       task = find_dynflow_task
       if task.resumable?
@@ -34,7 +44,7 @@ module ForemanTasks
       else
         flash[:warning] = _('The execution has to be resumable.')
       end
-      redirect_to foreman_tasks_task_path(task)
+      redirect_to :back
     end
 
     def unlock
@@ -46,7 +56,7 @@ module ForemanTasks
       else
         flash[:warning] =  _('The execution has to be paused.')
       end
-      redirect_to foreman_tasks_task_path(task)
+      redirect_to :back
     end
 
     def force_unlock
@@ -54,7 +64,7 @@ module ForemanTasks
       task.state = :stopped
       task.save!
       flash[:notice] = _('The task resources were unlocked with force.')
-      redirect_to foreman_tasks_task_path(task)
+      redirect_to :back
     end
 
     # we need do this to make the Foreman helpers working properly
@@ -76,7 +86,7 @@ module ForemanTasks
       case params[:action]
       when 'sub_tasks'
         :view
-      when 'resume', 'unlock', 'force_unlock', 'cancel_step'
+      when 'resume', 'unlock', 'force_unlock', 'cancel_step', 'cancel'
         :edit
       else
         super

--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -1,0 +1,82 @@
+module Actions
+  class ProxyAction < Base
+
+    include ::Dynflow::Action::Cancellable
+
+    class CallbackData
+      attr_reader :data
+
+      def initialize(data)
+        @data = data
+      end
+    end
+
+    def plan(proxy, options)
+      plan_self(options.merge(:proxy_url => proxy.url))
+    end
+
+    def run(event = nil)
+      case event
+      when nil
+        if output[:proxy_task_id]
+          on_resume
+        else
+          trigger_proxy_task
+        end
+        suspend
+      when ::Dynflow::Action::Skip
+        # do nothing
+      when ::Dynflow::Action::Cancellable::Cancel
+        cancel_proxy_task
+      when CallbackData
+        on_data(event.data)
+      else
+        raise "Unexpected event #{event.inspect}"
+      end
+    end
+
+    def trigger_proxy_task
+      response = proxy.trigger_task(proxy_action_name,
+                                    input.merge(:callback => { :task_id => task.id,
+                                                               :step_id => run_step_id }))
+      output[:proxy_task_id] = response["task_id"]
+    end
+
+    def cancel_proxy_task
+      if output[:cancel_sent]
+        error! _("Cancel enforced: the task might be still running on the proxy")
+      else
+        proxy.cancel_task(output[:proxy_task_id])
+        output[:cancel_sent] = true
+        suspend
+      end
+    end
+
+    def on_resume
+      # TODO: add logic to load the data from the external action
+      suspend
+    end
+
+    # @override to put custom logic on event handling
+    def on_data(data)
+      output[:proxy_output] = data
+    end
+
+    # @override String name of an action to be triggered on server
+    def proxy_action_name
+      raise NotImplemented
+    end
+
+    def proxy
+      ProxyAPI::ForemanDynflow::DynflowProxy.new(:url => input[:proxy_url])
+    end
+
+    def proxy_output
+      output[:proxy_output]
+    end
+
+    def proxy_output=(output)
+      output[:proxy_output] = output
+    end
+  end
+end

--- a/app/lib/proxy_api/foreman_dynflow/dynflow_proxy.rb
+++ b/app/lib/proxy_api/foreman_dynflow/dynflow_proxy.rb
@@ -1,0 +1,31 @@
+module ProxyAPI
+  module ForemanDynflow
+    class DynflowProxy
+      PREFIX = 'dynflow'
+
+      class Task < ProxyAPI::Resource
+        def initialize(args)
+          @url = "#{args[:url]}/#{PREFIX}/tasks"
+          super args
+          @connect_params[:headers] ||= {}
+          @connect_params[:headers]['content-type'] = 'application/json'
+        end
+      end
+
+      def initialize(args)
+        @args = args
+      end
+
+      # Initiate the command
+      def trigger_task(action_name, action_input)
+        payload = MultiJson.dump(:action_name => action_name, :action_input => action_input)
+        MultiJson.load(Task.new(@args).send(:post, payload))
+      end
+
+      # Initiate the command
+      def cancel_task(proxy_task_id)
+        MultiJson.load(Task.new(@args).send(:post, "", "#{ proxy_task_id }/cancel"))
+      end
+    end
+  end
+end

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -22,6 +22,14 @@ module ForemanTasks
       return changes
     end
 
+    def cancellable?
+      execution_plan.cancellable?
+    end
+
+    def cancel
+      execution_plan.cancel.any?
+    end
+
     def resumable?
       execution_plan.state == :paused
     end

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -9,6 +9,10 @@
                 resume_foreman_tasks_task_path(@task),
                 class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.resumable?)].compact,
                 method: :post) %>
+    <%= link_to(_('Cancel'),
+                cancel_foreman_tasks_task_path(@task),
+                class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.cancellable?)].compact,
+                method: :post) %>
     <% if Setting['dynflow_allow_dangerous_actions'] %>
       <%= link_to(_('Unlock'),
                   '',

--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -71,7 +71,7 @@
       taskProgressReloader.stop();
     });
 
-  <% if @task.state == 'running' %>
+  <% if @task.state != 'stopped' %>
     taskProgressReloader.start();
   <% else %>
     taskProgressReloader.stop();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Foreman::Application.routes.draw do
       end
       member do
         get :sub_tasks
+        post :cancel
         post :resume
         post :unlock
         post :force_unlock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Foreman::Application.routes.draw do
           post :bulk_search
           post :bulk_resume
           get :summary
+          post :callback
         end
       end
     end

--- a/db/seeds.d/60-dynflow_proxy_feature.rb
+++ b/db/seeds.d/60-dynflow_proxy_feature.rb
@@ -1,0 +1,2 @@
+f = Feature.find_or_create_by_name('Dynflow')
+raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -25,7 +25,7 @@ DESC
   end
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "dynflow", '~> 0.8.1'
+  s.add_dependency "dynflow", '~> 0.8.3'
   s.add_dependency "sequel" # for Dynflow process persistence
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "daemons" # for running remote executor

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -18,7 +18,7 @@ module ForemanTasks
         security_block :foreman_tasks do |map|
           permission :view_foreman_tasks, {:'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :show],
                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary] }, :resource_type => ForemanTasks::Task.name
-          permission :edit_foreman_tasks, {:'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step],
+          permission :edit_foreman_tasks, {:'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel],
                                            :'foreman_tasks/api/tasks' => [:bulk_resume]}, :resource_type => ForemanTasks::Task.name
         end
 

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -51,6 +51,12 @@ module ForemanTasks
       ForemanTasks.dynflow.config.eager_load_paths.concat(%W[#{ForemanTasks::Engine.root}/app/lib/actions])
     end
 
+    initializer "foreman_tasks.test_exceptions" do |app|
+      if defined? ActiveSupport::TestCase
+        require 'foreman_tasks/test_extensions'
+      end
+    end
+
     initializer "foreman_tasks.load_app_instance_data" do |app|
       app.config.paths['db/migrate'] += ForemanTasks::Engine.paths['db/migrate'].existent
     end

--- a/lib/foreman_tasks/test_extensions.rb
+++ b/lib/foreman_tasks/test_extensions.rb
@@ -1,0 +1,14 @@
+module ForemanTasks
+  module TestExtensions
+    module AccessPermissionsTestExtension
+      def setup
+        super
+        if defined?(AccessPermissionsTest) && self.class == AccessPermissionsTest
+          skip 'used by proxy only' if __name__.include?('foreman_tasks/api/tasks/callback')
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport::TestCase.send(:include, ForemanTasks::TestExtensions::AccessPermissionsTestExtension)

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -1,5 +1,8 @@
 require 'test_helper'
 require_relative './support/dummy_dynflow_action'
+require_relative './support/dummy_proxy_action'
+
+require 'dynflow/testing'
 
 FactoryGirl.definition_file_paths = ["#{ForemanTasks::Engine.root}/test/factories"]
 FactoryGirl.find_definitions

--- a/test/support/dummy_proxy_action.rb
+++ b/test/support/dummy_proxy_action.rb
@@ -1,0 +1,49 @@
+module Support
+  class DummyProxyAction < Actions::ProxyAction
+
+    class DummyProxy
+      attr_reader :log, :task_triggered
+
+      def initialize
+        @log = Hash.new { |h, k| h[k] = [] }
+        @task_triggered = Concurrent.future
+      end
+
+      def trigger_task(*args)
+        @log[:trigger_task] << args
+        @task_triggered.success(true)
+        {"task_id" => "123"}
+      end
+
+      def cancel_task(*args)
+        @log[:cancel_task] << args
+      end
+
+      def url
+        'proxy.example.com'
+      end
+    end
+
+    def proxy
+      self.class.proxy
+    end
+
+    def proxy_action_name
+      'Proxy::DummyAction'
+    end
+
+    def task
+      super
+    rescue ActiveRecord::RecordNotFound
+      ForemanTasks::Task::DynflowTask.new.tap { |task| task.id = '123' }
+    end
+
+    def self.proxy
+      @proxy
+    end
+
+    def self.reset
+      @proxy = DummyProxy.new
+    end
+  end
+end

--- a/test/unit/actions/proxy_action_test.rb
+++ b/test/unit/actions/proxy_action_test.rb
@@ -1,0 +1,67 @@
+require "foreman_tasks_test_helper"
+
+module ForemanTasks
+  class ProxyActionTest <  ActiveSupport::TestCase
+
+    describe Actions::ProxyAction do
+      include ::Dynflow::Testing
+
+      before do
+        Support::DummyProxyAction.reset
+        @action = create_and_plan_action(Support::DummyProxyAction, Support::DummyProxyAction.proxy, 'foo' => 'bar')
+        @action = run_action(@action)
+      end
+
+      describe 'first run' do
+        it 'triggers the corresponding action on the proxy' do
+          proxy_call = Support::DummyProxyAction.proxy.log[:trigger_task].first
+          proxy_call.must_equal(["Proxy::DummyAction",
+                                 { "foo" => "bar",
+                                   "proxy_url" => "proxy.example.com",
+                                   "callback" => { "task_id" => "123", "step_id" => @action.run_step_id }}])
+        end
+      end
+
+      describe 'resumed run' do
+        it "doesn't trigger the corresponding action again on the proxy" do
+          action = run_action(@action)
+
+          action.state.must_equal :suspended
+
+          Support::DummyProxyAction.proxy.log[:trigger_task].size.must_equal 1
+        end
+      end
+
+      it 'supports skipping' do
+        action = run_action(@action, ::Dynflow::Action::Skip)
+        action.state.must_equal :success
+      end
+
+      describe 'cancel' do
+        it 'sends the cancel event to the proxy when the cancel event is sent for the first time' do
+          action = run_action(@action, ::Dynflow::Action::Cancellable::Cancel)
+          Support::DummyProxyAction.proxy.log[:cancel_task].first.must_equal ['123']
+          action.state.must_equal :suspended
+        end
+
+        it 'cancels the action immediatelly when cancel event is sent for the second time' do
+          action = run_action(@action, ::Dynflow::Action::Cancellable::Cancel)
+          error = begin
+                    run_action(action, ::Dynflow::Action::Cancellable::Cancel)
+                  rescue => e
+                    e
+                  end
+
+          Support::DummyProxyAction.proxy.log[:cancel_task].size.must_equal 1
+          error.message.must_match 'Cancel enforced'
+        end
+      end
+
+      it 'saves the data comming from the proxy to the output and finishes' do
+        action = run_action(@action, ::Actions::ProxyAction::CallbackData.new('result' => 'success'))
+        action.output[:proxy_output].must_equal({'result' => 'success'})
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Ability to trigger action on foreman server and a corresponding action in
smart proxy, get the callback at the end and dispatch the control events (such
as cancel)

Depends on https://github.com/theforeman/smart_proxy_dynflow/pull/1