### PR TITLE
Fixes #15091 - Handle user timezones properly

### DIFF
--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -6,13 +6,14 @@ module ForemanTasks
     scope :for_action, ->(action_class) { where(label: action_class.name) }
 
     def update_from_dynflow(data)
+      utc_zone = ActiveSupport::TimeZone.new('UTC')
       self.external_id    = data[:id]
-      self.started_at     = data[:started_at]
-      self.ended_at       = data[:ended_at]
+      self.started_at     = utc_zone.parse(data[:started_at]) unless data[:started_at].nil?
+      self.ended_at       = utc_zone.parse(data[:ended_at]) unless data[:ended_at].nil?
       self.state          = data[:state].to_s
       self.result         = data[:result].to_s
-      self.start_at       = data[:start_at] if data[:start_at]
-      self.start_before   = data[:start_before] if data[:start_before]
+      self.start_at       = utc_zone.parse(data[:start_at]) if data[:start_at]
+      self.start_before   = utc_zone.parse(data[:start_before]) if data[:start_before]
       self.parent_task_id ||= begin
                                 if main_action.caller_execution_plan_id
                                   DynflowTask.where(:external_id => main_action.caller_execution_plan_id).first!.id

--- a/app/models/foreman_tasks/triggering.rb
+++ b/app/models/foreman_tasks/triggering.rb
@@ -11,7 +11,7 @@ module ForemanTasks
         parse_start_at!
         parse_start_before!
       else
-        self.start_at ||= Time.now
+        self.start_at ||= Time.zone.now
       end
     end
 
@@ -43,7 +43,7 @@ module ForemanTasks
         triggering.mode = params.fetch(:mode, :immediate).to_sym
         triggering.input_type = params.fetch(:input_type, :daily).to_sym
         triggering.end_time_limited = params[:end_time_limited] == "true"
-        triggering.start_at_raw ||= Time.now.strftime(TIME_FORMAT)
+        triggering.start_at_raw ||= Time.zone.now.strftime(TIME_FORMAT)
         triggering.recurring_logic = ::ForemanTasks::RecurringLogic.new_from_triggering(triggering) if triggering.recurring?
       end
     end
@@ -75,8 +75,8 @@ module ForemanTasks
 
     def delay_options
       {
-        :start_at => start_at,
-        :start_before => start_before
+        :start_at => start_at.utc,
+        :start_before => start_before.try(:utc)
       }
     end
 
@@ -93,11 +93,11 @@ module ForemanTasks
     end
 
     def parse_start_at!
-      self.start_at ||= Time.strptime(start_at_raw, TIME_FORMAT)
+      self.start_at ||= Time.zone.parse(start_at_raw)
     end
 
     def parse_start_before!
-      self.start_before ||= Time.strptime(start_before_raw, TIME_FORMAT) unless start_before_raw.blank?
+      self.start_before ||= Time.zone.parse(start_before_raw) unless start_before_raw.blank?
     end
 
     private

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -31,11 +31,9 @@ module ForemanTasks
       when :scheduled
         delayed_plan = load_delayed_plan(execution_plan_id)
         raise Foreman::Exception.new('Plan is delayed but the delay record is missing') if delayed_plan.nil?
-        # TODO: Rework this
-        delayed_plan = ::Dynflow::DelayedPlan.new_from_hash(ForemanTasks.dynflow.world, delayed_plan)
-        task = ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first
-        task.update_from_dynflow(data.merge(:start_at => delayed_plan.start_at,
-                                            :start_before => delayed_plan.start_before))
+        task = ::ForemanTasks::Task::DynflowTask.find_by!(:external_id => execution_plan_id)
+        task.update_from_dynflow(data.merge(:start_at => delayed_plan[:start_at],
+                                            :start_before => delayed_plan[:start_before]))
       when :planning
         task = ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first
         task.update_from_dynflow(data)


### PR DESCRIPTION
Also fixes issue where displayed times were depended on local system time (having system set as gmt+2 and user timezone as gmt-11 would lead to displaying times in the gmt-9 zone.