### PR TITLE
Fixes #17914 - Improve index performance

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -90,7 +90,6 @@ module ForemanTasks
       def bulk_resume
         scope = resource_scope
         scope = scope.search_for(params[:search]) if params[:search]
-        scope = scope.select('DISTINCT foreman_tasks_tasks.*')
         if params[:search].nil? && params[:task_ids].nil?
           scope = scope.where(:state => :paused)
           scope = scope.where(:result => :error)
@@ -131,7 +130,7 @@ module ForemanTasks
         param :order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
       end
       def index
-        scope =resource_scope.search_for(params[:search]).select('DISTINCT foreman_tasks_tasks.*')
+        scope = resource_scope.search_for(params[:search])
         total = scope.count
 
         ordering_params =  {
@@ -178,7 +177,7 @@ module ForemanTasks
       private
 
       def search_tasks(search_params)
-        scope = resource_scope_for_index.select('DISTINCT foreman_tasks_tasks.*')
+        scope = resource_scope_for_index
         scope = ordering_scope(scope, search_params)
         scope = search_scope(scope, search_params)
         scope = active_scope(scope, search_params)

--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -103,8 +103,7 @@ module ForemanTasks
 
     def filter(scope)
       scope.search_for(params[:search], :order => params[:order]).
-          paginate(:page => params[:page]).select('DISTINCT foreman_tasks_tasks.*')
+          paginate(:page => params[:page])
     end
-
   end
 end

--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -15,7 +15,7 @@ module ForemanTasks
       has_many :task_groups, -> { uniq }, :through => :tasks
     end
 
-    scoped_search :on => :id, :complete_value => false
+    scoped_search :on => :id, :complete_value => false, :only_explicit => true
     scoped_search :on => :max_iteration, :complete_value => false, :rename => :iteration_limit
     scoped_search :on => :iteration, :complete_value => false
     scoped_search :on => :cron_line, :complete_value => true

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -29,20 +29,20 @@ module ForemanTasks
     end
 
 
-    scoped_search :on => :id, :complete_value => false
+    scoped_search :on => :id, :complete_value => false, :only_explicit => true
     scoped_search :on => :label, :complete_value => true
     scoped_search :on => :state, :complete_value => true
     scoped_search :on => :result, :complete_value => true
     scoped_search :on => :started_at, :complete_value => false
     scoped_search :on => :start_at, :complete_value => false
     scoped_search :on => :ended_at, :complete_value => false
-    scoped_search :on => :parent_task_id, :complete_value => true
-    scoped_search :in => :locks,  :on => :resource_type, :complete_value => true, :rename => "resource_type", :ext_method => :search_by_generic_resource
-    scoped_search :in => :locks,  :on => :resource_id, :complete_value => false, :rename => "resource_id", :ext_method => :search_by_generic_resource
-    scoped_search :in => :owners,  :on => :id, :complete_value => true, :rename => "owner.id", :ext_method => :search_by_owner
-    scoped_search :in => :owners,  :on => :login, :complete_value => true, :rename => "owner.login", :ext_method => :search_by_owner
-    scoped_search :in => :owners,  :on => :firstname, :complete_value => true, :rename => "owner.firstname", :ext_method => :search_by_owner
-    scoped_search :in => :task_groups, :on => :id, :complete_value => true, :rename => "task_group.id"
+    scoped_search :on => :parent_task_id, :complete_value => true, :only_explicit => true
+    scoped_search :relation => :locks,  :on => :resource_type, :complete_value => true, :rename => "resource_type"
+    scoped_search :relation => :locks,  :on => :resource_id, :complete_value => false, :rename => "resource_id", :only_explicit => true
+    scoped_search :relation => :owners,  :on => :id, :complete_value => true, :rename => "owner.id", :ext_method => :search_by_owner, :only_explicit => true
+    scoped_search :relation => :owners,  :on => :login, :complete_value => true, :rename => "owner.login", :ext_method => :search_by_owner
+    scoped_search :relation => :owners,  :on => :firstname, :complete_value => true, :rename => "owner.firstname", :ext_method => :search_by_owner
+    scoped_search :relation => :task_groups, :on => :id, :complete_value => true, :rename => "task_group.id", :only_explicit => true
 
     scope :active, -> {  where('foreman_tasks_tasks.state != ?', :stopped) }
     scope :running, -> {  where("foreman_tasks_tasks.state NOT IN ('stopped', 'paused')") }
@@ -103,14 +103,6 @@ module ForemanTasks
           ret.concat(parent_task.self_and_parents)
         end
       end
-    end
-
-    def self.search_by_generic_resource(key, operator, value)
-      key =  "resource_type" if key.blank?
-      key_name = self.connection.quote_column_name(key.sub(/^.*\./,''))
-      condition = sanitize_sql_for_conditions(["foreman_tasks_locks.#{key_name} #{operator} ?", value])
-
-      return {:conditions => condition, :joins => :locks }
     end
 
     def self.search_by_owner(key, operator, value)


### PR DESCRIPTION
This commit addresses a couple of inefficiencies in the controllers.
the most siginificant being a `SELECT DISTINCT foreman_tasks_tasks.*`
that was added on the resource scopes to prevent duplicates when
searching on the lock properties. The duplicates were caused by an
unneeded ext_method that created a join on the lock table, instead of
using the built in scoped search capabilities to handle has many
relations.
Another inefficiency was including id fields in non-explicit searches
making those also result in more complex queries.
In addition, the scoped search declerations were updated to use the new
:relation property instead of :in.