### PR TITLE
Fixes #23348 - Set label field properly

### DIFF
--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -19,7 +19,7 @@ module ForemanTasks
                                   DynflowTask.where(:external_id => main_action.caller_execution_plan_id).first!.id
                                 end
                               end
-      self.label          ||= label
+      self[:label]        ||= label
       changes = self.changes
       save!
       changes


### PR DESCRIPTION
`self.label` invoked the method so `||=` never happend and the label was always calculated on demand