### PR TITLE
Fix namespace for rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ Metrics/BlockLength:
   Exclude:
     - lib/foreman_tasks/tasks/**/*
 
-Style/FileName:
+Naming/FileName:
   Exclude:
     - '*.gemspec'
     - Gemfile

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -94,7 +94,7 @@ Style/DoubleNegation:
     - 'app/models/foreman_tasks/recurring_logic.rb'
 
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts.
-Style/FileName:
+Naming/FileName:
   Exclude:
     - 'db/seeds.d/20-foreman_tasks_permissions.rb'
     - 'db/seeds.d/60-dynflow_proxy_feature.rb'
@@ -116,7 +116,7 @@ Style/GuardClause:
 # NamePrefix: is_, has_, have_
 # NamePrefixBlacklist: is_, has_, have_
 # NameWhitelist: is_a?
-Style/PredicateName:
+Naming/PredicateName:
   Exclude:
     - 'spec/**/*'
     - 'app/models/foreman_tasks/task/status_explicator.rb'

--- a/test/controllers/recurring_logics_controller_test.rb
+++ b/test/controllers/recurring_logics_controller_test.rb
@@ -5,10 +5,10 @@ module ForemanTasks
     basic_index_test('recurring_logics')
     basic_pagination_per_page_test
 
-    # rubocop:disable Style/AccessorMethodName
+    # rubocop:disable Naming/AccessorMethodName
     def get_factory_name
       :recurring_logic
     end
-    # rubocop:enable Style/AccessorMethodName
+    # rubocop:enable Naming/AccessorMethodName
   end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -7,11 +7,11 @@ module ForemanTasks
       basic_pagination_per_page_test
       basic_pagination_rendered_test
 
-      # rubocop:disable Style/AccessorMethodName
+      # rubocop:disable Naming/AccessorMethodName
       def get_factory_name
         :dynflow_task
       end
-      # rubocop:enable Style/AccessorMethodName
+      # rubocop:enable Naming/AccessorMethodName
     end
   end
 end


### PR DESCRIPTION
Should fix rubocop failures on [Jenkins](http://ci.theforeman.org/job/test_plugin_matrix/4287/database=postgresql,ruby=2.3,slave=fast/console)