### PR TITLE
Fixes #13335: Set primary key properly for foreman_tasks_tasks

### DIFF
--- a/db/migrate/20131205204140_create_foreman_tasks.rb
+++ b/db/migrate/20131205204140_create_foreman_tasks.rb
@@ -1,7 +1,7 @@
 class CreateForemanTasks < ActiveRecord::Migration
   def change
-    create_table :foreman_tasks_tasks, :id => false do |t|
-      t.string :id, primary_key: true
+    create_table :foreman_tasks_tasks, :id => false, :primary_key => :id do |t|
+      t.string :id, null: false
       t.string :type, index: true, null: false
       t.string :label, index: true
       t.datetime :started_at, index: true


### PR DESCRIPTION
This fixes a breakage that is exposed by Rails 4.1.14 where the
primary key 'id' is set to an integer and not a string.