### PR TITLE
fixes #22920 - Access variable, not datastructure

### DIFF
--- a/app/lib/actions/foreman/host/import_facts.rb
+++ b/app/lib/actions/foreman/host/import_facts.rb
@@ -8,7 +8,7 @@ module Actions
 
         def plan(_host_type, host_name, facts, certname, proxy_id)
           facts['domain'].try(:downcase!)
-          host = if SETTINGS[:version] > '1.16'
+          host = if SETTINGS[:version].short > '1.16'
                    ::Host::Base.import_host(host_name, certname, proxy_id)
                  else
                    # backwards compatibility


### PR DESCRIPTION
Was seeing a lot of errors like:
```
NoMethodError: undefined method `>' for <Foreman::Version:0x00000001252500>
```