### PR TITLE
Fixes #15598: Output task plan in JSON format

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -29,7 +29,7 @@ module ForemanTasks
       class BadRequest < Apipie::ParamError
       end
 
-      before_filter :find_task, :only => [:show]
+      before_filter :find_task, :only => [:show, :plan]
 
       api :GET, "/tasks/summary", "Show task summary"
       def summary
@@ -39,6 +39,11 @@ module ForemanTasks
       api :GET, "/tasks/:id", "Show task details"
       param :id, :identifier, desc: "UUID of the task"
       def show
+      end
+
+      api :GET, "/tasks/:id/plan", "Show task plan including sub-tasks"
+      param :id, :identifier, desc: "UUID of the task"
+      def plan
       end
 
       api :POST, "/tasks/bulk_search", "List dynflow tasks for uuids"

--- a/app/presenters/foreman_tasks/execution_plan_presenter.rb
+++ b/app/presenters/foreman_tasks/execution_plan_presenter.rb
@@ -1,0 +1,40 @@
+module ForemanTasks
+  class ExecutionPlanPresenter
+
+    attr_accessor :task
+
+    def initialize(task)
+      @task = task
+    end
+
+    def plan
+      output = []
+      @execution_plan = @task.execution_plan
+      output << {'run' => process_flow(@execution_plan.run_flow)}
+      output << {'finalize' => process_flow(@execution_plan.finalize_flow)}
+      output
+    end
+
+    def process_flow(flow)
+      case flow
+      when ::Dynflow::Flows::Sequence
+        steps = flow.flows.collect do |step|
+          process_flow(step)
+        end
+        {'type' => 'sequence', 'steps' => steps}
+      when ::Dynflow::Flows::Concurrence
+        steps = flow.flows.collect do |step|
+          process_flow(step)
+        end
+        {'type' => 'concurrence', 'steps' => steps}
+      when ::Dynflow::Flows::Atom
+        {'type' => 'atom', 'step' => process_atom(flow)}
+      end
+    end
+
+    def process_atom(atom)
+      @execution_plan.steps[atom.step_id].to_hash
+    end
+
+  end
+end

--- a/app/views/foreman_tasks/api/tasks/plan.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/plan.json.rabl
@@ -1,0 +1,7 @@
+object @task if @task
+
+attributes :id
+
+node :phases do |task|
+  ForemanTasks::ExecutionPlanPresenter.new(task).plan
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Foreman::Application.routes.draw do
           get :summary
           post :callback
         end
+        member do
+          get :plan
+        end
       end
     end
 

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -52,7 +52,7 @@ module ForemanTasks
 
         security_block :foreman_tasks do |map|
           permission :view_foreman_tasks, {:'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :show],
-                                           :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary] }, :resource_type => ForemanTasks::Task.name
+                                           :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :plan] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, {:'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel],
                                            :'foreman_tasks/api/tasks' => [:bulk_resume]}, :resource_type => ForemanTasks::Task.name
 


### PR DESCRIPTION
Provides the task execution plan output in JSON format, similar to
the dynflow console. This same JSON output is provided via export.
This allows users to export into a known and parseable format for
advanced processing.

New API:

/foreman_tasks/api/tasks/5c743d80-359c-4dcf-ab66-bf11a7fa2288/plan

Export:

rake foreman_tasks:export_tasks json=true
