### PR TITLE
Fixes #12460 - Rails 4 compatible changes with Rails 3 (find_or_create/where)

### DIFF
--- a/db/seeds.d/60-dynflow_proxy_feature.rb
+++ b/db/seeds.d/60-dynflow_proxy_feature.rb
@@ -1,2 +1,2 @@
-f = Feature.find_or_create_by_name('Dynflow')
+f = Feature.where(:name => 'Dynflow').first_or_create
 raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?


### PR DESCRIPTION
Some parts of foreman-tasks use find_or_create, that have to be replaced
by Rails 4 syntax. We can do this with where and first_or_create and
have it working on both Rails versions.