### PR TITLE
Refs #22969: s/taxonomies/user/ in midware test

### DIFF
--- a/test/lib/actions/middleware/keep_current_user_test.rb
+++ b/test/lib/actions/middleware/keep_current_user_test.rb
@@ -34,7 +34,7 @@ module Actions
           User.stubs(:current)
         end
 
-        test 'with current taxonomies as input' do
+        test 'with current user as input' do
           User.unscoped.class.any_instance.expects(:find).with(@user.id).returns(@user)
 
           User.expects(:current=).with(@user)


### PR DESCRIPTION
Fix a small typo in a keep_current_user middlware test description