### PR TITLE
Fixes #16593 - Capitalize the first letter of every world in menu.

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -47,7 +47,7 @@ module ForemanTasks
 
         menu :top_menu, :recurring_logics,
              :url_hash => { :controller => 'foreman_tasks/recurring_logics', :action => :index },
-             :caption  => N_('Recurring logics'),
+             :caption  => N_('Recurring Logics'),
              :parent   => :monitor_menu,
              :last     => true
 


### PR DESCRIPTION
To keep consistent in Foreman, we suggested to capitalize the first letter of every word in the menu.
FYI: https://github.com/theforeman/foreman/pull/3841
Thanks