### PR TITLE
Fixes #15283 - add indexes to make the locks request faster

### DIFF
--- a/db/migrate/20160920151810_add_more_lock_indexes.rb
+++ b/db/migrate/20160920151810_add_more_lock_indexes.rb
@@ -1,0 +1,9 @@
+class AddMoreLockIndexes < ActiveRecord::Migration
+  def change
+    add_index(:foreman_tasks_tasks, [:id, :state],
+              :name => 'index_foreman_tasks_id_state')
+    add_index(:foreman_tasks_locks, [:name, :resource_type, :resource_id],
+              :name => 'index_foreman_tasks_locks_name_resource_type_resource_id')
+  end
+
+end


### PR DESCRIPTION
We are searching on various lock attributes to find out if we don't
have any active task locking the resource.

https://github.com/theforeman/foreman-tasks/blob/v0.8.2/app/models/foreman_tasks/lock.rb#L62

If the amount of locks
it too high, it can lead to performance degradation.