### PR TITLE
Fixes #18507 - ActiveJob adapter [WIP]

### DIFF
--- a/lib/foreman_tasks_adapter.rb
+++ b/lib/foreman_tasks_adapter.rb
@@ -1,0 +1,21 @@
+module ActiveJob
+  module QueueAdapters
+    # To use ForemanTasks, set the queue_adapter config to +:foreman_tasks+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :foreman_tasks
+    class ForemanTasksJobAdapter
+      extend ActiveSupport::Concern
+      include ForemanTasks::Triggers
+
+      def enqueue(job) #:nodoc:
+        task = async_task(job.action, job.args*, &block)
+        task
+      end
+
+      def enqueue_at(job, timestamp) #:nodoc:
+        task = delay(job.action, { :start_at => timestamp }, job.args*, &block)
+        task
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a work in progress. 

In order for this to work we would need at a minimum.

- [ ] - Wrap tasks in ActiveJob::Base (or wrap DynflowTask directly) so we can pass it to ActiveJob
- [ ] - Make sure our ActiveJob::Base tasks class has a `perform` and `perform_later` method https://github.com/theforeman/foreman-tasks

I also looked into changing the default async adapter (https://github.com/rails/rails/blob/93c9534c9871d4adad4bc33b5edc355672b59c61/activejob/lib/active_job/queue_adapters/async_adapter.rb) and change the executor to Dynflow, but in such a case we would only get the Dynflow console for new jobs, and not the tasks page, which is not desirable. 
If there is a way of creating tasks for already existing jobs in Dynflow maybe we can just use the AsyncAdapter with the Dynflow executor.