### PR TITLE
Refs #10970 - Fixes task details page

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -29,7 +29,7 @@ module ForemanTasks
       class BadRequest < Apipie::ParamError
       end
 
-      before_filter :find_resource, :only => [:show]
+      before_filter :find_task, :only => [:show]
 
       api :GET, "/tasks/summary", "Show task summary"
       def summary
@@ -258,6 +258,10 @@ module ForemanTasks
       end
 
       private
+
+      def find_task
+        @task = Task.find(params[:id])
+      end
 
       def resource_scope(options = {})
         @resource_scope ||= ForemanTasks::Task.authorized("#{action_permission}_foreman_tasks")

--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -5,7 +5,7 @@ module ForemanTasks
     before_filter :restrict_dangerous_actions, :only => [:unlock, :force_unlock]
 
     def show
-      @task = find_resource
+      @task = Task.find(params[:id])
     end
 
     def index
@@ -14,7 +14,7 @@ module ForemanTasks
     end
 
     def sub_tasks
-      task   = find_resource
+      task   = Task.find(params[:id])
       @tasks = filter(task.sub_tasks)
       render :index
     end


### PR DESCRIPTION
find_resource is not working when showing a task page in katello in Rails 4, It will not use the full uuid as the id param.