### PR TITLE
Package name change?

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please see the Foreman manual for appropriate instructions:
 
 Set up the repo as explained in the link above, then run
 
-    # yum install ruby193-rubygem-foreman-tasks
+    # yum install tfm-rubygem-foreman-tasks
 
 ### Bundle (gem)
 


### PR DESCRIPTION
I believe the package name has changed per yum search and http://yum.theforeman.org/plugins/1.17/el7/x86_64 to:
tfm-rubygem-foreman-tasks