### PR TITLE
Fixes #15922 - Added validators to id fields

### DIFF
--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -14,7 +14,7 @@ module ForemanTasks
       has_many :task_groups, -> { uniq }, :through => :tasks
     end
 
-    scoped_search :on => :id, :complete_value => false
+    scoped_search :on => :id, :complete_value => false, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :max_iteration, :complete_value => false, :rename => :iteration_limit
     scoped_search :on => :iteration, :complete_value => false
     scoped_search :on => :cron_line, :complete_value => true

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -38,10 +38,15 @@ module ForemanTasks
     scoped_search :on => :parent_task_id, :complete_value => true
     scoped_search :relation => :locks,  :on => :resource_type, :complete_value => true, :rename => 'resource_type', :ext_method => :search_by_generic_resource
     scoped_search :relation => :locks,  :on => :resource_id, :complete_value => false, :rename => 'resource_id', :ext_method => :search_by_generic_resource
-    scoped_search :relation => :owners,  :on => :id, :complete_value => true, :rename => 'owner.id', :ext_method => :search_by_owner
+    scoped_search :relation => :owners,  
+                  :on => :id, 
+                  :complete_value => true, 
+                  :rename => 'owner.id', 
+                  :ext_method => :search_by_owner,
+                  :validator => ->(value) { ScopedSearch::Validators::INTEGER.call(value) || value == 'current_user' }
     scoped_search :relation => :owners,  :on => :login, :complete_value => true, :rename => 'owner.login', :ext_method => :search_by_owner
     scoped_search :relation => :owners,  :on => :firstname, :complete_value => true, :rename => 'owner.firstname', :ext_method => :search_by_owner
-    scoped_search :relation => :task_groups, :on => :id, :complete_value => true, :rename => 'task_group.id'
+    scoped_search :relation => :task_groups, :on => :id, :complete_value => true, :rename => 'task_group.id', :validator => ScopedSearch::Validators::INTEGER
 
     scope :active, -> {  where('foreman_tasks_tasks.state != ?', :stopped) }
     scope :running, -> { where("foreman_tasks_tasks.state NOT IN ('stopped', 'paused')") }


### PR DESCRIPTION
Will work only with new version of scoped_search gem.
As of today, it's still only in [master](https://github.com/wvanbergen/scoped_search/commit/265f22520066c7e37e4c60adbaec3ab262f8a389).