### PR TITLE
Fixes #20230 - Add time ended to error tasks widget

### DIFF
--- a/app/views/foreman_tasks/tasks/dashboard/_latest_tasks_in_error_warning.html.erb
+++ b/app/views/foreman_tasks/tasks/dashboard/_latest_tasks_in_error_warning.html.erb
@@ -1,15 +1,17 @@
 <h4><%= link_to _("Latest Warning/Error Tasks"), foreman_tasks_tasks_path(:order=>'started_at DESC') %></h4>
-<table class="table table-striped">
+<table class="table table-striped table-fixed">
   <tr>
-    <th><%= _("Name") %></th>
-    <th><%= _("State") %></th>
-    <th><%= _("Result") %></th>
+    <th class="col-md-5"><%= _("Name") %></th>
+    <th class="col-md-2"><%= _("State") %></th>
+    <th class="col-md-2"><%= _("Result") %></th>
+    <th class="col-md-3"><%= _("Ended") %></th>
   </tr>
   <% ForemanTasks::Task::Summarizer.new.latest_tasks_in_errors_warning.each do |task| %>
     <tr class="<%= ForemanTasks::Task::StatusExplicator.new.is_erroneous(task) ? 'text-danger' : '' %>">
-      <td><%= link_to task.humanized[:action], defined?(main_app) ? main_app.foreman_tasks_task_path(task.id) : foreman_tasks_task_path(task.id) %></td>
+      <td class="ellipsis"><%= link_to task.humanized[:action], defined?(main_app) ? main_app.foreman_tasks_task_path(task.id) : foreman_tasks_task_path(task.id) %></td>
       <td><%= task.state %></td>
       <td><%= task.result %></td>
+      <td><%= _('%s ago') % time_ago_in_words(task.ended_at) %></td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
Also made the table fixed with tooltips on overflow.