### PR TITLE
Fixes #25695 - finish migration to concurrent-ruby-1.1

### DIFF
--- a/foreman-tasks-core.gemspec
+++ b/foreman-tasks-core.gemspec
@@ -18,4 +18,6 @@ Common code used both at Forman and Foreman proxy regarding tasks
 
   s.files = Dir['lib/foreman_tasks_core/**/*'] +
             ['lib/foreman_tasks_core.rb', 'LICENSE']
+
+  s.add_dependency "dynflow", '>= 1.2.0'
 end

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -29,7 +29,7 @@ same resource. It also optionally provides Dynflow infrastructure for using it f
   s.extra_rdoc_files = Dir['README*', 'LICENSE']
 
   s.add_dependency "foreman-tasks-core"
-  s.add_dependency "dynflow", '~> 1.0', '>= 1.1.5'
+  s.add_dependency "dynflow", '>= 1.2.0'
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "parse-cron", '~> 0.1.4'
   s.add_dependency "get_process_mem" # for memory polling

--- a/lib/foreman_tasks_core/runner/dispatcher.rb
+++ b/lib/foreman_tasks_core/runner/dispatcher.rb
@@ -172,7 +172,7 @@ module ForemanTasksCore
         return unless runner_actor
         @logger.debug("closing session for command [#{runner_id}]," \
                       "#{@runner_actors.size} actors left ")
-        runner_actor.tell([:start_termination, (defined?(Concurrent::Promises) ? Concurrent::Promises.resolvable_future : Concurrent.future)])
+        runner_actor.tell([:start_termination, Concurrent::Promises.resolvable_future])
       ensure
         @runner_suspended_actions.delete(runner_id)
       end

--- a/test/support/dummy_proxy_action.rb
+++ b/test/support/dummy_proxy_action.rb
@@ -7,13 +7,13 @@ module Support
 
       def initialize
         @log = Hash.new { |h, k| h[k] = [] }
-        @task_triggered = defined?(Concurrent::Promises) ? Concurrent::Promises.resolvable_future : Concurrent.future
+        @task_triggered = Concurrent::Promises.resolvable_future
         @uuid = SecureRandom.uuid
       end
 
       def trigger_task(*args)
         @log[:trigger_task] << args
-        defined?(Concurrent::Promises) ? @task_triggered.fulfill(true) : @task_triggered.success(true)
+        @task_triggered.fulfill(true)
         { 'task_id' => @uuid }
       end
 


### PR DESCRIPTION
Remove the backward compatibility with concurrent-ruby-1.0

To be merged once dynflow 1.2 is released.