### PR TITLE
Fixes #11092 - fix tasks reloading

### DIFF
--- a/app/views/foreman_tasks/tasks/index.html.erb
+++ b/app/views/foreman_tasks/tasks/index.html.erb
@@ -14,11 +14,14 @@
 </style>
 
 <script>
+
+var currentTwoPaneTask;
+
 $(document).on('click', ".table-two-pane td.two-pane-link", function(e) {
-  var item = $(this).find("a");
-  if(item.length){
+  currentTwoPaneTask = $(this).find("a");
+  if(currentTwoPaneTask.length){
     e.preventDefault();
-    two_pane_open(item);
+    two_pane_open(currentTwoPaneTask);
   }
 });
 

--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -1,42 +1,45 @@
 <script>
-  var taskProgressReloader = {
-    timeoutId: null,
-    reload: function () {
-      // we need different reload mechanism for two-pane and non-two-pane
-      if (typeof currentTwoPaneTask !== 'undefined') {
-        two_pane_open(currentTwoPaneTask);
-      } else {
-        document.location.reload();
-      }
-    },
+  if (typeof taskProgressReloader === 'undefined') {
+    var taskProgressReloader = {
+      timeoutId: null,
+      reload: function () {
+        // we need different reload mechanism for two-pane and non-two-pane
+        if (typeof currentTwoPaneTask !== 'undefined') {
+          taskProgressReloader.timeoutId = null;
+          two_pane_open(currentTwoPaneTask);
+        } else {
+          document.location.reload();
+        }
+      },
 
-    start: function () {
-      if (!this.timeoutId) {
-        this.timeoutId = setTimeout(this.reload, 5000);
-      }
-     var button = $('.reload-button');
-     button.html('<span class="glyphicon glyphicon-refresh spin"></span> <%= _('Stop auto-reloading') %>');
-     button.show();
-    },
+      start: function () {
+        if (!taskProgressReloader.timeoutId) {
+          taskProgressReloader.timeoutId = setTimeout(this.reload, 5000);
+        }
+        var button = $('.reload-button');
+        button.html('<span class="glyphicon glyphicon-refresh spin"></span> <%= _('Stop auto-reloading') %>');
+        button.show();
+      },
 
-    stop: function () {
-      if (this.timeoutId) {
-        clearTimeout(this.timeoutId);
-      }
-      this.timeoutId = null;
-      var button = $('.reload-button');
-      button.html('<span class="glyphicon glyphicon-refresh"></span> <%= _('Start auto-reloading') %>');
-      button.show();
-    },
+      stop: function () {
+        if (taskProgressReloader.timeoutId) {
+          clearTimeout(taskProgressReloader.timeoutId);
+        }
+        taskProgressReloader.timeoutId = null;
+        var button = $('.reload-button');
+        button.html('<span class="glyphicon glyphicon-refresh"></span> <%= _('Start auto-reloading') %>');
+        button.show();
+      },
 
-    toggle: function () {
-      if (this.timeoutId) {
-        this.stop();
-      } else {
-        this.start();
+      toggle: function () {
+        if (taskProgressReloader.timeoutId) {
+          this.stop();
+        } else {
+          this.start();
+        }
       }
-    }
-  };
+    };
+  }
 
   $(document).ready(function () {
     $('.modal-submit').click(function(e){

--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -2,14 +2,12 @@
   var taskProgressReloader = {
     timeoutId: null,
     reload: function () {
-      $.ajax({
-        url: "",
-        context: document.body,
-        success: function (s, x) {
-          $(this).html(s);
-          taskProgressReloader.start();
-        }
-      });
+      // we need different reload mechanism for two-pane and non-two-pane
+      if (typeof currentTwoPaneTask !== 'undefined') {
+        two_pane_open(currentTwoPaneTask);
+      } else {
+        document.location.reload();
+      }
     },
 
     start: function () {


### PR DESCRIPTION
The previous implementation often caused the browser to crash due to way how
the reloading was implemented. It also fixes the behaviour in the two-pane
mode variant.