### PR TITLE
fixes #11162 : add scoped_search parent_task_id to task model

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -23,6 +23,7 @@ module ForemanTasks
     scoped_search :on => :state, :complete_value => true
     scoped_search :on => :result, :complete_value => true
     scoped_search :on => :started_at, :complete_value => false
+    scoped_search :on => :parent_task_id, :complete_value => true
     scoped_search :in => :locks,  :on => :resource_type, :complete_value => true, :rename => "resource_type", :ext_method => :search_by_generic_resource
     scoped_search :in => :locks,  :on => :resource_id, :complete_value => false, :rename => "resource_id", :ext_method => :search_by_generic_resource
     scoped_search :in => :owners,  :on => :id, :complete_value => true, :rename => "owner.id", :ext_method => :search_by_owner


### PR DESCRIPTION
This change is to enable users to search for tasks (in UI or API) using
the parent_task_id.  This is useful if the user has the parent task
but needs to get access to it's children.

The following is an example of using API to query for tasks that have the same parent:

curl -k -u admin:password -H "Content-Type:application/json" -H "Accept:application/json,version=2" -X GET -d "{\"search\": \"parent_task_id=50b6b3ba-fa71-4a1c-840b-e1913fc5d8a6\"}" https://sat61fusor.example.com/foreman_tasks/api/tasks | json_reformat