### PR TITLE
Fixes #12729 - Add dynflow navbar links

### DIFF
--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -91,6 +91,9 @@ module ForemanTasks
           end
         end
 
+        set(:custom_navigation) do
+          { "Back to Foreman" => "/#{ForemanTasks::TasksController.controller_path}" }
+        end
         set(:world) { ForemanTasks.dynflow.world }
       end
     end

--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -92,7 +92,7 @@ module ForemanTasks
         end
 
         set(:custom_navigation) do
-          { "Back to Foreman" => "/#{ForemanTasks::TasksController.controller_path}" }
+          { _("Back to tasks") => "/#{ForemanTasks::TasksController.controller_path}" }
         end
         set(:world) { ForemanTasks.dynflow.world }
       end


### PR DESCRIPTION
requires https://github.com/Dynflow/dynflow/pull/204

The only issue here would be if whole foreman was mounted on some unusual location instead of `/`
