### PR TITLE
Fixes #18356 - Assume incoming output is UTF-8

### DIFF
--- a/lib/foreman_tasks_core/runner/base.rb
+++ b/lib/foreman_tasks_core/runner/base.rb
@@ -42,7 +42,7 @@ module ForemanTasksCore
       end
 
       def publish_data(data, type)
-        @continuous_output.add_output(data, type)
+        @continuous_output.add_output(data.force_encoding('UTF-8'), type)
       end
 
       def publish_exception(context, exception, fatal = true)


### PR DESCRIPTION
`net-ssh` read the data as bytes and assumes it is `ASCII-8BIT` encoded. Sadly we have no reliable way of detecting the encoding of the incoming data.