### PR TITLE
Fixes #26014 - don't use Rails truncate in breadcrumb

### DIFF
--- a/app/views/foreman_tasks/tasks/show.html.erb
+++ b/app/views/foreman_tasks/tasks/show.html.erb
@@ -7,7 +7,7 @@
       url: url_for(foreman_tasks_tasks_path)
     },
     {
-      caption: truncate(format_task_input(@task), :length => 50)
+      caption: format_task_input(@task)
     }
   ],
   name_field: 'action',


### PR DESCRIPTION
The truncation does additional html escaping that doesn't work well
will JS's one. Since https://projects.theforeman.org/issues/25503, we
don't need to do explicit truncation in breadrumbs anymore, so we can
just get rid of it.