### PR TITLE
Fixes #18189 - Round completed tasks percentage

### DIFF
--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -168,7 +168,7 @@
            aria-valuemin="0"
            aria-valuemax="100"
            style="width: <%= progress %>%;">
-        <span><%= progress %>% Complete</span>
+        <span><%= progress.round %>% Complete</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The task percentage is excessively long and can be
rounded to a whole number.