### PR TITLE
Revert "Fixes #18673 - Remove initialization code in favor of Dynflow"

### DIFF
--- a/bin/dynflow-executor
+++ b/bin/dynflow-executor
@@ -64,7 +64,7 @@ end
 if $PROGRAM_NAME == __FILE__
   parser = ArgvParser.new(ARGV, $PROGRAM_NAME)
 
-  Dir.chdir(options[:foreman_root])
+  Dir.chdir(parser.options[:foreman_root])
   app_file = File.expand_path('./config/application', parser.options[:foreman_root])
   require app_file
 

--- a/bin/dynflow-executor
+++ b/bin/dynflow-executor
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+class ArgvParser
+  attr_reader :options, :command
+
+  def initialize(argv, file)
+    @options = { foreman_root: Dir.pwd }
+
+    opts = OptionParser.new do |opts|
+      opts.banner = banner(file)
+
+      opts.on('-h', '--help', 'Show this message') do
+        puts opts
+        exit 1
+      end
+      opts.on('-f', '--foreman-root=PATH', "Path to Foreman Rails root path. By default '#{@options[:foreman_root]}'") do |path|
+        @options[:foreman_root] = path
+      end
+      opts.on('-c', '--executors-count=COUNT', 'Number of parallel executors to spawn. Overrides EXECUTORS_COUNT environment varaible.') do |count|
+        @options[:executors_count] = count.to_i
+      end
+      opts.on('-m', '--memory-limit=SIZE', 'Limits the amount of memory an executor can consume. Overrides EXECUTOR_MEMORY_LIMIT environment varaible. You can use kb, mb, gb') do |size|
+        @options[:memory_limit] = size
+      end
+      opts.on('--executor-memory-init-delay=SECONDS', 'Start memory polling after SECONDS. Overrides EXECUTOR_MEMORY_MONITOR_DELAY environment varaible.') do |seconds|
+        @options[:memory_init_delay] = seconds.to_i
+      end
+      opts.on('--executor-memory-polling-interval=SECONDS', 'Check for memory useage every SECONDS sec. Overrides EXECUTOR_MEMORY_MONITOR_INTERVAL environment varaible.') do |seconds|
+        @options[:memory_polling_interval] = seconds.to_i
+      end
+    end
+
+    args = opts.parse!(argv)
+    @command = args.first || 'run'
+  end
+
+  def banner(file)
+    banner = <<BANNER
+Run Dynflow executor for Foreman tasks.
+
+Usage: #{File.basename(file)} [options] ACTION"
+
+ACTION can be one of:
+
+* start   - start the executor on background. It creates these files
+          in tmp/pid directory:
+
+            * dynflow_executor_monitor.pid - pid of monitor ensuring
+                                             the executor keeps running
+            * dynflow_executor.pid         - pid of the executor itself
+            * dynflow_executor.output      - stdout of the executor
+* stop    - stops the running executor
+* restart - restarts the running executor
+* run     - run the executor in foreground
+
+BANNER
+    banner
+  end
+end
+
+# run the script if it's executed explicitly
+if $PROGRAM_NAME == __FILE__
+  parser = ArgvParser.new(ARGV, $PROGRAM_NAME)
+
+  Dir.chdir(options[:foreman_root])
+  app_file = File.expand_path('./config/application', parser.options[:foreman_root])
+  require app_file
+
+  Dynflow::Rails::Daemon.new.run_background(parser.command, parser.options)
+end

--- a/bin/foreman-tasks
+++ b/bin/foreman-tasks
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+foreman_root = '/usr/share/foreman'
+Dir.chdir(foreman_root)
+require File.expand_path('./config/application', foreman_root)
+Dynflow::Rails::Daemon.new.run_background(ARGV.last, :foreman_root => foreman_root)

--- a/deploy/foreman-tasks.service
+++ b/deploy/foreman-tasks.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Foreman jobs daemon
+Documentation=https://github.com/theforeman/foreman-tasks
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+User=foreman
+TimeoutSec=600
+WorkingDirectory=/usr/share/foreman
+ExecStart=/usr/bin/foreman-tasks start 
+ExecStop=/usr/bin/foreman-tasks stop
+EnvironmentFile=-/etc/sysconfig/foreman-tasks
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/foreman-tasks.sysconfig
+++ b/deploy/foreman-tasks.sysconfig
@@ -1,0 +1,26 @@
+FOREMAN_USER=foreman
+BUNDLER_EXT_HOME=/usr/share/foreman
+RAILS_RELATIVE_URL_ROOT=$FOREMAN_PREFIX
+RAILS_ENV=production
+FOREMAN_LOGGING=warn
+FOREMAN_LOGGING_SQL=warn
+FOREMAN_TASK_PARAMS="-p foreman"
+FOREMAN_LOG_DIR=/var/log/foreman
+
+RUBY_GC_MALLOC_LIMIT=4000100
+RUBY_GC_MALLOC_LIMIT_MAX=16000100
+RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.1
+RUBY_GC_OLDMALLOC_LIMIT=16000100
+RUBY_GC_OLDMALLOC_LIMIT_MAX=16000100
+
+#Set the number of executors you want to run
+#EXECUTORS_COUNT=1
+
+#Set memory limit for executor process, before it's restarted automatically
+#EXECUTOR_MEMORY_LIMIT=2gb
+
+#Set delay before first memory polling to let executor initialize (in sec)
+#EXECUTOR_MEMORY_MONITOR_DELAY=7200 #default: 2 hours
+
+#Set memory polling interval, process memory will be checked every N seconds.
+#EXECUTOR_MEMORY_MONITOR_INTERVAL=60


### PR DESCRIPTION
This partially reverts commit ecb8c5b39f6281c9c29ff3ea677b3d43002bbea2.

The only thing I've reverted was removing the init scripts themselves
and updated them to use the code, that was moved to foreman/dynflow