### PR TITLE
Fixes #17347 - Stop autorefresh leaking to other pages

### DIFF
--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -4,10 +4,11 @@
   if (typeof taskProgressReloader === 'undefined') {
     var taskProgressReloader = {
       timeoutId: null,
+      formId: null,
       reload: function () {
         // we need different reload mechanism for two-pane and non-two-pane
         if (typeof currentTwoPaneTask !== 'undefined') {
-          if($('.two-pane-right').length) {
+          if($('.two-pane-right').length && $('form#' + taskProgressReloader.formId).length) {
             taskProgressReloader.timeoutId = null;
             two_pane_open(currentTwoPaneTask);
           } else {
@@ -19,10 +20,11 @@
       },
 
       start: function () {
+        var button = $('.reload-button');
         if (!taskProgressReloader.timeoutId) {
           taskProgressReloader.timeoutId = setTimeout(this.reload, 5000);
+          taskProgressReloader.formId = $(button).closest('form')[0].id;
         }
-        var button = $('.reload-button');
         button.html('<span class="glyphicon glyphicon-refresh spin"></span> <%= _('Stop auto-reloading') %>');
         button.show();
       },
@@ -32,6 +34,7 @@
           clearTimeout(taskProgressReloader.timeoutId);
         }
         taskProgressReloader.timeoutId = null;
+        taskProgressReloader.formId = null;
         var button = $('.reload-button');
         button.html('<span class="glyphicon glyphicon-refresh"></span> <%= _('Start auto-reloading') %>');
         button.show();


### PR DESCRIPTION
When starting the autorefresh we store the id of the form, which contains the uuid of current task. The refresh is cancelled if element with that id doesn't exist on page