### PR TITLE
Fixes #18635 - redirect stdout/err to syslog

### DIFF
--- a/lib/foreman_tasks/dynflow/daemon.rb
+++ b/lib/foreman_tasks/dynflow/daemon.rb
@@ -49,6 +49,7 @@ module ForemanTasks
                          :dir_mode => :normal,
                          :monitor => true,
                          :log_output => true,
+                         :log_output_syslog => true,
                          :ARGV => [command]) do |*_args|
           begin
             ::Logging.reopen


### PR DESCRIPTION
Hello, there is a flaw in rubygem daemons - it does not close stdout/stderr correctly when spawning subprocesses. This is file descriptor leak that is reported by SELinux.

I fixed this in the upstream version (it's pending release now), the change closes descriptors. But if you pass log_output_syslog variable, it also attempts to redirect the stdout/err to syslog on platforms which supports this (Linux...) so we don't lost error messages (in this case the root issue was sendmail).

This patch adds this flag. We need to wait until new version is released and rebase on the new version, but we can send the flag today as it will be simply ignored.