### PR TITLE
Fixes #23938 - api/tasks uses the index-layout

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -33,6 +33,8 @@ module ForemanTasks
     has_many :owners, -> { where(['foreman_tasks_locks.name = ?', Lock::OWNER_LOCK_NAME]) },
              :through => :locks, :source => :resource, :source_type => 'User'
 
+    default_scope -> { order(start_at: :desc) }
+
     scoped_search :on => :id, :complete_value => false
     scoped_search :on => :action, :complete_value => false
     scoped_search :on => :label, :complete_value => true

--- a/app/views/foreman_tasks/api/tasks/index.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/index.json.rabl
@@ -1,0 +1,2 @@
+collection @tasks
+extends "foreman_tasks/api/tasks/show"


### PR DESCRIPTION
Refactor the `api/tasks_controller#index` so it will based on the basic controllers

`sort_by` and `sort_order` won't work anymore and you will need to use `order=id desc` instead.
is that a problem? should we show a deprecation message? should migrate other places?
I just not sure where it got used, I know about `index page` and the `breadcrumbs`. (hammer?)