### PR TITLE
fixes #13743 - remove 'Recurring logics' menu

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -44,12 +44,6 @@ module ForemanTasks
              :parent   => :monitor_menu,
              :last     => true
 
-        menu :top_menu, :recurring_logics,
-             :url_hash => { :controller => 'foreman_tasks/recurring_logics', :action => :index },
-             :caption  => N_('Recurring logics'),
-             :parent   => :monitor_menu,
-             :last     => true
-
         security_block :foreman_tasks do |map|
           permission :view_foreman_tasks, {:'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :show],
                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary] }, :resource_type => ForemanTasks::Task.name


### PR DESCRIPTION
I removed the menu but left the infrastructure in case there's somewhere less obtrusive to put it.