### PR TITLE
Fixes #22336 - use `distinct` in has_many definition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Rails/ReversibleMigration:
 
 Metrics/BlockLength:
   Exclude:
+    - config/routes.rb
+    - lib/foreman_remote_execution/engine.rb
+    - test/**/*
     - lib/foreman_tasks/tasks/**/*
 
 Naming/FileName:

--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -11,7 +11,7 @@ module ForemanTasks
     if Rails::VERSION::MAJOR < 4
       has_many :task_groups, :through => :tasks, :uniq => true
     else
-      has_many :task_groups, -> { uniq }, :through => :tasks
+      has_many :task_groups, -> { distinct }, :through => :tasks
     end
 
     scoped_search :on => :id, :complete_value => false, :validator => ScopedSearch::Validators::INTEGER

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 require_relative './support/dummy_dynflow_action'
 require_relative './support/dummy_proxy_action'
+require_relative './support/dummy_task_group'
 
 require 'dynflow/testing'
 

--- a/test/support/dummy_task_group.rb
+++ b/test/support/dummy_task_group.rb
@@ -1,0 +1,4 @@
+module Support
+  class DummyTaskGroup < ForemanTasks::TaskGroup
+  end
+end

--- a/test/unit/recurring_logic_test.rb
+++ b/test/unit/recurring_logic_test.rb
@@ -88,6 +88,17 @@ class RecurringLogicsTest < ActiveSupport::TestCase
       recurring_logic.start(::Support::DummyDynflowAction)
     end
 
+    it 'has a task group associated to all tasks that were created as part of the recurring logic' do
+      recurring_logic = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      recurring_logic.save
+      recurring_logic.task_group.must_be_kind_of ForemanTasks::TaskGroups::RecurringLogicTaskGroup
+      task = FactoryBot.build(:dynflow_task, :user_create_task)
+      task.task_groups << Support::DummyTaskGroup.new
+      task.save!
+      recurring_logic.task_group.tasks << task
+      recurring_logic.task_groups.must_include(*task.task_groups)
+    end
+
     it 'can be created from triggering' do
       triggering = FactoryBot.build(:triggering, :recurring, :end_time_limited)
       logic = ForemanTasks::RecurringLogic.new_from_triggering(triggering)


### PR DESCRIPTION
Since Rails 5.1, it seems the semantic is a bit different. Also added
tests for this code path.