### PR TITLE
Fixes #22999 - repo synchronization task page have broken link

### DIFF
--- a/app/lib/actions/helpers/humanizer.rb
+++ b/app/lib/actions/helpers/humanizer.rb
@@ -126,7 +126,7 @@ module Actions
           product_id = fetch_data(data, :product, :id)
           repo_id = fetch_data(data, :repo, :id)
           if product_id && repo_id
-            "#/products/#{product_id}/repositories/#{repo_id}"
+            "/products/#{product_id}/repositories/#{repo_id}"
           end
         end
       end
@@ -152,7 +152,7 @@ module Actions
 
         def link(data)
           if (content_view_id = fetch_data(data, :content_view, :id))
-            "#/content_views/#{content_view_id}/versions"
+            "/content_views/#{content_view_id}/versions"
           end
         end
       end
@@ -168,7 +168,7 @@ module Actions
 
         def link(data)
           if (product_id = fetch_data(data, :product, :id))
-            "#/products/#{product_id}/info"
+            "/products/#{product_id}/"
           end
         end
       end


### PR DESCRIPTION
### Description of problem:
Repository synchronization task page has broken link to product details.
### Additional Findings:
Similar broken link in content views task page

### Steps to Reproduce:
1. Create product and some yum-type repository in it
2. Sync that repository
3. You will be taken to page with progress bar indicating syncing status. Now
check link to product details in "Parameters: ..."
