### PR TITLE
Refs #25160 - fix disabling of batch triggering

### DIFF
--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -193,7 +193,7 @@ module Actions
     end
 
     def with_batch_triggering?(proxy_version)
-      (proxy_version[:major] == 1 && proxy_version[:minor] > 20) || proxy_version[:major] > 1 &&
+      ((proxy_version[:major] == 1 && proxy_version[:minor] > 20) || proxy_version[:major] > 1) &&
         input.fetch(:connection_options, {}).fetch(:proxy_batch_triggering, false)
     end
 

--- a/app/models/setting/foreman_tasks.rb
+++ b/app/models/setting/foreman_tasks.rb
@@ -12,7 +12,7 @@ class Setting::ForemanTasks < Setting
         set('foreman_tasks_proxy_action_retry_count', N_('Number of attempts to start a task on the smart proxy before failing'), 4),
         set('foreman_tasks_proxy_action_retry_interval', N_('Time in seconds between retries'), 15),
         set('foreman_tasks_proxy_batch_trigger', N_('Allow triggering tasks on the smart proxy in batches'), true),
-        set('foreman_tasks_proxy_batch_size', N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'), 1000)
+        set('foreman_tasks_proxy_batch_size', N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'), 100)
       ].each { |s| create! s.update(:category => 'Setting::ForemanTasks') }
     end
 


### PR DESCRIPTION
also make the default for batch size a bit smaller: the planning
of a job on host can sometimes be quite long-running process, and
the larger the batch size is, the longer we would wait until something
would start happening.