### PR TITLE
Fixes #25282 - Create a task for each target even if missing 

### DIFF
--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -48,7 +48,7 @@ module Actions
       target_class = input[:target_class].constantize
       targets = target_class.where(:id => current_batch)
 
-      missing = (current_batch - targets.map(&:id)).count.times.map { nil }
+      missing = Array.new((current_batch - targets.map(&:id)).count) { nil }
 
       (targets + missing).map do |target|
         trigger(action_class, target, *input[:args])

--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -48,7 +48,9 @@ module Actions
       target_class = input[:target_class].constantize
       targets = target_class.where(:id => current_batch)
 
-      targets.map do |target|
+      missing = (current_batch - targets.map(&:id)).count.times.map { nil }
+
+      (targets + missing).map do |target|
         trigger(action_class, target, *input[:args])
       end
     end

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -29,7 +29,7 @@ same resource. It also optionally provides Dynflow infrastructure for using it f
   s.extra_rdoc_files = Dir['README*', 'LICENSE']
 
   s.add_dependency "foreman-tasks-core"
-  s.add_dependency "dynflow", '~> 1.0', '>= 1.1.1'
+  s.add_dependency "dynflow", '~> 1.0', '>= 1.1.5'
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "parse-cron", '~> 0.1.4'
   s.add_dependency "get_process_mem" # for memory polling

--- a/test/unit/actions/bulk_action_test.rb
+++ b/test/unit/actions/bulk_action_test.rb
@@ -1,0 +1,44 @@
+require 'foreman_tasks_test_helper'
+
+module ForemanTasks
+  class BulkActionTest < ActiveSupport::TestCase
+    before do
+      User.current = User.where(:login => 'apiadmin').first
+    end
+
+    Target = Struct.new(:id)
+
+    class ParentAction < Actions::BulkAction; end
+
+    class ChildAction < Actions::EntryAction
+      def plan(target)
+        target.id
+      end
+    end
+
+    describe Actions::BulkAction do
+      let(:targets) { (1..5).map { |i| Target.new i } }
+      let(:task) do
+        triggered = ForemanTasks.trigger(ParentAction, ChildAction, targets)
+        triggered.finished.wait(2)
+        ForemanTasks::Task.where(:external_id => triggered.id).first
+      end
+
+      specify 'it plans a task for each target' do
+        Target.expects(:where).with(:id => targets.map(&:id)).returns(targets)
+
+        task.sub_tasks.count.must_equal targets.count
+        assert task.sub_tasks.all? { |subtask| subtask.result == 'success' }
+      end
+
+      specify 'it plans a task for each target even if target cannot be found' do
+        Target.expects(:where).with(:id => targets.map(&:id)).returns(targets.take(4))
+
+        task.sub_tasks.count.must_equal targets.count
+        success, failed = task.sub_tasks.partition { |sub_task| sub_task.result == 'success' }
+        success.count.must_equal 4
+        failed.count.must_equal 1
+      end
+    end
+  end
+end

--- a/test/unit/actions/bulk_action_test.rb
+++ b/test/unit/actions/bulk_action_test.rb
@@ -20,8 +20,9 @@ module ForemanTasks
       let(:targets) { (1..5).map { |i| Target.new i } }
       let(:task) do
         triggered = ForemanTasks.trigger(ParentAction, ChildAction, targets)
-        triggered.finished.wait(2)
-        ForemanTasks::Task.where(:external_id => triggered.id).first
+        task = ForemanTasks::Task.where(:external_id => triggered.id).first
+        wait_for { task.reload.state == 'stopped' }
+        task
       end
 
       specify 'it plans a task for each target' do

--- a/test/unit/actions/bulk_action_test.rb
+++ b/test/unit/actions/bulk_action_test.rb
@@ -28,7 +28,9 @@ module ForemanTasks
         Target.expects(:where).with(:id => targets.map(&:id)).returns(targets)
 
         task.sub_tasks.count.must_equal targets.count
-        assert task.sub_tasks.all? { |subtask| subtask.result == 'success' }
+        success, failed = task.sub_tasks.partition { |sub_task| sub_task.result == 'success' }
+        failed.must_be :empty?
+        success.count.must_equal 5
       end
 
       specify 'it plans a task for each target even if target cannot be found' do


### PR DESCRIPTION
We always assumed we will get all targets from the DB. If some of
the targets were missing in the DB, we didn't create the task for
it and it lead to task counters going out of sync.

With this patch we create tasks for missing targets, but pass nil
instead of the target to it.