### PR TITLE
Fixes #24493 - fix double creation of resources on host.update

### DIFF
--- a/app/models/foreman_tasks/concerns/action_triggering.rb
+++ b/app/models/foreman_tasks/concerns/action_triggering.rb
@@ -39,13 +39,13 @@ module ForemanTasks
       # the host record for these update and update! methods.
       def update(*args)
         assign_attributes(*args)
-        dynflow_task_wrap(:save) { super(*args) }
+        dynflow_task_wrap(:save) { save }
       end
       alias update_attributes update
 
       def update!(*args)
         assign_attributes(*args)
-        dynflow_task_wrap(:save) { super(*args) }
+        dynflow_task_wrap(:save) { save! }
       end
       alias update_attributes! update!
 


### PR DESCRIPTION
The issue is the `assign_attributes` can have already some side-effects
for sub-resources (such as parameters), and calling `super` causes
double-creation of the resources.

Changing super to `save` makes sure that we avoid this double creation.