### PR TITLE
Fixes #20080 - Allow runners to set timeout

### DIFF
--- a/lib/foreman_tasks_core/runner/base.rb
+++ b/lib/foreman_tasks_core/runner/base.rb
@@ -43,6 +43,7 @@ module ForemanTasksCore
 
       def timeout
         # Override when timeouts and regular kills should be handled differently
+        publish_data('Timeout for execution passed, trying to stop the job', 'debug')
         kill
       end
 

--- a/lib/foreman_tasks_core/runner/base.rb
+++ b/lib/foreman_tasks_core/runner/base.rb
@@ -41,6 +41,16 @@ module ForemanTasksCore
         # if cleanup is needed
       end
 
+      def timeout
+        # Override when timeouts and regular kills should be handled differently
+        kill
+      end
+
+      def timeout_interval
+        # A number of seconds after which the runner should receive a #timeout
+        #   or nil for no timeout
+      end
+
       def publish_data(data, type)
         @continuous_output.add_output(data, type)
       end


### PR DESCRIPTION
 - [x] add info about timeout to continuous output (https://github.com/theforeman/foreman-tasks/pull/258/files#r123245188)
- [X] add separate issue for this change, for better tracking of what needs to be done where and why