### PR TITLE
Fixes #18919 - Pull DynflowTask status in after_commit

### DIFF
--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -2,8 +2,14 @@ module ForemanTasks
   class Task::DynflowTask < ForemanTasks::Task
     include Algebrick::TypeCheck
 
+    after_commit :pull_update_from_dynflow
+
     delegate :cancellable?, :progress, to: :execution_plan
     scope :for_action, ->(action_class) { where(label: action_class.name) }
+
+    def pull_update_from_dynflow
+      execution_plan.save unless (state == execution_plan.state.to_s)
+    end
 
     def update_from_dynflow(data)
       utc_zone = ActiveSupport::TimeZone.new('UTC')


### PR DESCRIPTION
reinitiante update in case we missed on it