### PR TITLE
Fixes #17283 - improve caching to test world

### DIFF
--- a/lib/foreman_tasks/test_helpers.rb
+++ b/lib/foreman_tasks/test_helpers.rb
@@ -2,8 +2,9 @@ require 'dynflow/testing'
 module ForemanTasks
   module TestHelpers
     def self.test_in_thread_world
+      return @test_in_thread_world if @test_in_thread_world
       world_config = ForemanTasks.dynflow.config.world_config
-      @test_in_thread_world ||= ::Dynflow::Testing::InThreadWorld.new(world_config)
+      @test_in_thread_world = ::Dynflow::Testing::InThreadWorld.new(world_config)
     end
 
     module WithInThreadExecutor


### PR DESCRIPTION
Every time somebody asked for InThreadExecutor, new connection was
created, leading to getting out of available connections eventually.

This can start causing issues when running full test suite, where mupltiple in
thread worlds are requested over time.

The easiest way to reproduce is to run:

    require 'foreman_tasks/test_helpers'
    10000.times { ForemanTasks::TestHelpers.test_in_thread_world }