### PR TITLE
Fixes #18758 - Allow ActiveJobs to be displayed in the tasks lists

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -210,7 +210,8 @@ module ForemanTasks
     end
 
     def action
-      super || to_label
+      return to_label if super.blank?
+      super
     end
 
     def to_label


### PR DESCRIPTION
The jobs created by ActiveJob would not show up properly in the tasks
list. Small adaptions should be made to allow foreman-tasks to pick up
the 'humanized' methods and display it.

Can be merged at any point, before or after: https://github.com/theforeman/foreman-tasks/pull/235