### PR TITLE
Rails4 compatibility changes

### DIFF
--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -2,7 +2,7 @@ module Actions
   class Base < Dynflow::Action
 
     def task
-      @task ||= ::ForemanTasks::Task::DynflowTask.find_by_external_id!(execution_plan_id)
+      @task ||= ::ForemanTasks::Task::DynflowTask.find_by!(:external_id => execution_plan_id)
     end
 
     # This method says what data form input gets into the task details in Rest API

--- a/app/models/foreman_tasks/concerns/action_triggering.rb
+++ b/app/models/foreman_tasks/concerns/action_triggering.rb
@@ -130,7 +130,7 @@ module ForemanTasks
           if @dynflow_sync_action
             run.wait
             if run.value.error?
-              task = ForemanTasks::Task::DynflowTask.find_by_external_id!(@execution_plan.id)
+              task = ForemanTasks::Task::DynflowTask.find_by!(:external_id => @execution_plan.id)
               raise ForemanTasks::TaskError.new(task)
             end
           end

--- a/app/models/foreman_tasks/concerns/host_action_subject.rb
+++ b/app/models/foreman_tasks/concerns/host_action_subject.rb
@@ -22,8 +22,8 @@ module ForemanTasks
           hostname.try(:downcase!)
           certname.try(:downcase!)
 
-          host = certname.present? ? Host.find_by_certname(certname) : nil
-          host ||= Host.find_by_name hostname
+          host = certname.present? ? Host.find_by(:certname => certname) : nil
+          host ||= Host.find_by(:name => hostname)
           host ||= Host.new(:name => hostname, :certname => certname) if Setting[:create_new_host_when_facts_are_uploaded]
           if host
             # if we were given a certname but found the Host by hostname we should update the certname

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -15,8 +15,9 @@ module ForemanTasks
 
     # in fact, the task has only one owner but Rails don't let you to
     # specify has_one relation though has_many relation
-    has_many :owners, :through => :locks, :source => :resource, :source_type => 'User',
-        :conditions => ["foreman_tasks_locks.name = ?", Lock::OWNER_LOCK_NAME]
+    has_many :owners, ->{ where("foreman_tasks_locks.name = #{Lock::OWNER_LOCK_NAME}") }, 
+                      :through => :locks, :source => :resource, :source_type => 'User'
+                       
 
     scoped_search :on => :id, :complete_value => false
     scoped_search :on => :label, :complete_value => true

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -15,7 +15,7 @@ module ForemanTasks
       self.start_before   = data[:start_before] if data[:start_before]
       self.parent_task_id ||= begin
                                 if main_action.caller_execution_plan_id
-                                  DynflowTask.find_by_external_id!(main_action.caller_execution_plan_id).id
+                                  DynflowTask.find_by!(:external_id => main_action.caller_execution_plan_id).id
                                 end
                               end
       self.label          ||= main_action.class.name

--- a/db/seeds.d/60-dynflow_proxy_feature.rb
+++ b/db/seeds.d/60-dynflow_proxy_feature.rb
@@ -1,2 +1,2 @@
-f = Feature.find_or_create_by_name('Dynflow')
+f = Feature.find_or_create_by(:name => 'Dynflow')
 raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -27,7 +27,7 @@ module ForemanTasks
           end),
           (on ::Dynflow::World::Triggered.(execution_plan_id: ~any, future: ~any) do |id, finished|
             finished.wait if async == false
-            ForemanTasks::Task::DynflowTask.find_by_external_id!(id)
+            ForemanTasks::Task::DynflowTask.find_by!(:external_id => id)
           end)
   end
 

--- a/lib/foreman_tasks/dynflow/console_authorizer.rb
+++ b/lib/foreman_tasks/dynflow/console_authorizer.rb
@@ -4,7 +4,7 @@ module ForemanTasks
     def initialize(env)
       @rack_request          = Rack::Request.new(env)
       @user_id, @expires_at = @rack_request.session.values_at('user', 'expires_at')
-      @user                 = User.find_by_id(@user_id) unless session_expired?
+      @user                 = User.find_by(:id => @user_id) unless session_expired?
     end
 
     def allow?

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -39,7 +39,7 @@ module ForemanTasks
         task.update_from_dynflow(data)
         Lock.owner!(::User.current, task.id) if ::User.current
       else
-        if task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
+        if task = ::ForemanTasks::Task::DynflowTask.find_by(:external_id => execution_plan_id)
           unless task.state.to_s == data[:state].to_s
             task.update_from_dynflow(data)
           end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -58,7 +58,9 @@ module ForemanTasks
     end
 
     initializer "foreman_tasks.load_app_instance_data" do |app|
-      app.config.paths['db/migrate'] += ForemanTasks::Engine.paths['db/migrate'].existent
+      ForemanTasks::Engine.paths['db/migrate'].existent.each do |path|
+        app.config.paths['db/migrate'] << path
+      end
     end
 
     # to enable async Foreman operations using Dynflow


### PR DESCRIPTION
- switch to `find_or_create_by` method
- only handing logname vs an actual logger object

Conflicts:
	lib/foreman_tasks/dynflow/persistence.rb