### PR TITLE
Fixes #16922 - Clean old tasks automaticaly

### DIFF
--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -13,11 +13,11 @@
 # Cleaning configuration: how long should the actions be kept before deleted
 # by `rake foreman_tasks:clean` task
 #
-#  :cleanup:
+  :cleanup:
 #
 # the period after which to delete all the tasks (by default all tasks are not being deleted after some period)
 #
-#    :after: 365d
+    :after: 30d
 #
 # per action settings to override the default defined in the actions (self.cleanup_after method)
 #

--- a/deploy/foreman-tasks.cron.d
+++ b/deploy/foreman-tasks.cron.d
@@ -1,0 +1,8 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+RAILS_ENV=production
+FOREMAN_HOME=/usr/share/foreman
+
+# Clean up the session entries in the database
+45 19 * * *     foreman    /usr/sbin/foreman-rake foreman_tasks:cleanup >>/var/log/foreman/cron.log 2>&1


### PR DESCRIPTION
Setup to cleanup tasks older then 30 days.
While the config is in foreman-tasks.yaml it is reflected by
'foreman_tasks:cleanup:config' rake task.
The time was set to 7:45 pm so it happens before nightly syncs
and do not collide with other default tasks of Foreman