### PR TITLE
Fixes #24114 - additional cleanup logging

### DIFF
--- a/lib/foreman_tasks/cleaner.rb
+++ b/lib/foreman_tasks/cleaner.rb
@@ -79,6 +79,7 @@ module ForemanTasks
                           :states       => ['stopped'],
                           :backup_dir   => ForemanTasks.dynflow.world.persistence.current_backup_dir }
       options         = default_options.merge(options)
+      Foreman::Logging.logger('foreman-tasks').info("Running foreman-tasks cleaner with options #{options.inspect}")
 
       @filter         = options[:filter]
       @after          = parse_time_interval(options[:after])


### PR DESCRIPTION
Allows seeing which options is the user running the cleanup script with.