### PR TITLE
Improved speed of rake export task

### DIFF
--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -252,7 +252,7 @@ namespace :foreman_tasks do
         renderer = TaskRender.new
         total = tasks.count
 
-        tasks.each_with_index do |task, count|
+        tasks.find_each.with_index do |task, count|
           File.open(File.join(tmp_dir, "#{task.id}.html"), 'w') { |file| file.write(PageHelper.pagify(renderer.render_task(task))) }
           puts "#{count + 1}/#{total}"
         end
@@ -264,7 +264,7 @@ namespace :foreman_tasks do
     elsif format == 'csv'
       CSV.open(export_filename, 'wb') do |csv|
         csv << %w[id state type label result parent_task_id started_at ended_at]
-        tasks.each do |task|
+        tasks.find_each do |task|
           csv << [task.id, task.state, task.type, task.label, task.result,
                   task.parent_task_id, task.started_at, task.ended_at]
         end


### PR DESCRIPTION
Find each should improve batch processing a bit, I can see small boost about
1-5 % in my environment. I was also thinking removing the counter which makes
export slower on slow terminals (ssh, encryption, thousands of lines). The
patch also changed the default format from html to csv, I can change that if
you don't like it.