### PR TITLE
Fixes #17283 - helpers for test in thread executor

### DIFF
--- a/app/models/foreman_tasks/concerns/action_triggering.rb
+++ b/app/models/foreman_tasks/concerns/action_triggering.rb
@@ -141,6 +141,11 @@ module ForemanTasks
       # we don't want to start executing the task calling to external services
       # when inside some other transaction. Might lead to unexpected results
       def ensure_not_in_transaction!
+        # we don't care about transactions when using InThreadWorld
+        if defined?(::Dynflow::Testing::InThreadWorld) &&
+              ForemanTasks.dynflow.world.is_a?(::Dynflow::Testing::InThreadWorld)
+          return
+        end
         if self.class.connection.open_transactions > 0
           raise 'Executing dynflow action inside a transaction is not a good idea'
         end

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -29,7 +29,7 @@ DESC
   s.extra_rdoc_files = Dir['README*', 'LICENSE']
 
   s.add_dependency "foreman-tasks-core"
-  s.add_dependency "dynflow", '~> 0.8.16'
+  s.add_dependency "dynflow", '~> 0.8.17'
   s.add_dependency "sequel" # for Dynflow process persistence
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "daemons" # for running remote executor

--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -82,6 +82,10 @@ module ForemanTasks
       return @world
     end
 
+    def world=(world)
+      @world = world
+    end
+
     def web_console
       ::Dynflow::Web.setup do
         before do

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -94,8 +94,6 @@ module ForemanTasks
       end
     end
 
-    protected
-
     # generates the options hash consumable by the Dynflow's world
     def world_config
       ::Dynflow::Config.new.tap do |config|
@@ -111,6 +109,8 @@ module ForemanTasks
         config.auto_execute        = false
       end
     end
+
+    protected
 
     def default_sequel_adapter_options
       db_config            = ActiveRecord::Base.configurations[Rails.env].dup

--- a/lib/foreman_tasks/test_helpers.rb
+++ b/lib/foreman_tasks/test_helpers.rb
@@ -1,0 +1,23 @@
+require 'dynflow/testing'
+module ForemanTasks
+  module TestHelpers
+    def self.test_in_thread_world
+      world_config = ForemanTasks.dynflow.config.world_config
+      @test_in_thread_world ||= ::Dynflow::Testing::InThreadWorld.new(world_config)
+    end
+
+    module WithInThreadExecutor
+      extend ActiveSupport::Concern
+      included do
+        setup do
+          @old_dynflow_world = ForemanTasks.dynflow.world
+          ForemanTasks.dynflow.world = ForemanTasks::TestHelpers.test_in_thread_world
+        end
+
+        teardown do
+          ForemanTasks.dynflow.world = @old_dynflow_world
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Usage:

    # in test_helper.rb
    require 'foreman_tasks/test_helpers'

    # in the test suite that needs in thread executor
    include ForemanTasks::TestHelpers::WithInThreadExecutor

Requires https://github.com/Dynflow/dynflow/pull/209