### PR TITLE
Fixes #20352 - backup deleted tasks

### DIFF
--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -9,6 +9,10 @@
 #     :action:
 #       :enabled: true
 
+  :backup:
+    :backup_deleted_tasks: true
+    :backup_dir: /var/lib/foreman/tasks-backup
+
 
 # Cleaning configuration: how long should the actions be kept before deleted
 # by `rake foreman_tasks:clean` task

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -78,9 +78,10 @@ module ForemanTasks
         say "[noop] #{ForemanTasks::Task.search_for(full_filter).size} tasks would be deleted"
       else
         start_tracking_progress
+        backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir
         while (chunk = ForemanTasks::Task.search_for(full_filter).limit(batch_size)).any?
-          delete_tasks(chunk)
-          delete_dynflow_plans(chunk)
+          delete_tasks(chunk, backup_dir)
+          delete_dynflow_plans(chunk, backup_dir)
           report_progress(chunk)
         end
       end
@@ -90,13 +91,15 @@ module ForemanTasks
       ForemanTasks::Task.search_for(full_filter).select('DISTINCT foreman_tasks_tasks.id, foreman_tasks_tasks.type, foreman_tasks_tasks.external_id')
     end
 
-    def delete_tasks(chunk)
-      ForemanTasks::Task.where(:id => chunk.map(&:id)).delete_all
+    def delete_tasks(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)
+      tasks = ForemanTasks::Task.where(:id => chunk.map(&:id))
+      ForemanTasks.dynflow.world.persistence.adapter.backup_to_csv(tasks, backup_dir, 'foreman_tasks.csv') if backup_dir
+      tasks.delete_all
     end
 
-    def delete_dynflow_plans(chunk)
+    def delete_dynflow_plans(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)
       dynflow_ids = chunk.find_all { |task| task.is_a? Task::DynflowTask }.map(&:external_id)
-      ForemanTasks.dynflow.world.persistence.delete_execution_plans({ 'uuid' => dynflow_ids }, batch_size)
+      ForemanTasks.dynflow.world.persistence.delete_execution_plans({ 'uuid' => dynflow_ids }, batch_size, backup_dir)
     end
 
     def prepare_filter

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -84,7 +84,7 @@ module ForemanTasks
         start_tracking_progress
         while (chunk = ForemanTasks::Task.search_for(full_filter).limit(batch_size)).any?
           delete_tasks(chunk)
-          delete_dynflow_plans(chunk, @backup_dir)
+          delete_dynflow_plans(chunk)
           report_progress(chunk)
         end
       end
@@ -114,9 +114,9 @@ module ForemanTasks
       dataset
     end
 
-    def delete_dynflow_plans(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)
+    def delete_dynflow_plans(chunk)
       dynflow_ids = chunk.find_all { |task| task.is_a? Task::DynflowTask }.map(&:external_id)
-      ForemanTasks.dynflow.world.persistence.delete_execution_plans({ 'uuid' => dynflow_ids }, batch_size, backup_dir)
+      ForemanTasks.dynflow.world.persistence.delete_execution_plans({ 'uuid' => dynflow_ids }, batch_size, @backup_dir)
     end
 
     def prepare_filter

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -58,7 +58,8 @@ module ForemanTasks
                           :verbose      => false,
                           :batch_size   => 1000,
                           :noop         => false,
-                          :states       => ['stopped'] }
+                          :states       => ['stopped'],
+                          :backup_dir   => ForemanTasks.dynflow.world.persistence.current_backup_dir }
       options         = default_options.merge(options)
 
       @filter         = options[:filter]
@@ -67,6 +68,7 @@ module ForemanTasks
       @verbose        = options[:verbose]
       @batch_size     = options[:batch_size]
       @noop           = options[:noop]
+      @backup_dir     = options[:backup_dir]
 
       raise ArgumentError, 'filter not speficied' if @filter.nil?
 
@@ -80,10 +82,9 @@ module ForemanTasks
         say "[noop] #{ForemanTasks::Task.search_for(full_filter).size} tasks would be deleted"
       else
         start_tracking_progress
-        backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir
         while (chunk = ForemanTasks::Task.search_for(full_filter).limit(batch_size)).any?
-          delete_tasks(chunk, backup_dir)
-          delete_dynflow_plans(chunk, backup_dir)
+          delete_tasks(chunk)
+          delete_dynflow_plans(chunk, @backup_dir)
           report_progress(chunk)
         end
       end
@@ -93,9 +94,9 @@ module ForemanTasks
       ForemanTasks::Task.search_for(full_filter).select('DISTINCT foreman_tasks_tasks.id, foreman_tasks_tasks.type, foreman_tasks_tasks.external_id')
     end
 
-    def delete_tasks(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)
+    def delete_tasks(chunk)
       tasks = ForemanTasks::Task.where(:id => chunk.map(&:id))
-      tasks_to_csv(tasks, backup_dir, 'foreman_tasks.csv') if backup_dir
+      tasks_to_csv(tasks, @backup_dir, 'foreman_tasks.csv') if @backup_dir
       tasks.delete_all
     end
 

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -105,9 +105,9 @@ module ForemanTasks
       appending = File.exist?(csv_file)
       columns = ForemanTasks::Task.attribute_names
       File.open(csv_file, 'a') do |csv|
-        csv << columns unless appending
+        csv << columns.to_csv unless appending
         dataset.each do |row|
-          csv << row.attributes.values
+          csv << row.attributes.values.to_csv
         end
       end
       dataset

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module ForemanTasks
   # Represents the cleanup mechanism for tasks
   class Cleaner
@@ -93,8 +95,22 @@ module ForemanTasks
 
     def delete_tasks(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)
       tasks = ForemanTasks::Task.where(:id => chunk.map(&:id))
-      ForemanTasks.dynflow.world.persistence.adapter.backup_to_csv(tasks, backup_dir, 'foreman_tasks.csv') if backup_dir
+      tasks_to_csv(tasks, backup_dir, 'foreman_tasks.csv') if backup_dir
       tasks.delete_all
+    end
+
+    def tasks_to_csv(dataset, backup_dir, file_name)
+      FileUtils.mkdir_p(backup_dir) unless File.directory?(backup_dir)
+      csv_file = File.join(backup_dir, file_name)
+      appending = File.exist?(csv_file)
+      columns = ForemanTasks::Task.attribute_names
+      File.open(csv_file, 'a') do |csv|
+        csv << columns unless appending
+        dataset.each do |row|
+          csv << row.attributes.values
+        end
+      end
+      dataset
     end
 
     def delete_dynflow_plans(chunk, backup_dir = ForemanTasks.dynflow.world.persistence.current_backup_dir)

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -9,7 +9,7 @@ module ForemanTasks
     def world_config
       super.tap do |config|
         config.backup_deleted_plans = backup_settings[:backup_deleted_plans]
-        config.backup_dir          = backup_settings[:backup_dir]
+        config.backup_dir           = backup_settings[:backup_dir]
       end
     end
 

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -6,6 +6,27 @@ require 'foreman_tasks/dynflow/persistence'
 module ForemanTasks
   # Import all Dynflow configuration from Foreman, and add our own for Tasks
   class Dynflow::Configuration < ::Foreman::Dynflow::Configuration
+    def world_config
+      super.tap do |config|
+        config.backup_deleted_plans = backup_settings[:backup_deleted_plans]
+        config.backup_dir          = backup_settings[:backup_dir]
+      end
+    end
+
+    def backup_settings
+      backup_options = {
+        :backup_deleted_plans => true,
+        :backup_dir => default_backup_dir,
+      }
+      settings = SETTINGS[:'foreman-tasks'] && SETTINGS[:'foreman-tasks'][:backup]
+      backup_options.merge!(settings) if settings
+      backup_options
+    end
+
+    def default_backup_dir
+      "./backup"
+    end
+
     def initialize_persistence
       ForemanTasks::Dynflow::Persistence.new(default_sequel_adapter_options)
     end

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -16,7 +16,7 @@ module ForemanTasks
     def backup_settings
       backup_options = {
         :backup_deleted_plans => true,
-        :backup_dir => default_backup_dir,
+        :backup_dir => default_backup_dir
       }
       settings = SETTINGS[:'foreman-tasks'] && SETTINGS[:'foreman-tasks'][:backup]
       backup_options.merge!(settings) if settings


### PR DESCRIPTION
This patch uses and extends https://github.com/Dynflow/dynflow/pull/241.
- adds backup of foreman tasks and ensures it lands in the same dir as the backup of related dynflow objects
- adds a way to configure the backups (the default dir is `./backup` for now though. Should it be set during packaging?)

```
cat >> /etc/foreman/plugins/foreman-tasks.yaml <<EOF

  :backup:
    :backup_deleted_plans: true
    :backup_dir: /var/lib/foreman/tasks-backup
```