### PR TITLE
Fixes #16922 - Clean old tasks automaticaly

### DIFF
--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -28,7 +28,7 @@
 #
 # Rules defined in this section by default don't operate
 # on tasks specified in the actions section. This behavior
-# can be overriden by setting the avoid_actions to false
+# can be overriden by setting the override_actions to true
    :rules:
      # Delete successful tasks after a month
      - :filter: result = success
@@ -36,4 +36,4 @@
      # Delete everything (any action, any state) after one year
      - :states: []
        :after: 1y
-       :avoid_actions: false
+       :override_actions: true

--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -16,7 +16,7 @@
   :cleanup:
 #
 # the period after which to delete all the tasks (by default all tasks are not being deleted after some period)
-# will be deprecated (TODO: mention when) and the use of rules is recommended
+# will be deprecated in Foreman 1.18 and the use of rules is recommended.
 #
 #     :after: 30d
 #

--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -34,6 +34,6 @@
      - :filter: result = success
        :after: 30d
      # Delete everything (any action, any state) after one year
-     - :states: []
+     - :states: all # Either list of state names or all
        :after: 1y
        :override_actions: true

--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -13,14 +13,27 @@
 # Cleaning configuration: how long should the actions be kept before deleted
 # by `rake foreman_tasks:clean` task
 #
-#  :cleanup:
+  :cleanup:
 #
 # the period after which to delete all the tasks (by default all tasks are not being deleted after some period)
+# will be deprecated (TODO: mention when) and the use of rules is recommended
 #
-#    :after: 365d
+#     :after: 30d
 #
 # per action settings to override the default defined in the actions (self.cleanup_after method)
 #
 #    :actions:
 #      - :name: Actions::Foreman::Host::ImportFacts
 #        :after: 10d
+#
+# Rules defined in this section by default don't operate
+# on tasks specified in the actions section. This behavior
+# can be overriden by setting the avoid_actions to false
+   :rules:
+     # Delete successful tasks after a month
+     - :filter: result = success
+       :after: 30d
+     # Delete everything (any action, any state) after one year
+     - :states: []
+       :after: 1y
+       :avoid_actions: false

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -53,12 +53,13 @@ module ForemanTasks
     def self.actions_by_rules(actions_with_periods)
       disable_actions_with_periods = "label !^ (#{actions_with_periods.keys.join(', ') })"
       cleanup_settings.fetch(:rules, []).map do |hash|
+        return nil if hash[:after].nil?
         conditions = []
         conditions << disable_actions_with_periods unless hash[:avoid_actions]
         conditions << hash[:filter] if hash[:filter]
         hash[:filter] = conditions.map { |condition| "(#{condition})" }.join(' AND ')
         hash
-      end
+      end.compact
     end
 
     attr_reader :filter, :after, :states, :verbose, :batch_size, :noop, :full_filter

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -54,7 +54,7 @@ module ForemanTasks
       cleanup_settings.fetch(:rules, []).map do |hash|
         next if hash[:after].nil?
         conditions = []
-        conditions << disable_actions_with_periods if hash[:avoid_actions].nil? || hash[:avoid_actions]
+        conditions << disable_actions_with_periods unless hash[:override_actions]
         conditions << hash[:filter] if hash[:filter]
         hash[:filter] = conditions.map { |condition| "(#{condition})" }.join(' AND ')
         hash

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -11,8 +11,7 @@ module ForemanTasks
           end
         end
         if cleanup_settings[:after]
-          # TODO: Mention version in which this will be removed completely
-          ActiveSupport::Deprecation.warn('You are using legacy interface, please migrate from using :after to cleanup rules')
+          Foreman::Deprecation.deprecation_warning('1.18', _(':after setting in tasks cleanup section is deprecated, use :after in :rules section to set the value. to cleanup rules'))
           new(options.merge(:filter => '', :after => cleanup_settings[:after])).delete
         end
         with_periods = actions_with_default_cleanup
@@ -53,7 +52,7 @@ module ForemanTasks
     def self.actions_by_rules(actions_with_periods)
       disable_actions_with_periods = "label !^ (#{actions_with_periods.keys.join(', ')})"
       cleanup_settings.fetch(:rules, []).map do |hash|
-        return nil if hash[:after].nil?
+        next if hash[:after].nil?
         conditions = []
         conditions << disable_actions_with_periods unless hash[:avoid_actions]
         conditions << hash[:filter] if hash[:filter]

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -54,7 +54,7 @@ module ForemanTasks
       cleanup_settings.fetch(:rules, []).map do |hash|
         next if hash[:after].nil?
         conditions = []
-        conditions << disable_actions_with_periods unless hash[:avoid_actions]
+        conditions << disable_actions_with_periods if hash[:avoid_actions].nil? || hash[:avoid_actions]
         conditions << hash[:filter] if hash[:filter]
         hash[:filter] = conditions.map { |condition| "(#{condition})" }.join(' AND ')
         hash

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -11,10 +11,16 @@ module ForemanTasks
           end
         end
         if cleanup_settings[:after]
+          # TODO: Mention version in which this will be removed completely
+          ActiveSupport::Deprecation.warn('You are using legacy interface, please migrate from using :after to cleanup rules')
           new(options.merge(:filter => '', :after => cleanup_settings[:after])).delete
         end
-        actions_with_default_cleanup.each do |action_class, period|
+        with_periods = actions_with_default_cleanup
+        with_periods.each do |action_class, period|
           new(options.merge(:filter => "label = #{action_class.name}", :after => period)).delete
+        end
+        actions_by_rules(with_periods).each do |hash|
+          new(options.merge(hash)).delete
         end
       end
     end
@@ -42,6 +48,17 @@ module ForemanTasks
     def self.cleanup_settings
       return @cleanup_settings if @cleanup_settings
       @cleanup_settings = SETTINGS[:'foreman-tasks'] && SETTINGS[:'foreman-tasks'][:cleanup] || {}
+    end
+
+    def self.actions_by_rules(actions_with_periods)
+      disable_actions_with_periods = "label !^ (#{actions_with_periods.keys.join(', ') })"
+      cleanup_settings.fetch(:rules, []).map do |hash|
+        conditions = []
+        conditions << disable_actions_with_periods unless hash[:avoid_actions]
+        conditions << hash[:filter] if hash[:filter]
+        hash[:filter] = conditions.map { |condition| "(#{condition})" }.join(' AND ')
+        hash
+      end
     end
 
     attr_reader :filter, :after, :states, :verbose, :batch_size, :noop, :full_filter

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -51,7 +51,7 @@ module ForemanTasks
     end
 
     def self.actions_by_rules(actions_with_periods)
-      disable_actions_with_periods = "label !^ (#{actions_with_periods.keys.join(', ') })"
+      disable_actions_with_periods = "label !^ (#{actions_with_periods.keys.join(', ')})"
       cleanup_settings.fetch(:rules, []).map do |hash|
         return nil if hash[:after].nil?
         conditions = []

--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -56,6 +56,7 @@ module ForemanTasks
         conditions = []
         conditions << disable_actions_with_periods unless hash[:override_actions]
         conditions << hash[:filter] if hash[:filter]
+        hash[:states] = [] if hash[:states] == 'all'
         hash[:filter] = conditions.map { |condition| "(#{condition})" }.join(' AND ')
         hash
       end.compact

--- a/lib/foreman_tasks/tasks/cleanup.rake
+++ b/lib/foreman_tasks/tasks/cleanup.rake
@@ -52,6 +52,24 @@ namespace :foreman_tasks do
           printf("%-50s %s\n", action.name, after)
         end
       end
+      puts
+      by_rules = ForemanTasks::Cleaner.actions_by_rules(ForemanTasks::Cleaner.actions_with_default_cleanup)
+      if by_rules.empty?
+        puts _('No cleanup rules are configured')
+      else
+        printf("%-50s %-15s %s\n", _('states'), _('delete after'), _('filter'))
+        by_rules.each do |hash|
+          state = case hash[:states]
+                  when []
+                    _('ANY')
+                  when nil
+                    'stopped'
+                  else
+                    hash[:states]
+                  end
+          printf("%-50s %-15s %s\n", state, hash[:after], hash[:filter])
+        end
+      end
     end
   end
 

--- a/lib/foreman_tasks/tasks/cleanup.rake
+++ b/lib/foreman_tasks/tasks/cleanup.rake
@@ -5,7 +5,7 @@ namespace :foreman_tasks do
 
         * TASK_SEARCH : scoped search filter (example: 'label = "Actions::Foreman::Host::ImportFacts"')
         * AFTER       : delete tasks created after *AFTER* period. Expected format is a number followed by the time unit (s,h,m,y), such as '10d' for 10 days
-        * STATES      : comma separated list of task states to touch with the cleanup, by default only stopped tasks are covered
+        * STATES      : comma separated list of task states to touch with the cleanup, by default only stopped tasks are covered, special value all can be used to clean the tasks, disregarding their states
         * NOOP        : set to "true" if the task should not actuall perform the deletion
         * VERBOSE     : set to "true" for more verbose output
         * BATCH_SIZE  : the size of batches the tasks get processed in (1000 by default)
@@ -21,6 +21,7 @@ namespace :foreman_tasks do
       options[:after] = ENV['AFTER'] if ENV['AFTER']
 
       options[:states] = ENV['STATES'].to_s.split(',') if ENV['STATES']
+      options[:states] = [] if options[:states] == ['all']
 
       options[:noop] = true if ENV['NOOP']
 

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -83,7 +83,7 @@ class TasksTest < ActiveSupport::TestCase
         rules = [{ :after => nil },
                  { :after => '10d', :filter => 'label = something', :states => %w[stopped paused] },
                  { :after => '15d', :filter => 'label = something_else',
-                   :avoid_actions => false, :states => [] }]
+                   :override_actions => false, :states => [] }]
         ForemanTasks::Cleaner.stubs(:cleanup_settings).returns(:rules => rules)
         r1, r2 = ForemanTasks::Cleaner.actions_by_rules actions_with_default
         r1[:filter].must_equal '(label !^ (action1, action2)) AND (label = something)'

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -68,6 +68,30 @@ class TasksTest < ActiveSupport::TestCase
                                      { :actions => [{ :name => ActionWithCleanup.name, :after => '5d' }] })
         ForemanTasks::Cleaner.actions_with_default_cleanup[ActionWithCleanup].must_equal '5d'
       end
+
+      it 'deprecates the usage of :after' do
+        Foreman::Deprecation.expects(:deprecation_warning)
+        ForemanTasks::Cleaner.any_instance.expects(:delete)
+        ForemanTasks::Cleaner.stubs(:cleanup_settings =>
+                                    { :after => '1d' })
+        ForemanTasks::Cleaner.stubs(:actions_with_default_cleanup).returns({})
+        ForemanTasks::Cleaner.run({})
+      end
+
+      it 'generates filters from rules properly' do
+        actions_with_default = { 'action1' => nil, 'action2' => nil }
+        rules = [{ :after => nil, :avoid_actions => true },
+                 { :after => '10d', :filter => 'label = something', :states => %w(stopped paused) },
+                 { :after => '15d', :filter => 'label = something_else',
+                   :avoid_actions => true, :states => [] }
+                ]
+        ForemanTasks::Cleaner.stubs(:cleanup_settings).returns(:rules => rules)
+        r1, r2 = ForemanTasks::Cleaner.actions_by_rules actions_with_default
+        r1[:filter].must_equal '(label !^ (action1, action2)) AND (label = something)'
+        r1[:states].must_equal %w(stopped paused)
+        r2[:filter].must_equal '(label = something_else)'
+        r2[:states].must_equal []
+      end
     end
   end
 end

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -83,7 +83,7 @@ class TasksTest < ActiveSupport::TestCase
         rules = [{ :after => nil },
                  { :after => '10d', :filter => 'label = something', :states => %w[stopped paused] },
                  { :after => '15d', :filter => 'label = something_else',
-                   :override_actions => false, :states => [] }]
+                   :override_actions => true, :states => 'all' }]
         ForemanTasks::Cleaner.stubs(:cleanup_settings).returns(:rules => rules)
         r1, r2 = ForemanTasks::Cleaner.actions_by_rules actions_with_default
         r1[:filter].must_equal '(label !^ (action1, action2)) AND (label = something)'

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -81,14 +81,13 @@ class TasksTest < ActiveSupport::TestCase
       it 'generates filters from rules properly' do
         actions_with_default = { 'action1' => nil, 'action2' => nil }
         rules = [{ :after => nil, :avoid_actions => true },
-                 { :after => '10d', :filter => 'label = something', :states => %w(stopped paused) },
+                 { :after => '10d', :filter => 'label = something', :states => %w[stopped paused] },
                  { :after => '15d', :filter => 'label = something_else',
-                   :avoid_actions => true, :states => [] }
-                ]
+                   :avoid_actions => true, :states => [] }]
         ForemanTasks::Cleaner.stubs(:cleanup_settings).returns(:rules => rules)
         r1, r2 = ForemanTasks::Cleaner.actions_by_rules actions_with_default
         r1[:filter].must_equal '(label !^ (action1, action2)) AND (label = something)'
-        r1[:states].must_equal %w(stopped paused)
+        r1[:states].must_equal %w[stopped paused]
         r2[:filter].must_equal '(label = something_else)'
         r2[:states].must_equal []
       end

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -80,10 +80,10 @@ class TasksTest < ActiveSupport::TestCase
 
       it 'generates filters from rules properly' do
         actions_with_default = { 'action1' => nil, 'action2' => nil }
-        rules = [{ :after => nil, :avoid_actions => true },
+        rules = [{ :after => nil },
                  { :after => '10d', :filter => 'label = something', :states => %w[stopped paused] },
                  { :after => '15d', :filter => 'label = something_else',
-                   :avoid_actions => true, :states => [] }]
+                   :avoid_actions => false, :states => [] }]
         ForemanTasks::Cleaner.stubs(:cleanup_settings).returns(:rules => rules)
         r1, r2 = ForemanTasks::Cleaner.actions_by_rules actions_with_default
         r1[:filter].must_equal '(label !^ (action1, action2)) AND (label = something)'


### PR DESCRIPTION
This PR includes https://github.com/theforeman/foreman-tasks/pull/247. Based on discussion in original PR this now also allows to distinguish between green an red (and any other) tasks and set different cleanup intervals.