### PR TITLE
Refs #11895 - optimize humanized data loading

### DIFF
--- a/app/helpers/foreman_tasks/tasks_helper.rb
+++ b/app/helpers/foreman_tasks/tasks_helper.rb
@@ -2,8 +2,8 @@ module ForemanTasks
   module TasksHelper
     def format_task_input(task, include_action = false)
       parts = []
-      parts << task.humanized[:action] if include_action
-      parts << Array(task.humanized[:input]).map do |part|
+      parts << task.get_humanized(:name) if include_action
+      parts << Array(task.get_humanized(:input)).map do |part|
         if part.is_a? Array
           part[1][:text]
         else

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -83,14 +83,20 @@ module ForemanTasks
     end
 
     def get_humanized(method)
-      Match! method, :humanized_name, :humanized_input, :humanized_output, :humanized_errors
-      if main_action.respond_to? method
-        begin
-          main_action.send method
-        rescue => error
-          "#{error.message} (#{error.class})\n#{error.backtrace.join "\n"}"
-        end
+      @humanized_cache ||= {}
+      if [:name, :input, :output, :error].include?(method)
+        method = "humanized_#{method}".to_sym
       end
+      Match! method, :humanized_name, :humanized_input, :humanized_output, :humanized_errors
+      @humanized_cache[method] ||= begin
+                                     if main_action.respond_to? method
+                                       begin
+                                         main_action.send method
+                                       rescue Exception => error # rubocop:disable Lint/RescueException
+                                         "#{error.message} (#{error.class})\n#{error.backtrace.join "\n"}"
+                                       end
+                                     end
+                                   end
     end
 
     def self.consistency_check

--- a/test/helpers/foreman_tasks/tasks_helper_test.rb
+++ b/test/helpers/foreman_tasks/tasks_helper_test.rb
@@ -2,13 +2,12 @@ require "foreman_tasks_test_helper"
 
 module ForemanTasks
   class TasksHelperTest < ActionView::TestCase
-
     describe 'when formatting simple input' do
       before do
         @task = FactoryGirl.build(:dynflow_task, :user_create_task)
-        humanized = {:action=>"Create", :input=>[[:user, {:text=>"user 'Anonymous Admin'", :link=>nil}]], :output=>"", :errors=>[]}
+        humanized = { :humanized_name => "Create", :humanized_input => [[:user, {:text => "user 'Anonymous Admin'", :link => nil}]] }
+        @task.instance_variable_set('@humanized_cache', humanized)
         @task.stubs(:input).returns({"user"=>{"id"=>1, "name"=>"Anonymous Admin"}, "locale"=>"en"})
-        @task.stubs(:humanized).returns(humanized)
       end
 
       it 'formats the task input properly' do
@@ -21,17 +20,15 @@ module ForemanTasks
     describe 'when formatting input' do
       before do
         @task = FactoryGirl.build(:dynflow_task, :product_create_task)
-        humanized = {:action=>"Create",
-                     :input=>[[:product, {:text=>"product 'product-2'", :link=>"#/products/3/info"}], [:organization, {:text=>"organization 'test-0'", :link=>"/organizations/3/edit"}]],
-                     :output=>"",
-                     :errors=>[]}
+        humanized = { :humanized_name => "Create",
+                      :humanized_input => [[:product, { :text => "product 'product-2'", :link => "#/products/3/info"}], [:organization, { :text => "organization 'test-0'", :link => "/organizations/3/edit" }]]}
+        @task.instance_variable_set('@humanized_cache', humanized)
         input = {"product"=>{"id"=>3, "name"=>"product-2", "label"=>"product-2", "cp_id"=>nil},
                  "provider"=>{"id"=>3, "name"=>"Anonymous"},
                  "organization"=>{"id"=>3, "name"=>"test-0", "label"=>"test-0"},
                  "cp_id"=>"1412251033866",
                  "locale"=>"en"}
         @task.stubs(:input).returns(input)
-        @task.stubs(:humanized).returns(humanized)
       end
 
       it 'formats the task input properly' do


### PR DESCRIPTION
On tasks index page, call only humainzed methods that are needed. Also, cache
the humanized data on first call, as the humanization might be relatively
expensive sometimes. Also, we catch all the exceptions when calling the
humanization, as it's not critical and the errors at humanization should not
prevent the user to see other task data.