### PR TITLE
Fixes #24909 - Mark proxy tasks as failed only if confirmed

### DIFF
--- a/app/lib/actions/middleware/watch_delegated_proxy_sub_tasks.rb
+++ b/app/lib/actions/middleware/watch_delegated_proxy_sub_tasks.rb
@@ -64,9 +64,9 @@ module Actions
           task
         end
       rescue => e
-        # We could not reach the remote task, we assume it's gone
+        # We could not reach the remote task, we'll try again next time
         action.action_logger.warn(_('Failed to check on tasks on proxy at %{url}: %{exception}') % { :url => url, :exception => e.message })
-        tasks
+        []
       end
     end
   end


### PR DESCRIPTION
Before this changed we marked tasks as failed if we failed to check on
their counterparts on the smart proxy. With this change, tasks are
marked as failed only if the check succeeds.