### PR TITLE
Fixes #14806 - added executors_count option

### DIFF
--- a/bin/dynflow-executor
+++ b/bin/dynflow-executor
@@ -32,6 +32,9 @@ BANNER
   opts.on('-f', '--foreman-root=PATH', "Path to Foreman Rails root path. By default '#{options[:foreman_root]}'") do |path|
     options[:foreman_root] = path
   end
+  opts.on('-c', '--executors-count=COUNT', 'Number of parallel executors to spawn. Overrides EXECUTORS_COUNT environment varaible.') do |count|
+    options[:executors_count] = count.to_i
+  end
 end
 
 args = opts.parse!(ARGV)


### PR DESCRIPTION
Now you can start multiple executors using `dynflow-executor`
or `foreman-task` and setting environment variable
`EXECUTORS_COUNT` to the desired number of executors.