### PR TITLE
Refs #10755 - Support for recurring actions and task groups

### DIFF
--- a/app/assets/javascripts/trigger_form.js
+++ b/app/assets/javascripts/trigger_form.js
@@ -1,0 +1,41 @@
+function trigger_form_selector_binds(form_name, form_object_name) {
+  var form = $('form#' +  form_name);
+  var trigger_mode_selector = form.find('input.trigger_mode_selector');
+  var input_type_selector = form.find('.form-control#input_type_selector');
+
+  trigger_mode_selector.on('click', function () {
+    ["future", "immediate", "recurring"].forEach(function(type) {
+      form.find('fieldset.trigger_mode_form#trigger_mode_' + type).hide();
+    });
+    form.find('fieldset.trigger_mode_form#trigger_mode_' + $(this).val()).show();
+  });
+
+  input_type_selector.on('change', function () {
+    var fieldset = form.find('fieldset.trigger_mode_form#trigger_mode_recurring');
+    ['cronline', 'monthly', 'weekly', 'hourly', 'daily'].forEach(function(type) {
+      fieldset.find('fieldset.input_type_form#input_type_' + type).hide();
+    })
+    fieldset.find('fieldset.input_type_form#input_type_' + $(this).val()).show();
+    var timepicker = fieldset.find('fieldset.input_type_form#time_picker');
+    if($(this).val() == 'cronline') {
+      timepicker.hide();
+    } else {
+      var hour_picker = timepicker.find('#s2id_triggering_time_time_4i');
+      if($(this).val() == 'hourly') {
+        hour_picker.hide();
+      } else {
+        hour_picker.show();
+      }
+      timepicker.show();
+    }
+  });
+
+  form.find('input.end_time_limit_selector').on('click', function() {
+    var o = form.find('fieldset#trigger_mode_recurring fieldset#end_time_limit_form');
+    if($(this).val() === 'true') {
+      o.show();
+    } else {
+      o.hide();
+    };
+  });
+};

--- a/app/controllers/foreman_tasks/recurring_logics_controller.rb
+++ b/app/controllers/foreman_tasks/recurring_logics_controller.rb
@@ -1,0 +1,33 @@
+module ForemanTasks
+  class RecurringLogicsController < ::ApplicationController
+
+    before_filter :find_recurring_logic, :only => [:show, :cancel]
+
+    def index
+      @recurring_logics = filter(resource_base)
+    end
+
+    def show
+    end
+
+    def cancel
+      @recurring_logic.cancel
+      redirect_to :action => :index
+    end
+
+    def controller_name
+      'foreman_tasks_recurring_logics'
+    end
+
+    private
+
+    def find_recurring_logic
+      @recurring_logic ||= ::ForemanTasks::RecurringLogic.find(params[:id])
+    end
+
+    def filter(scope)
+      scope.search_for(params[:search]).paginate(:page => params[:page])
+    end
+
+  end
+end

--- a/app/helpers/foreman_tasks/foreman_tasks_helper.rb
+++ b/app/helpers/foreman_tasks/foreman_tasks_helper.rb
@@ -1,0 +1,144 @@
+module ForemanTasks
+  module ForemanTasksHelper
+
+    def recurring_logic_state(recurring_logic)
+      icon, status = case recurring_logic.state
+             when 'active'
+               'glyphicon-info-sign'
+             when 'finished'
+               ['glyphicon-ok-sign', 'status-ok']
+             when 'cancelled'
+               ['glyphicon-warning-sign', 'status-error']
+             else
+               'glyphicon-question-sign'
+             end
+      content_tag(:i, '&nbsp'.html_safe, :class => "glyphicon #{icon}") + content_tag(:span, recurring_logic.humanized_state, :class => status)
+    end
+
+    def recurring_logic_action_buttons(recurring_logic)
+      buttons = []
+      if authorized_for(:permission => :edit_recurring_logics, :auth_object => recurring_logic)
+        buttons << link_to(N_("Cancel"), cancel_foreman_tasks_recurring_logic_path(recurring_logic), :method => :post, :class => 'btn btn-danger') unless %w(cancelled finished).include? recurring_logic.state
+      end
+      button_group buttons
+    end
+
+    def recurring_logic_next_occurrence(recurring_logic)
+      if %w(finished cancelled).include? recurring_logic.state
+        N_('-')
+      else
+        recurring_logic.next_occurrence_time
+      end
+    end
+
+    def time_f(f, attr, field_options = {}, time_options = {}, html_options = {})
+      f.fields_for attr do |fields|
+        field(fields, attr, field_options) do
+          fields.time_select attr, time_options, html_options
+        end
+      end
+    end
+
+    def datetime_f(f, attr, field_options = {}, datetime_options = {}, html_options = {})
+      f.fields_for attr do |fields|
+        field(fields, attr, field_options) do
+          fields.datetime_select attr, datetime_options, html_options
+        end
+      end
+    end
+
+    def inline_checkboxes_f(f, attr, field_options = {}, checkboxes = {}, options = {})
+      field(f, attr, field_options) do
+        checkboxes.map do |key, name|
+          [f.check_box(key, options), " #{name} "]
+        end.flatten.join('')
+      end
+    end
+
+    def trigger_selector(f, triggering = Triggering.new, options = {})
+      render :partial => 'common/trigger_form', :locals => { :f => f, :triggering => triggering }
+    end
+
+    private
+
+    def future_mode_fieldset(f, triggering)
+      tags = []
+      tags << text_f(f, :start_at_raw, :label => _('Start at'), :placeholder => 'YYYY-mm-dd HH:MM')
+      tags << text_f(f, :start_before_raw, :label => _('Start before'), :placeholder => 'YYYY-mm-dd HH:MM')
+      content_tag(:fieldset, nil, :id => "trigger_mode_future", :class => "trigger_mode_form #{'hidden' unless triggering.future?}") do
+        tags.join.html_safe
+      end
+    end
+
+    def recurring_mode_fieldset(f, triggering)
+      tags = []
+      tags << selectable_f(f, :input_type, %w(cronline monthly weekly daily hourly), {}, :label => _("Repeats"), :id => 'input_type_selector')
+      tags += [
+        cronline_fieldset(f, triggering),
+        monthly_fieldset(f, triggering),
+        weekly_fieldset(f, triggering),
+        time_picker_fieldset(f, triggering)
+      ]
+
+      content_tag(:fieldset, nil, :id => 'trigger_mode_recurring', :class => "trigger_mode_form #{'hidden' unless triggering.recurring?}") do
+        tags.join.html_safe
+      end
+    end
+
+    def cronline_fieldset(f, triggering)
+      options = [
+        _('is minute (range: 0-59)'),
+        _('is hour (range: 0-23)'),
+        _('is day of month (range: 1-31)'),
+        _('is month (range: 1-12)'),
+        _('is day of week (range: 0-6)')
+      ].map { |opt| content_tag(:li, opt) }.join
+      help = content_tag(:span, nil, :class => 'help-inline') do
+        popover(_('Explanation'),
+                _("Cron line format 'a b c d e', where:<br><ol type=\"a\">#{options}</ol>"))
+      end
+      content_tag(:fieldset, nil, :class => "input_type_form #{'hidden' unless triggering.input_type == :cronline}", :id => "input_type_cronline") do
+        text_f f, :cronline, :label => _('Cron line'), :placeholder => '* * * * *', :help_inline => help
+      end
+    end
+
+    def monthly_fieldset(f, triggering)
+      content_tag(:fieldset, nil, :id => "input_type_monthly", :class => "input_type_form #{'hidden' unless triggering.input_type == :monthly}") do
+        text_f(f, :days, :label => _('Days'), :placeholder => '1,2...')
+      end
+    end
+
+    def weekly_fieldset(f, triggering)
+      content_tag(:fieldset, nil, :id => 'input_type_weekly', :class => "input_type_form #{'hidden' unless triggering.input_type == :weekly}") do
+        f.fields_for :days_of_week do |days_of_week|
+          inline_checkboxes_f(days_of_week,
+                              :weekday,
+                              { :label => _("Days of week") },
+                              { 1 => _("Mon"),
+                                2 => _("Tue"),
+                                3 => _("Wed"),
+                                4 => _("Thu"),
+                                5 => _("Fri"),
+                                6 => _("Sat"),
+                                7 => _("Sun") })
+        end
+      end
+    end
+
+    def time_picker_fieldset(f, triggering)
+      tags = []
+      tags << content_tag(:fieldset, nil, :id => 'time_picker', :class => "input_type_form #{'hidden' if triggering.input_type == :cronline}") do
+        time_f(f, :time, { :label => _("At"), :id => 'something' }, { :time_separator => '' })
+      end
+      tags << number_f(f, :max_iteration, :label => _('Repeat N times'), :min => 1, :placeholder => 'N')
+      tags << field(f, :end_time_limit_select, :label => _("Ends"), :control_group_id => "end_time_limit_select") do
+        radio_button_f(f, :end_time_limited, :value => false, :checked=> true, :text => _("Never"), :class => 'end_time_limit_selector') +
+        radio_button_f(f, :end_time_limited, :value => true, :text => _("On"), :class => 'end_time_limit_selector')
+      end
+      tags << content_tag(:fieldset, nil, :id => 'end_time_limit_form', :class => "input_type_form #{'hidden' unless triggering.end_time_limited}") do
+        datetime_f f, :end_time, { :label => _("Ends at") }, { :use_month_numbers => true, :use_two_digit_numbers => true, :time_separator => '' }
+      end
+      tags.join.html_safe
+    end
+  end
+end

--- a/app/helpers/foreman_tasks/tasks_helper.rb
+++ b/app/helpers/foreman_tasks/tasks_helper.rb
@@ -12,5 +12,13 @@ module ForemanTasks
       end.join('; ')
       parts.join(" ")
     end
+
+    def format_recurring_logic_limit(thing)
+      if thing.nil?
+        content_tag(:i, N_('Unlimited'))
+      else
+        thing
+      end
+    end
   end
 end

--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -55,5 +55,9 @@ module Actions
       ForemanTasks::Task::DynflowTask.for_action(self.class).
         running.where('external_id != ?', execution_plan_id).any?
     end
+
+    def serializer_class
+      ::Actions::Serializers::ActiveRecordSerializer
+    end
   end
 end

--- a/app/lib/actions/entry_action.rb
+++ b/app/lib/actions/entry_action.rb
@@ -57,7 +57,11 @@ module Actions
     end
 
     def delay(_schedule_options, *args)
-      Serializers::ActiveRecordSerializer.new args
+      self.serializer_class.new args
+    end
+
+    def self.serializer_class
+      Serializers::ActiveRecordSerializer
     end
 
   end

--- a/app/lib/actions/middleware/inherit_task_groups.rb
+++ b/app/lib/actions/middleware/inherit_task_groups.rb
@@ -1,0 +1,39 @@
+module Actions
+  module Middleware
+    class InheritTaskGroups < Dynflow::Middleware
+
+      def delay(*args)
+        pass *args
+      end
+
+      def plan(*args)
+        inherit_task_groups
+        pass *args
+      end
+
+      def run(*args)
+        pass *args
+        collect_children_task_groups
+      end
+
+      def finalize
+        pass
+      end
+
+      private
+
+      def inherit_task_groups
+        task.add_missing_task_groups(task.parent_task.task_groups) if task.parent_task
+      end
+
+      def collect_children_task_groups
+        task.add_missing_task_groups task.sub_tasks.map(&:task_groups).flatten
+      end
+
+      def task
+        @task ||= action.task
+      end
+    end
+  end
+end
+

--- a/app/lib/actions/middleware/recurring_logic.rb
+++ b/app/lib/actions/middleware/recurring_logic.rb
@@ -1,0 +1,42 @@
+module Actions
+  module Middleware
+    class RecurringLogic < ::Dynflow::Middleware
+
+      # ::Actions::Middleware::RecurringLogic
+      #
+      # A middleware designed to make action repeatable.
+      # After an action is delayed, it checks whether the delay_options
+      # hash contains an id of a recurring logic. If so, it adds the task
+      # to the recurring logic's task group, otherwise does nothing.
+      #
+      # After the action's plan phase the middleware checks if the task
+      # is associated with a task group of any recurring logic, in which case
+      # it triggers another repeat using the task group's recurring logic,
+      # otherwise does nothing.
+      def delay(delay_options, *args)
+        pass(delay_options, *args).tap do
+          if delay_options[:recurring_logic_id]
+            task.add_missing_task_groups(recurring_logic(delay_options).task_group)
+          end
+        end
+      end
+
+      def plan(*args)
+        pass(*args).tap do
+          task_group = task.task_groups.find { |tg| tg.is_a? ::ForemanTasks::TaskGroups::RecurringLogicTaskGroup }
+          task_group.recurring_logic.trigger_repeat(action.class, *args) if task_group
+        end
+      end
+
+      private
+
+      def recurring_logic(delay_options)
+        ForemanTasks::RecurringLogic.find(delay_options[:recurring_logic_id])
+      end
+
+      def task
+        @task ||= action.task
+      end
+    end
+  end
+end

--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -1,0 +1,136 @@
+module ForemanTasks
+
+  require 'parse-cron'
+
+  class RecurringLogic < ActiveRecord::Base
+    include Authorizable
+
+    belongs_to :task_group
+    belongs_to :triggering
+
+    has_many :tasks, :through => :task_group
+    has_many :task_groups, :through => :tasks, :uniq => true
+
+    validates :cron_line, :presence => true
+
+    scoped_search :on => :id, :complete_value => false
+    scoped_search :on => :max_iteration, :complete_value => false, :rename => :iteration_limit
+    scoped_search :on => :iteration, :complete_value => false
+    scoped_search :on => :cron_line, :complete_value => true
+
+    before_create do
+      self.task_group.save
+    end
+
+    def self.allowed_states
+      %w(active finished cancelled failed)
+    end
+
+    def start(action_class, *args)
+      self.state = 'active'
+      save!
+      trigger_repeat(action_class, *args)
+    end
+
+    def trigger_repeat(action_class, *args)
+      unless can_continue?
+        self.state = 'finished'
+        save!
+        return
+      else
+        self.iteration += 1
+        save!
+        ::ForemanTasks.delay action_class,
+                             generate_delay_options,
+                             *args
+      end
+    end
+
+    def cancel
+      self.state = 'cancelled'
+      save!
+      tasks.active.each(&:cancel)
+    end
+
+    def next_occurrence_time(time = Time.now)
+      @parser ||= CronParser.new(cron_line)
+      @parser.next(time)
+    end
+
+    def generate_delay_options(time = Time.now, options = {})
+      {
+        :start_at => next_occurrence_time(time),
+        :start_before => options['start_before'],
+        :recurring_logic_id => self.id
+      }
+    end
+
+    def can_continue?(time = Time.now)
+      self.state == 'active' &&
+        (end_time.nil? || next_occurrence_time(time) < end_time) &&
+        (max_iteration.nil? || iteration < max_iteration)
+    end
+
+    def finished?
+      self.state == 'finished'
+    end
+
+    def humanized_state
+      case self.state
+      when 'active'
+        N_('Active')
+      when 'cancelled'
+        N_('Cancelled')
+      when 'finished'
+        N_('Finished')
+      else
+        N_('N/A')
+      end
+    end
+
+    def self.assemble_cronline(hash)
+      hash.values_at(*[:minutes, :hours, :days, :months, :days_of_week])
+          .map { |value| (value.nil? || value.blank?) ? '*' : value }
+          .join(' ')
+    end
+
+    def self.new_from_cronline(cronline)
+      self.new.tap do |logic|
+        logic.cron_line = cronline
+        logic.task_group = ::ForemanTasks::TaskGroups::RecurringLogicTaskGroup.new
+      end
+    end
+
+    def self.new_from_triggering(triggering)
+      cronline = if triggering.input_type == :cronline
+                   triggering.cronline
+                 else
+                   ::ForemanTasks::RecurringLogic.assemble_cronline(cronline_hash triggering.input_type, triggering.time, triggering.days_of_week)
+                 end
+      ::ForemanTasks::RecurringLogic.new_from_cronline(cronline).tap do |manager|
+        manager.end_time = Time.new(*recurring_options.end_time.values) if triggering.end_time_limited
+        manager.max_iteration = triggering.max_iteration unless triggering.max_iteration.blank?
+        manager.triggering = triggering
+      end
+    end
+
+    def self.cronline_hash(recurring_type, time_hash, days_of_week_hash)
+      hash = Hash[[:years, :months, :days, :hours, :minutes].zip(time_hash.values)]
+      
+      hash.update :days_of_week => days_of_week_hash
+                                  .select { |value, index| value == "1" }
+                                  .values.join(',')
+      allowed_keys = case recurring_type
+                     when :monthly
+                       [:minutes, :hours, :days]
+                     when :weekly
+                       [:minutes, :hours, :days_of_week]
+                     when :daily
+                       [:minutes, :hours]
+                     when :hourly
+                       [:minutes]
+                     end
+      hash.select { |key, _| allowed_keys.include? key }
+    end
+  end
+end

--- a/app/models/foreman_tasks/task_group.rb
+++ b/app/models/foreman_tasks/task_group.rb
@@ -1,0 +1,16 @@
+module ForemanTasks
+  class TaskGroup < ActiveRecord::Base
+
+    has_many :task_group_members
+    has_many :tasks, :through => :task_group_members
+
+    def resource_name
+      raise NotImplementedError
+    end
+
+    def resource
+      raise NotImplementedError
+    end
+
+  end
+end

--- a/app/models/foreman_tasks/task_group_member.rb
+++ b/app/models/foreman_tasks/task_group_member.rb
@@ -1,0 +1,8 @@
+module ForemanTasks
+  class TaskGroupMember < ActiveRecord::Base
+
+    belongs_to :task_group
+    belongs_to :task
+    
+  end
+end

--- a/app/models/foreman_tasks/task_groups/recurring_logic_task_group.rb
+++ b/app/models/foreman_tasks/task_groups/recurring_logic_task_group.rb
@@ -1,0 +1,16 @@
+module ForemanTasks
+  module TaskGroups
+    class RecurringLogicTaskGroup < ::ForemanTasks::TaskGroup
+
+      has_one :recurring_logic, :foreign_key => :task_group_id
+
+      alias_method :resource, :recurring_logic
+
+      def resource_name
+        N_('Recurring logic')
+      end
+
+    end
+  end
+end
+

--- a/app/models/foreman_tasks/triggering.rb
+++ b/app/models/foreman_tasks/triggering.rb
@@ -1,0 +1,99 @@
+module ForemanTasks
+  class Triggering < ActiveRecord::Base
+
+    attr_accessor :start_at_raw, :start_before_raw, :max_iteration, :input_type,
+                  :cronline, :days, :days_of_week, :time, :end_time_limited,
+                  :end_time
+
+    before_save do
+      if future?
+        parse_start_at!
+        parse_start_before!
+      end
+    end
+
+    after_find do |triggering|
+      triggering.mode = triggering.mode.to_sym
+    end
+
+    ALLOWED_MODES = [:immediate, :future, :recurring]
+    ALLOWED_INPUT_TYPES = [:cronline, :monthly, :weekly, :daily, :hourly]
+
+    TIME_FORMAT = "%Y-%m-%d %H:%M"
+    TIME_REGEXP = /\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}\Z/
+    DAYS_REGEXP = /\A(\s*\d{1,2}\s*)(,\s*\d{1,2}\s*)*\Z/
+
+    has_one :recurring_logic, :foreign_key => :triggering_id
+
+    validates :mode, :inclusion => { :in => ALLOWED_MODES,
+                                     :message => _("%{value} is not allowed triggering mode")  }
+    validates :input_type, :if => :recurring?,
+              :inclusion => { :in => ALLOWED_INPUT_TYPES,
+                              :message => _("%{value} is not allowed input type") }
+    validates_format_of :start_at_raw, :with => TIME_REGEXP, :if => :future?,
+                        :message => _("%{value} is wrong format")
+    validates_format_of :start_before_raw, :with => TIME_REGEXP, :if => :future?,
+                        :message => _("%{value} is wrong format"), :allow_blank => true
+    validates_format_of :days, :with => DAYS_REGEXP,
+                        :if => Proc.new { |t| t.recurring? && t.input_type == :monthly }
+    validate :correct_cronline, :if => Proc.new { |t| t.recurring? && t.input_type == :cronline }
+
+    def self.new_from_params(params = {})
+      self.new(params).tap do |targeting|
+        targeting.mode = params.fetch(:mode, :immediate).to_sym
+        targeting.input_type = params.fetch(:input_type, :cronline).to_sym
+        targeting.end_time_limited = params[:end_time_limited] == "true"
+        targeting.start_at_raw = Time.now.strftime(TIME_FORMAT)
+      end
+    end
+
+    def trigger(action, *args)
+      case mode
+      when :immediate
+        ::ForemanTasks.async_task action, *args
+      when :future
+        ::ForemanTasks.delay action,
+                             delay_options,
+                             *args
+      when :recurring
+        ::ForemanTasks::RecurringLogic.new_from_triggering(self)
+        .start(action, *args)
+      end
+    end
+
+    def delay_options
+      {
+        :start_at => start_at,
+        :start_before => start_before
+      }
+    end
+
+    def future?
+      mode == :future
+    end
+
+    def immediate?
+      mode == :immediate
+    end
+
+    def recurring?
+      mode == :recurring
+    end
+
+    def parse_start_at!
+      self.start_at ||= Time.strptime(start_at_raw, TIME_FORMAT)
+    end
+
+    def parse_start_before!
+      self.start_before ||= Time.strptime(start_before_raw, TIME_FORMAT) unless start_before_raw.blank?
+    end
+
+    private
+
+    def correct_cronline
+      ForemanTasks::RecurringLogic.new_from_cronline(cronline).next_occurrence_time
+    rescue ArgumentError => _
+      self.errors.add(:cronline, _("#{cronline} is not valid format of cronline"))
+    end
+  end
+end

--- a/app/views/common/_trigger_form.html.erb
+++ b/app/views/common/_trigger_form.html.erb
@@ -1,0 +1,14 @@
+<div class="form-group trigger_mode">
+  <% javascript 'trigger_form' %>
+  <%= javascript_tag do %>
+  $(function() { trigger_form_selector_binds('<%= f.options[:html][:id] %>','<%= f.object_name %>') });
+  <% end %>
+  <%= fields_for :triggering, triggering do |trigger_fields| %>
+  <legend><%= _('Schedule Job') %></legend>
+  <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'immediate', :text => _("Execute now") %>
+  <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'future',    :text => _("Schedule future execution") %>
+  <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'recurring', :text => _("Set up recurring execution") %>
+  <%= future_mode_fieldset trigger_fields, triggering %>
+  <%= recurring_mode_fieldset trigger_fields, triggering %>
+  <% end %>
+</div>

--- a/app/views/foreman_tasks/recurring_logics/_tab_related.html.erb
+++ b/app/views/foreman_tasks/recurring_logics/_tab_related.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= render 'foreman_tasks/task_groups/tab_related', :source => source %>
+</div>

--- a/app/views/foreman_tasks/recurring_logics/index.html.erb
+++ b/app/views/foreman_tasks/recurring_logics/index.html.erb
@@ -1,0 +1,34 @@
+<% title _("Recurring logics") %>
+<% title_actions help_path %>
+
+<table class="table table-fixed table-bordered table-striped table-condensed">
+  <thead>
+    <th><%= N_("Cronline") %></th>
+    <th><%= N_("Task count") %></th>
+    <th><%= N_("Action") %></th>
+    <th><%= N_("Last occurrence") %></th>
+    <th><%= N_("Next occurrence") %></th>
+    <th><%= N_("Current iteration") %></th>
+    <th><%= N_("Iteration limit") %></th>
+    <th><%= N_("Repeat until") %></th>
+    <th><%= N_("State") %></th>
+    <th/>
+  </thead>
+  <% @recurring_logics.each do |recurring_logic| %>
+    <tr>
+      <td><%= link_to(recurring_logic.cron_line, foreman_tasks_recurring_logic_path(recurring_logic)) %></td>
+      <td><%= link_to(recurring_logic.tasks.count, foreman_tasks_tasks_url(:search => "task_group.id = #{recurring_logic.task_group.id}")) %></td>
+      <td><%= format_task_input(recurring_logic.tasks.first, true) %></td>
+      <td><%= recurring_logic.tasks.order(:started_at).where('started_at IS NOT NULL').last.try(:started_at) || N_("-") %></td>
+      <td><%= recurring_logic_next_occurrence recurring_logic %></td>
+      <td><%= recurring_logic.iteration %></td>
+      <td><%= format_recurring_logic_limit recurring_logic.max_iteration %></td>
+      <td><%= format_recurring_logic_limit recurring_logic.end_time.try(:in_time_zone) %></td>
+      <td><%= recurring_logic_state(recurring_logic) %></td>
+      <td><%= recurring_logic_action_buttons(recurring_logic) %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= page_entries_info @recurring_logics %>
+<%= will_paginate @recurring_logics %>

--- a/app/views/foreman_tasks/recurring_logics/show.html.erb
+++ b/app/views/foreman_tasks/recurring_logics/show.html.erb
@@ -1,0 +1,12 @@
+<% title N_('Recurring logic') %>
+
+<% title_actions(button_group(recurring_logic_action_buttons(@recurring_logic))) %>
+
+<div class="tab-content col-md-6">
+  <legend><%= _('Details') %></legend>
+  <%= render @recurring_logic.task_group, :task_group => @recurring_logic.task_group %>
+</div>
+
+<div class="tab-content col-md-6">
+  <%= render 'tab_related', :source => @recurring_logic %>
+</div>

--- a/app/views/foreman_tasks/task_groups/_common.html.erb
+++ b/app/views/foreman_tasks/task_groups/_common.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <table class='table table-condensed'>
+    <tr>
+      <th><%= N_('ID') %></th>
+      <td><%= link_to(task_group.id, foreman_tasks_task_group_url(task_group)) %></td>
+    </tr>
+    <tr>
+      <th><%= N_('Task count') %></th>
+      <td><%= link_to(task_group.tasks.count, foreman_tasks_tasks_url(:search => "task_group.id = #{task_group.id}")) %></td>
+    </tr>
+  </table>
+</div>

--- a/app/views/foreman_tasks/task_groups/_detail.html.erb
+++ b/app/views/foreman_tasks/task_groups/_detail.html.erb
@@ -1,0 +1,7 @@
+<legend><%= N_('Task group common') %></legend>
+<%= render 'foreman_tasks/task_groups/common', :task_group => task_group %>
+<legend><%= task_group.humanized_name %> specific</legend>
+<div>
+  <%= begin; render task_group.to_partial_path.dup, :task_group => task_group; rescue ActionView::MissingTemplate => e; end %>
+</div>
+

--- a/app/views/foreman_tasks/task_groups/_tab_related.html.erb
+++ b/app/views/foreman_tasks/task_groups/_tab_related.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <legend><%= _("Associated resources") %></legend>
+  <ul>
+    <% source.task_groups.pluck(:type).uniq.each do |type| %>
+      <% next if type == source.task_group.type %>
+      <% groups = source.task_groups.where(:type => type) %>
+      <% begin %>
+        <%= render groups.first.to_partial_path.pluralize.dup, :source => source, :task_groups => groups %>
+      <% rescue ActionView::MissingTemplate => _ %>
+        <% groups.each do |group| %>
+          <%= render 'foreman_tasks/task_groups/common', :source => source, :task_group => group %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </ul>
+</div>
+

--- a/app/views/foreman_tasks/task_groups/recurring_logic_task_groups/_recurring_logic_task_group.html.erb
+++ b/app/views/foreman_tasks/task_groups/recurring_logic_task_groups/_recurring_logic_task_group.html.erb
@@ -1,0 +1,39 @@
+<% recurring_logic = task_group.recurring_logic -%>
+<table class='table table-condensed'>
+  <tr>
+    <th>ID</th>
+    <td><%= link_to(recurring_logic.id, recurring_logic) %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Cronline") %></th>
+    <td><%= recurring_logic.cron_line %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Action") %></th>
+    <td><%= format_task_input(recurring_logic.tasks.first, true) %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Last occurrence") %></th>
+    <td><%= recurring_logic.tasks.order(:started_at).where('started_at IS NOT NULL').last.try(:started_at) || N_('-') %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Next occurrence") %></th>
+    <td><%= recurring_logic_next_occurrence recurring_logic %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Current iteration") %></th>
+    <td><%= recurring_logic.iteration %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Iteration limit") %></th>
+    <td><%= format_recurring_logic_limit recurring_logic.max_iteration %></td>
+  </tr>
+  <tr>
+    <th><%= N_("Repeat until") %></th>
+    <td><%= format_recurring_logic_limit recurring_logic.end_time.try(:in_time_zone) %></td>
+  </tr>
+  <tr>
+    <th><%= N_("State") %></th>
+    <td><%= recurring_logic_state(recurring_logic) %></td>
+  </tr>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Foreman::Application.routes.draw do
   namespace :foreman_tasks do
+    resources :recurring_logics, :only => [:index, :show] do
+      member do
+        post :cancel
+      end
+    end
+
     resources :tasks, :only => [:index, :show] do
       collection do
         get 'auto_complete_search'

--- a/db/migrate/20150907124936_create_recurring_logic.rb
+++ b/db/migrate/20150907124936_create_recurring_logic.rb
@@ -1,0 +1,11 @@
+class CreateRecurringLogic < ActiveRecord::Migration
+  def change
+    create_table :foreman_tasks_recurring_logics do |t|
+      t.string :cron_line, :null => false
+      t.datetime :end_time
+      t.integer :max_iteration
+      t.integer :iteration, :default => 0
+      t.integer :task_group_id, :index => true, :null => false
+    end
+  end
+end

--- a/db/migrate/20150907131503_create_task_groups.rb
+++ b/db/migrate/20150907131503_create_task_groups.rb
@@ -1,0 +1,19 @@
+class CreateTaskGroups < ActiveRecord::Migration
+  def up
+    create_table :foreman_tasks_task_groups do |t|
+      t.string :type, index: true, null: false
+    end
+
+    create_table :foreman_tasks_task_group_members do |t|
+      t.string :task_id, null: false
+      t.integer :task_group_id, null: false
+    end
+
+    add_index :foreman_tasks_task_group_members, [:task_id, :task_group_id], unique: true, name: 'foreman_tasks_task_group_members_index'
+  end
+
+  def down
+    drop_table :foreman_tasks_task_groups
+    drop_table :foreman_tasks_task_group_members
+  end
+end

--- a/db/migrate/20151022123457_add_recurring_logic_state.rb
+++ b/db/migrate/20151022123457_add_recurring_logic_state.rb
@@ -1,0 +1,9 @@
+class AddRecurringLogicState < ActiveRecord::Migration
+  def up
+    add_column :foreman_tasks_recurring_logics, :state, :string, :index => true
+  end
+
+  def down
+    remove_column :foreman_tasks_recurring_logics, :state
+  end
+end

--- a/db/migrate/20151112152108_create_triggerings.rb
+++ b/db/migrate/20151112152108_create_triggerings.rb
@@ -1,0 +1,18 @@
+class CreateTriggerings < ActiveRecord::Migration
+  def up
+    create_table :foreman_tasks_triggerings do |t|
+      t.string :mode, null: false
+      t.datetime :start_at
+      t.datetime :start_before
+    end
+
+    change_table :foreman_tasks_recurring_logics do |t|
+      t.integer :triggering_id
+    end
+  end
+
+  def down
+    drop_table :foreman_tasks_triggerings
+    remove_column :foreman_tasks_recurring_logics, :triggering_id
+  end
+end

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -25,8 +25,9 @@ DESC
   end
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "dynflow", '~> 0.8.6'
+  s.add_dependency "dynflow", '~> 0.8.8'
   s.add_dependency "sequel" # for Dynflow process persistence
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "daemons" # for running remote executor
+  s.add_dependency "parse-cron", '~> 0.1.4'
 end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -15,11 +15,23 @@ module ForemanTasks
              :caption  => N_('Tasks'),
              :parent   => :monitor_menu
 
+        menu :top_menu, :recurring_logics, :after => :tasks,
+             :url_hash => { :controller => 'foreman_tasks/recurring_logics', :action => :index },
+             :caption  => N_('Recurring logics'),
+             :parent   => :monitor_menu
+
         security_block :foreman_tasks do |map|
           permission :view_foreman_tasks, {:'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :show],
                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, {:'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel],
                                            :'foreman_tasks/api/tasks' => [:bulk_resume]}, :resource_type => ForemanTasks::Task.name
+
+          permission :create_recurring_logics, { }, :resource_type => ForemanTasks::RecurringLogic
+
+          permission :view_recurring_logics, { :'foreman_tasks/recurring_logics' => [:index, :show] }, :resource_type => ForemanTasks::RecurringLogic
+
+          permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel] }, :resource_type => ForemanTasks::RecurringLogic
+                                                                                                                                 
         end
 
         logger :dynflow, :enabled => true

--- a/test/unit/recurring_logic_test.rb
+++ b/test/unit/recurring_logic_test.rb
@@ -1,0 +1,74 @@
+require 'foreman_tasks_test_helper'
+
+class RecurringLogicsTest < ActiveSupport::TestCase
+
+  describe 'generating times' do
+
+    it 'assembles cronline' do
+      hash = { }
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* * * * *'
+      hash.update :minutes => '*'
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* * * * *'
+      hash.update :hours => '0,12'
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* 0,12 * * *'
+      hash.update :days => '*/2'
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* 0,12 */2 * *'
+      hash.update :months  => '12'
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* 0,12 */2 12 *'
+      hash.update :days_of_week => '1,2,3,4,5,6,7'
+      ForemanTasks::RecurringLogic.assemble_cronline(hash).must_equal '* 0,12 */2 12 1,2,3,4,5,6,7'
+    end
+
+    it 'generates correct times' do
+      year, month, day, hour, minute = [2015, 9, 29, 15, 0]
+      reference_time = Time.new(year, month, day, hour, minute)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, month, day, hour, minute + 1)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('*/2 * * * *')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, month, day, hour, minute + 2)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('*/2 18,19 * * *')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, month, day, 18)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('*/2 18,19 10 * *')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, month + 1, 10, 18, minute)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('*/2 18,19 10 11,12 *')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, 11, 10, 18, 0)
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('* * * * 1')
+      parser.next_occurrence_time(reference_time).must_equal Time.new(year, month + 1, 5)
+    end
+
+    it 'can have limited number of repeats' do
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      parser.state = 'active'
+      parser.must_be :can_continue?
+      parser.max_iteration = 5
+      parser.expects(:iteration).twice.returns(5)
+      parser.wont_be :can_continue?
+      parser.max_iteration = nil
+      time = Time.new(2015, 9, 29, 15, 0)
+      parser.end_time = time
+      parser.wont_be :can_continue?, time
+      parser.end_time = time + 120
+      parser.must_be :can_continue?, time
+      parser.max_iteration = 5
+      parser.wont_be :can_continue?, time
+    end
+
+    it 'generates delay options' do
+      parser = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      parser.stubs(:id).returns(1)
+      reference_time = Time.new(2015, 9, 29, 15)
+      expected_hash = { :start_at => reference_time + 60, :start_before => nil, :recurring_logic_id => parser.id }
+      parser.generate_delay_options(reference_time).must_equal expected_hash
+      parser.generate_delay_options(reference_time, 'start_before' => reference_time + 3600)
+        .must_equal expected_hash.merge(:start_before => reference_time + 3600)
+    end
+
+    it 'can start' do
+      recurring_logic = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      ::ForemanTasks.expects(:delay)
+      recurring_logic.expects(:save!).twice
+      recurring_logic.start(::Support::DummyDynflowAction)
+    end
+  end
+
+end

--- a/test/unit/task_groups_test.rb
+++ b/test/unit/task_groups_test.rb
@@ -1,0 +1,76 @@
+require "foreman_tasks_test_helper"
+
+module ForemanTasks
+  class TaskGroupsTest < ActiveSupport::TestCase
+    self.use_transactional_fixtures = false
+    include ::Dynflow::Testing
+
+    before do
+      User.current = User.where(:login => 'apiadmin').first
+    end
+
+    after do
+      ::ForemanTasks::TaskGroup.all.each(&:destroy)
+      ::ForemanTasks::Task::DynflowTask.all.each(&:destroy)
+    end
+
+    class ParentAction < Actions::ActionWithSubPlans
+
+      middleware.use ::Actions::Middleware::InheritTaskGroups
+
+      def plan(count)
+        task_group = ::ForemanTasks::TaskGroups::RecurringLogicTaskGroup.new
+        task_group.id = 1
+        task_group.save!
+        task.add_missing_task_groups(task_group)
+        plan_self :count => count
+      end
+      
+      def create_sub_plans
+        input[:count].times.map { |i| trigger InheritingChildAction, i + 2 }
+      end
+    end
+
+    class ChildAction < Actions::EntryAction
+      def plan(number = 1)
+        task_group = ::ForemanTasks::TaskGroups::RecurringLogicTaskGroup.new
+        task_group.id = number
+        task_group.save!
+        task.add_missing_task_groups task_group
+        input[:id] = task_group.id
+      end
+    end
+
+    class InheritingChildAction < ChildAction
+      middleware.use ::Actions::Middleware::InheritTaskGroups
+    end
+
+    describe ForemanTasks::TaskGroup do
+      let(:spawn_task) do
+        lambda do |action_class, *args|
+          triggered = ForemanTasks.trigger(action_class, *args)
+          raise triggered.error if triggered.respond_to?(:error)
+          triggered.finished.wait
+          ForemanTasks::Task.find_by_external_id(triggered.id)
+        end
+      end
+
+      it 'has the task group assigned' do
+        task = spawn_task.call ChildAction
+        task.task_groups.map(&:id).must_equal [1]
+      end
+
+      it 'tasks inherit task groups correctly' do
+        children_count = 3
+        task = spawn_task.call ParentAction, children_count
+        # Parent task has task groups of its children
+        task.task_groups.map(&:id).must_equal [1, 2, 3, 4]
+        # Children have the parent's and their own, they don't have their siblings' task groups
+        task.sub_tasks.count.must_equal children_count
+        task.sub_tasks.each do |sub_task|
+          sub_task.task_groups.map(&:id).must_equal [1, sub_task.input[:id]]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
TODO:
- [x] recurring actions
- [x] task groups
- [x] permissions
- [x] tests
- [ ] improve UI
- [ ] ability to clone (and edit) recurring logic
- [x] cleanup stale comments

### Task Groups
Do this in action's plan method
```ruby
task.add_missing_task_groups(task_groups)
```

### Recurring logic
Use the middleware in an action
```ruby

middleware.use ::Actions::Middleware::RecurringLogic
``` 

To start a recurring action
```ruby
recurring_logic = ::ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
recurring_logic.start(action_class, plan_arg1, plan_arg2...)
```


~~Task Groups (for actions with sub plans)
Subtasks which want to be in the same task groups as the task which spawned them must use the InheritTaskGroups middleware. This middleware makes the child task inherit task groups from the parent before its plan phase and it makes the parent collect task groups from its children at the end of its run phase. That means the parent task has to set its task groups during the plan phase. At the end of the parent's run phase, it adds the children's task groups to its own.~~

~~tl;dr version:~~
+ ~~`middleware.use InheritTaskGroups`~~
+ ~~the children inherit task groups from the parent before the children's plan phase~~
+ ~~parent adds all of children's task groups to its own at the end of parent's run phase~~
+ ~~sibling tasks don't modify each others' task groups~~