### PR TITLE
Fixes #25958 - use foreman core fix for autocompletion endpoint

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -97,10 +97,6 @@ module ForemanTasks
       ForemanTasks::Task
     end
 
-    def auto_complete_controller_name
-      '/foreman_tasks/tasks'
-    end
-
     private
 
     def restrict_dangerous_actions


### PR DESCRIPTION
After https://github.com/theforeman/foreman/pull/6460, the original
workaround is not needed anymore.

Revert "Fixes #25427 - Make task autocomplete hit the right endpoint"

This reverts commit 1ad5207357cd22d376f1e39055de291e845c20e2.