### PR TITLE
Fixes #25655 - Recurring Logic skips the first schedule before starting

### DIFF
--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -83,6 +83,9 @@ module ForemanTasks
 
     def next_occurrence_time(time = Time.zone.now)
       @parser ||= CronParser.new(cron_line, Time.zone)
+      # @parser.next(start_time) is not inclusive of the start_time hence stepping back one run to include checking start_time for the first run.
+      before_next = @parser.next(@parser.last(time))
+      return before_next if before_next >= time && tasks.count == 0
       @parser.next(time)
     end
 


### PR DESCRIPTION
In the method start_after we call next_occurence_time which calls @parser.next(start_time) when starting even if the start time is valid for the cron and we could very well start at the start-time itself. 
For example
cron = "* * * * *"
start_time = 12:35:00
We can start at 12:35 instead of starting at 12:36. 


