### PR TITLE
Fixes #17290 - Usability improvements

### DIFF
--- a/app/assets/stylesheets/foreman_tasks/tasks.css.scss
+++ b/app/assets/stylesheets/foreman_tasks/tasks.css.scss
@@ -1,0 +1,9 @@
+.param-name {
+    display: inline-block;
+    width: 10em;
+  }
+
+.task-details pre {
+  white-space: pre;
+  word-break: normal;
+}

--- a/app/helpers/foreman_tasks/foreman_tasks_helper.rb
+++ b/app/helpers/foreman_tasks/foreman_tasks_helper.rb
@@ -16,6 +16,41 @@ module ForemanTasks
       content_tag(:i, '&nbsp'.html_safe, :class => "glyphicon #{icon}") + content_tag(:span, recurring_logic.humanized_state, :class => status)
     end
 
+    def task_result_icon_class(task)
+      return 'task-status pficon-help' if task.state != 'stopped'
+
+      icon_class = case task.result
+                     when 'success'
+                       'pficon-ok'
+                     when 'error'
+                       'pficon-error-circle-o'
+                     when 'warning'
+                       'pficon-ok status-warn'
+                     else
+                       'pficon-help'
+                   end
+
+      "task-status #{icon_class}"
+    end
+
+    def time_in_words_span(time)
+      if time.nil?
+        _('N/A')
+      else
+        content_tag :span, (time > Time.now.utc ? _('in %s') : _('%s ago')) % time_ago_in_words(time),
+                    { :'data-original-title' => time.try(:in_time_zone), :rel => 'twipsy' }
+      end
+    end
+
+    def duration_in_words_span(start, finish)
+      if start.nil?
+        _('N/A')
+      else
+        content_tag :span, distance_of_time_in_words(start, finish),
+                    { :'data-original-title' => number_with_delimiter((finish - start).to_i) + _(' seconds'), :rel => 'twipsy' }
+      end
+    end
+
     def recurring_logic_action_buttons(recurring_logic)
       buttons = []
       if authorized_for(:permission => :edit_recurring_logics, :auth_object => recurring_logic)

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -69,6 +69,10 @@ module ForemanTasks
       self.owner.try(:login)
     end
 
+    def execution_type
+      self.start_at.to_i == self.started_at.to_i ? N_('Immediate') : N_('Delayed')
+    end
+
     def humanized
       { action: label,
         input:  "",

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -13,6 +13,12 @@
                 cancel_foreman_tasks_task_path(@task),
                 class:  ['btn', 'btn-sm', 'btn-primary', ('disabled' unless @task.cancellable?)].compact,
                 method: :post) %>
+    <% if @task.parent_task %>
+      <%= link_to(_("Parent task"), foreman_tasks_task_path(@task.parent_task), class: ['btn', 'btn-sm', 'btn-default']) %>
+    <% end %>
+    <% if @task.sub_tasks.any? %>
+      <%= link_to(_("Sub tasks"), sub_tasks_foreman_tasks_task_path(@task), class: ['btn', 'btn-sm', 'btn-default']) %>
+  <% end %>
     <% if Setting['dynflow_allow_dangerous_actions'] %>
       <%= link_to(_('Unlock'),
                   '',
@@ -79,72 +85,68 @@
   </div>
 </div>
 
-<div>
-  <span class="param-name"><%= _("Id") %>:</span>
-  <span class="param-value"><%= @task.id %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Label") %>:</span>
-  <span class="param-value"><%= @task.label %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Name") %>:</span>
-  <span class="param-value"><%= @task.humanized[:action] %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Owner") %>:</span>
-  <span class="param-value"><%= @task.username %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Execution type") %>:</span>
-  <span class="param-value"><%= @task.start_at.nil? ? _('Immediate') : _('Delayed') %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Start at") %>:</span>
-  <span class="param-value"><%= @task.start_at.nil? ? '-' : @task.start_at %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Start before") %>:</span>
-  <span class="param-value"><%= @task.start_before.nil? ? '-' : @task.start_before %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Started at") %>:</span>
-  <span class="param-value"><%= @task.started_at.try(:in_time_zone) %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Ended at") %>:</span>
-  <span class="param-value"><%= @task.ended_at.try(:in_time_zone) %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("State") %>:</span>
-  <span class="param-value"><%= @task.state %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Result") %>:</span>
-  <span class="param-value"><%= @task.state == 'running' ? '-' : @task.result %></span>
-</div>
-<div>
-  <span class="param-name"><%= _("Params") %>:</span>
-  <span class="param-value"><%= format_task_input(@task) %></span>
-</div>
-<% if @task.parent_task %>
-<div>
-  <span class="param-name"><%= link_to(_("Parent task"), foreman_tasks_task_path(@task.parent_task)) %></span>
-</div>
-<% end %>
-<% if @task.sub_tasks.any? %>
-<div>
-  <span class="param-name"><%= link_to(_("Sub tasks"), sub_tasks_foreman_tasks_task_path(@task)) %></span>
-</div>
-<% end %>
 <div class="row">
-  <div class="col-xs-11">
-    <div class="progress progress-striped <%= 'active' if @task.state == 'running' %>">
-      <% progress = 100 * @task.progress %>
-      <% progress_class = if @task.state == 'running'
-                            nil
-                          else
-                            case @task.result
+  <div class="col-md-6">
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Name") %>:</span>
+      <% task_label = format_task_input(@task, true) %>
+      <span class="param-value" data-original-title="<%= task_label %>" rel="twipsy"> <%= truncate(task_label, :length => 50) %></span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Result") %>:</span>
+      <span class="param-value">
+        <% if @task.state != 'stopped' %>
+          <%= content_tag(:i, '&nbsp'.html_safe, :class => 'task-status pficon-help') %>
+        <% else %>
+          <%= content_tag(:i, '&nbsp'.html_safe, :class => task_result_icon_class(@task)) + content_tag(:span, @task.result) %>
+        <% end %>
+      </span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Triggered by") %>:</span>
+      <span class="param-value">
+        <% if @task.owner.present? && @task.username != User::ANONYMOUS_API_ADMIN && @task.username != User::ANONYMOUS_ADMIN %>
+          <%= link_to_if_authorized(@task.username, hash_for_edit_user_path(@task.owner)) %>
+        <% else %>
+          <%= @task.username %>
+        <% end %>
+      </span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Execution type") %>:</span>
+      <span class="param-value"><%= _(@task.execution_type) %></span>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Start at") %>:</span>
+      <span class="param-value"><%= @task.start_at.nil? ? '-' : time_in_words_span(@task.start_at) %></span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Started at") %>:</span>
+      <span class="param-value"><%= time_in_words_span @task.started_at.try(:in_time_zone) %></span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Ended at") %>:</span>
+      <span class="param-value"><%= time_in_words_span @task.ended_at.try(:in_time_zone) %></span>
+    </div>
+    <div>
+      <span class="param-name list-group-item-heading"><%= _("Start before") %>:</span>
+      <span class="param-value"><%= @task.start_before.nil? ? '-' : time_in_words_span(@task.start_before) %></span>
+    </div>
+  </div>
+</div>
+
+<br />
+
+<div class="row">
+  <div class="col-xs-12">
+    <% progress = 100 * @task.progress %>
+    <% progress_class = if @task.state == 'running'
+                          nil
+                        else
+                          case @task.result
                             when 'success'
                               'progress-bar-success'
                             when 'error'
@@ -153,27 +155,28 @@
                               'progress-bar-warning'
                             else
                               nil
-                            end
-                          end %>
-      <% classes = ['progress-bar', progress_class] %>
-      <div class="<%= classes.join ' ' %>"
+                          end
+                        end %>
+
+    <div class="progress-description <%= 'active' if @task.state == 'running' %>">
+      <span class="list-group-item-heading">State:</span>  <%= @task.state %>
+    </div>
+    <div class="progress progress-striped progress-label-top-right">
+      <div class="progress-bar <%= progress_class %>"
            role="progressbar"
            aria-valuenow="<%= progress %>"
            aria-valuemin="0"
            aria-valuemax="100"
            style="width: <%= progress %>%;">
-        <span class="sr-only"><%= progress %>% Complete</span>
+        <span><%= progress %>% Complete</span>
       </div>
     </div>
-  </div>
-  <div class="col-xs-1">
-    <%= progress.round %>%
   </div>
 </div>
 
 <% unless @task.humanized[:output].blank? %>
 <div>
-  <span class="param-name"><%= _("Output") %>:</span>
+  <span class="param-name list-group-item-heading"><%= _("Output") %>:</span>
   <span class="param-value">
     <pre><%= @task.humanized[:output] %></pre>
   </span>

--- a/app/views/foreman_tasks/tasks/_locks.html.erb
+++ b/app/views/foreman_tasks/tasks/_locks.html.erb
@@ -1,13 +1,19 @@
-<div>
-  <ul>
+<%= alert(:close => false, :class => 'alert-info', :header => '',
+          :text => _("You can find resource locks on this page. Exclusive lock marked with locked icon means that no other task can use locked resource while this task is running. Non-exclusive lock marked with unlocked icon means other tasks can access the resource freely, it is only used to indicate the relation of this task with the resource")) %>
+
+<div class="container-fluid container-cards-pf">
+  <div class="row row-cards-pf">
     <% @task.locks.each do |lock| %>
-      <li>
-        name: <%= lock.name %>
-        <br/>
-        resource: <%= format('%s id:%s', lock.resource_type, lock.resource_id) %>
-        <br/>
-        exclusive: <%= lock.exclusive %>
-      </li>
+      <div class="col-xs-6 col-sm-4 col-md-4">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status">
+          <h2 class="card-pf-title">
+            <span class="fa <%= lock.exclusive ? 'fa-lock' : 'fa-unlock-alt' %>"></span> <%= lock.name %>
+          </h2>
+          <div class="card-pf-body">
+            <%= format('%s id:%s', lock.resource_type, lock.resource_id) %><br>
+          </div>
+        </div>
+      </div>
     <% end %>
-  </ul>
+  </div>
 </div>

--- a/app/views/foreman_tasks/tasks/_raw.html.erb
+++ b/app/views/foreman_tasks/tasks/_raw.html.erb
@@ -1,16 +1,28 @@
 <div>
-  <span class="param-name"><%= _("Raw input") %>:</span>
+  <span class="param-name list-group-item-heading"><%= _("Id") %>:</span>
+  <span class="param-value"><%= @task.id %></span>
+</div>
+<div>
+  <span class="param-name list-group-item-heading"><%= _("Label") %>:</span>
+  <span class="param-value"><%= @task.label %></span>
+</div>
+<div>
+  <span class="param-name list-group-item-heading"><%= _("Duration") %>:</span>
+  <span class="param-value"><%= duration_in_words_span(@task.started_at, @task.ended_at || Time.now.utc) %></span>
+</div>
+<div>
+  <span class="param-name list-group-item-heading"><%= _("Raw input") %>:</span>
   <span class="param-value">
     <pre><%= @task.input.pretty_inspect %></pre>
   </span>
 </div>
 <div>
-  <span class="param-name"><%= _("Raw output") %>:</span>
+  <span class="param-name list-group-item-heading"><%= _("Raw output") %>:</span>
   <span class="param-value">
     <pre><%= @task.output.pretty_inspect %></pre>
   </span>
 </div>
 <div>
-  <span class="param-name"><%= _("External Id") %>:</span>
+  <span class="param-name list-group-item-heading"><%= _("External Id") %>:</span>
   <span class="param-value"><%= @task.external_id %></span>
 </div>

--- a/app/views/foreman_tasks/tasks/index.html.erb
+++ b/app/views/foreman_tasks/tasks/index.html.erb
@@ -1,17 +1,6 @@
 <% title _("Tasks") %>
 <% title_actions SETTINGS[:version].short <= '1.13' ? help_path : help_button %>
-
-<style>
-  .param-name {
-    display: inline-block;
-    width: 10em;
-  }
-
-  .task-details pre {
-    white-space: pre;
-    word-break: normal;
-  }
-</style>
+<% stylesheet 'foreman_tasks/tasks' %>
 
 <script>
 

--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -1,3 +1,5 @@
+<% stylesheet 'foreman_tasks/tasks' %>
+
 <script>
   if (typeof taskProgressReloader === 'undefined') {
     var taskProgressReloader = {


### PR DESCRIPTION
I started with some UI changes some time ago, since we now have dedicated person for it and I fail to find time for doing more I decided to send current version. Feel free to take what you find useful.
![tasks_details](https://cloud.githubusercontent.com/assets/109773/18478579/12740130-79d2-11e6-8bc4-3aab75bcd843.png)

notable changes:
- owner is a link to user, reworded to triggered by
- result is only displayed if the task state is stopped, "?" otherwise, result has icon
- dates are printed more user friendly, grouped in right column
- id and label are moved to Raw tab
- progress bar changes according to patternfly
- sub tasks, parent task links converted to buttons (next to cancel)
