### PR TITLE
Fixes #13006 - unable to view task details page

### DIFF
--- a/lib/foreman_tasks/dynflow/console_authorizer.rb
+++ b/lib/foreman_tasks/dynflow/console_authorizer.rb
@@ -3,7 +3,8 @@ module ForemanTasks
   class Dynflow::ConsoleAuthorizer
     def initialize(env)
       @rack_request          = Rack::Request.new(env)
-      @user_id, @expires_at = @rack_request.session.values_at('user', 'expires_at')
+      current_session = @rack_request.session
+      @user_id, @expires_at = current_session['user'], current_session['expires_at']
       @user                 = User.where(:id => @user_id).first unless session_expired?
     end
 


### PR DESCRIPTION
sessions are lazily loaded, and @rack_request.session will return ```#<ActionDispatch::Request::Session:0x7f76982e76b8 not yet loaded>
``` if not accessed first. This seems to have broke with the rails 4 changes