### PR TITLE
Fixes #13578 - remove the at_exit hook to terminate the world

### DIFF
--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -41,8 +41,6 @@ module ForemanTasks
         @world = world
 
         unless config.remote?
-          at_exit { world.terminate.wait }
-
           # don't try to do any rescuing until the tables are properly migrated
           if !Foreman.in_rake?('db:migrate') && (ForemanTasks::Task.table_exists? rescue(false))
             world.auto_execute


### PR DESCRIPTION
Since https://github.com/Dynflow/dynflow/commit/4e3a002bd5f798090bf9d9896c5c625695c386d2#diff-35ca92bf5b10414a154a2844535ab5e9R29
we already are terminating the dynflow world in at_exit hook. Doing this
outside for Dynflow can lead to calling `exit` twice on termination finish.