### PR TITLE
Fixes #22438 - Remove KeepParams

### DIFF
--- a/app/controllers/foreman_tasks/concerns/parameters/triggering.rb
+++ b/app/controllers/foreman_tasks/concerns/parameters/triggering.rb
@@ -3,22 +3,28 @@ module ForemanTasks
     module Parameters
       module Triggering
         extend ActiveSupport::Concern
-        include Foreman::Controller::Parameters::KeepParam
 
         class_methods do
           def triggering_params_filter
             Foreman::ParameterFilter.new(::ForemanTasks::Triggering).tap do |filter|
-              filter.permit_by_context(:mode, :start_at, :start_before,
-                                       *::ForemanTasks::Triggering::PARAMS,
-                                       :nested => true)
+              filter.permit_by_context(
+                [
+                  :mode,
+                  :start_at,
+                  :start_before,
+                  *::ForemanTasks::Triggering::PARAMS,
+                  :days_of_week => {},
+                  :time => {},
+                  :end_time => {}
+                ],
+                :nested => true
+              )
             end
           end
         end
 
         def triggering_params
-          keep_param(params, :triggering, :days_of_week, :time, :end_time) do
-            self.class.triggering_params_filter.filter_params(params, parameter_filter_context, :triggering)
-          end
+          self.class.triggering_params_filter.filter_params(params, parameter_filter_context, :triggering)
         end
       end
     end


### PR DESCRIPTION
KeepParams was created as a workaround for an issue in strong
params prior to Rails 5.1. It is no longer required.