### PR TITLE
Fixes #23355 - Replace alias_method_chain with prepend

### DIFF
--- a/app/controllers/foreman_tasks/concerns/hosts_controller_extension.rb
+++ b/app/controllers/foreman_tasks/concerns/hosts_controller_extension.rb
@@ -1,13 +1,7 @@
 module ForemanTasks
   module Concerns
     module HostsControllerExtension
-      extend ActiveSupport::Concern
-
-      included do
-        alias_method_chain :facts, :dynflow
-      end
-
-      def facts_with_dynflow
+      def facts
         task = ForemanTasks.async_task(::Actions::Foreman::Host::ImportFacts,
                                        detect_host_type,
                                        params[:name],

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -133,7 +133,7 @@ module ForemanTasks
     # to enable async Foreman operations using Dynflow
     if ENV['FOREMAN_TASKS_MONKEYS'] == 'true'
       config.to_prepare do
-        ::Api::V2::HostsController.send :include, ForemanTasks::Concerns::HostsControllerExtension
+        ::Api::V2::HostsController.send :prepend, ForemanTasks::Concerns::HostsControllerExtension
         ::Host::Base.send :include, ForemanTasks::Concerns::HostActionSubject
       end
     end


### PR DESCRIPTION
This was most likely missed becuase the extention module is only
included when FOREMAN_TASKS_MONKEYS env variable is set to true.
The module has been updated to use the new module#prepend syntax.

(cherry picked from commit 226d4523ce1fce95d33f75b243b7998d67c1952b)