### PR TITLE
fixes #25958 - incorrect value for auto_complete_controller_name

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -98,7 +98,7 @@ module ForemanTasks
     end
 
     def auto_complete_controller_name
-      '/foreman_tasks/tasks'
+      'foreman_tasks_tasks'
     end
 
     private


### PR DESCRIPTION
- [x] [required change on Foreman side](https://github.com/theforeman/foreman/pull/6460)

/foreman_tasks/tasks should be foreman_tasks_tasks
Fixes https://projects.theforeman.org/issues/25958