### PR TITLE
Fixes #15256 - Fix plugin assets deprecation

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -34,7 +34,7 @@ module ForemanTasks
       Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
     end
 
-    initializer 'foreman_tasks.register_plugin', :after => :finisher_hook do |app|
+    initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :"foreman-tasks" do
         requires_foreman '>= 1.9.0'
         divider :top_menu, :parent => :monitor_menu, :last => true


### PR DESCRIPTION
On 1.13 foreman_tasks needs to be initialized before :finisher_hook,
since doing it 'after' has been deprecated for a while and will be
removed.