### PR TITLE
Fixes #18422 - Expose pool_size in config file

### DIFF
--- a/config/foreman-tasks.yaml.example
+++ b/config/foreman-tasks.yaml.example
@@ -9,6 +9,11 @@
 #     :action:
 #       :enabled: true
 
+#
+# Configure how many workers should be used to handle incoming requests.
+#
+#   :pool_size: 5
+
   # Task backup configuration can be changed by altering the values in
   # the backup section
   #

--- a/lib/foreman_tasks/dynflow/configuration.rb
+++ b/lib/foreman_tasks/dynflow/configuration.rb
@@ -6,6 +6,13 @@ require 'foreman_tasks/dynflow/persistence'
 module ForemanTasks
   # Import all Dynflow configuration from Foreman, and add our own for Tasks
   class Dynflow::Configuration < ::Foreman::Dynflow::Configuration
+    def initialize
+      super
+      self.pool_size = SETTINGS.fetch(:'foreman-tasks', {})
+                               .fetch(:pool_size, pool_size)
+      self.db_pool_size = pool_size + 5
+    end
+
     def world_config
       super.tap do |config|
         config.backup_deleted_plans = backup_settings[:backup_deleted_plans]


### PR DESCRIPTION
Or should this go directly into core, now that core uses dynflow as well? Should this also be configurable for smart_proxy_dynflow_core?