### PR TITLE
Fixes #26399 - add summary endpoint to support tasks dashboard

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -24,6 +24,10 @@ module ForemanTasks
       end
     end
 
+    def summary
+      render json: Task::Summarizer.new(params[:recent_timeframe].to_i).summary
+    end
+
     def sub_tasks
       task   = Task.find(params[:id])
       @tasks = filter(task.sub_tasks)
@@ -109,7 +113,7 @@ module ForemanTasks
 
     def action_permission
       case params[:action]
-      when 'sub_tasks'
+      when 'sub_tasks', 'summary'
         :view
       when 'resume', 'unlock', 'force_unlock', 'cancel_step', 'cancel', 'abort'
         :edit

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -15,6 +15,7 @@ module ForemanTasks
 
     self.primary_key = :id
     before_create :generate_id
+    before_save :update_state_updated_at
 
     belongs_to :parent_task, :class_name => 'ForemanTasks::Task'
     has_many :sub_tasks, :class_name => 'ForemanTasks::Task', :foreign_key => :parent_task_id, :dependent => :nullify
@@ -268,6 +269,10 @@ module ForemanTasks
 
     def generate_id
       self.id ||= SecureRandom.uuid
+    end
+
+    def update_state_updated_at
+      self.state_updated_at = Time.now.utc if changes.key?(:state)
     end
   end
 end

--- a/app/models/foreman_tasks/task/summarizer.rb
+++ b/app/models/foreman_tasks/task/summarizer.rb
@@ -16,7 +16,7 @@ module ForemanTasks
       # updates `field` (one of [:recent, :total]) with counts from aggregated_scope
       def update(field, counts)
         raise ArgumentError, "Unexpected field #{field}" unless @data.key?(field)
-        @data[field] = counts.map(&:count).sum
+        @data[field] = counts.sum(&:count)
       end
     end
 

--- a/app/models/foreman_tasks/task/summarizer.rb
+++ b/app/models/foreman_tasks/task/summarizer.rb
@@ -1,15 +1,105 @@
 module ForemanTasks
   class Task::Summarizer
-    def summarize_by_status(since = nil)
-      result = ::ForemanTasks::Task.where("result <> 'success'")
-                                   .select('count(state) AS count, state, result, max(started_at) AS started_at')
-                                   .group(:state, :result).order(:state)
-      result = result.where('started_at > ?', since) if since
-      result
+    ENSURED_STATE_KEYS = %w[running paused stopped scheduled].freeze
+    ENSURED_RESULT_KEYS = %w[success error warning].freeze
+
+    # number of recent/total tasks for specific classification (state/result)
+    class Record
+      def initialize
+        @data = { recent: 0, total: 0 }
+      end
+
+      def to_h
+        @data.dup
+      end
+
+      # updates `field` (one of [:recent, :total]) with counts from aggregated_scope
+      def update(field, counts)
+        raise ArgumentError, "Unexpected field #{field}" unless @data.key?(field)
+        @data[field] = counts.map(&:count).sum
+      end
+    end
+
+    # number of recent/total tasks for specific state + distribution across different results
+    # in `by_result` attribute
+    class RecordWithResult < Record
+      attr_reader :by_result
+
+      def initialize
+        super
+        @by_result = Hash.new { |h, k| h[k] = Record.new }
+        ENSURED_RESULT_KEYS.each { |result_value| @by_result[result_value] = Record.new }
+      end
+
+      def to_h
+        by_result_hash = @by_result.each.with_object({}) do |(result, record), hash|
+          hash[result] = record.to_h
+        end
+        super.update(by_result: by_result_hash)
+      end
+
+      # Updates the `field` summary + grouping by result
+      def update(field, counts)
+        super(field, counts)
+        counts.group_by(&:result).each do |(result, result_counts)|
+          @by_result[result].update(field, result_counts)
+        end
+      end
+    end
+
+    def initialize(recent_timeframe = 24)
+      @recent_timeframe = recent_timeframe.hours
+    end
+
+    def summarize_by_status
+      aggregated_scope.where("result <> 'success'")
     end
 
     def latest_tasks_in_errors_warning(limit = 5)
       ::ForemanTasks::Task.where('result in (?)', %w[error warning]).order('started_at DESC').limit(limit)
+    end
+
+    # Returns summary of tasks count, grouped by `state` and `result`, if form of:
+    #
+    #    { 'running'   => { recent: 3, total: 6 },
+    #      'paused'    => { recent: 1, total: 3 },
+    #      'stopped'   => { recent: 3, total: 7,
+    #                       by_result: {
+    #                         'success' => { recent: 2, total: 4 },
+    #                         'warning' => { recent: 1, total: 2 },
+    #                         'error'   => { recent: 0, total: 1 },
+    #                       }}
+    #      'scheduled' => { recent: 0, total: 3 }}
+    #
+    def summary
+      @summary = Hash.new { |h, state| h[state] = Record.new }
+      ENSURED_STATE_KEYS.each do |state|
+        @summary[state] = state == 'stopped' ? RecordWithResult.new : Record.new
+      end
+
+      add_to_summary(aggregated_scope, :total)
+      add_to_summary(aggregated_recent_scope, :recent)
+
+      @summary.each.with_object({}) do |(key, record), hash|
+        hash[key] = record.to_h
+      end
+    end
+
+    private
+
+    def add_to_summary(aggregated_scope, field)
+      aggregated_scope.group_by(&:state).each do |(state, state_counts)|
+        @summary[state].update(field, state_counts)
+      end
+    end
+
+    def aggregated_scope
+      ::ForemanTasks::Task.select('count(state) AS count, state, result, max(started_at) AS started_at')
+                          .group(:state, :result).order(:state)
+    end
+
+    def aggregated_recent_scope
+      aggregated_scope.where("state_updated_at > ?", Time.now.utc - @recent_timeframe)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Foreman::Application.routes.draw do
     resources :tasks, :only => [:index, :show] do
       collection do
         get 'auto_complete_search'
+        get '/summary/:recent_timeframe', action: 'summary'
       end
       member do
         get :sub_tasks

--- a/db/migrate/20190318153925_add_task_state_updated_at.foreman_tasks.rb
+++ b/db/migrate/20190318153925_add_task_state_updated_at.foreman_tasks.rb
@@ -1,0 +1,5 @@
+class AddTaskStateUpdatedAt < ActiveRecord::Migration[5.2]
+  def change
+    add_column :foreman_tasks_tasks, :state_updated_at, :timestamp, index: true
+  end
+end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -56,7 +56,7 @@ module ForemanTasks
              :last     => true
 
         security_block :foreman_tasks do |_map|
-          permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :show],
+          permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :summary, :show],
                                             :'foreman_tasks/react' => [:index],
                                             :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -24,6 +24,16 @@ module ForemanTasks
         Organization.current = Location.current = nil
       end
 
+      describe 'summary' do
+        it 'works' do
+          FactoryBot.create(:some_task, :action => 'Some action')
+          get(:summary, params: { recent_timeframe: 24 }, session: set_session_user)
+          assert_response :success
+          response = JSON.parse(@response.body)
+          assert response['running']
+        end
+      end
+
       it 'supports csv export' do
         FactoryBot.create(:some_task, :action => 'Some action')
         get(:index, params: { format: :csv }, session: set_session_user)

--- a/test/unit/summarizer_test.rb
+++ b/test/unit/summarizer_test.rb
@@ -52,12 +52,8 @@ class SummarizerTest < ActiveSupport::TestCase
             task.update(state_updated_at: nil)
           end
         end
-        recent_tasks = []
-        status_summary[:recent].times do |i|
-          task = tasks[i]
-          task.update(state_updated_at: Time.now.utc)
-          recent_tasks << task
-        end
+        recent_tasks = tasks.take(status_summary[:recent])
+        recent_tasks.each { |t| t.update(state_updated_at: Time.now.utc) }
 
         untouched_recent_tasks = recent_tasks
         untouched_old_tasks = tasks - recent_tasks

--- a/test/unit/summarizer_test.rb
+++ b/test/unit/summarizer_test.rb
@@ -1,0 +1,79 @@
+require 'foreman_tasks_test_helper'
+
+class SummarizerTest < ActiveSupport::TestCase
+  before do
+    ::ForemanTasks::Task.delete_all
+  end
+
+  describe ForemanTasks::Task::Summarizer do
+    before do
+      build_tasks
+    end
+
+    let :subject do
+      ForemanTasks::Task::Summarizer.new
+    end
+
+    let :expected do
+      { 'running' => { recent: 3, total: 6 },
+        'stopped' => { recent: 3, total: 7,
+                       by_result: {
+                         'success' => { recent: 2, total: 4 },
+                         'warning' => { recent: 1, total: 2 },
+                         'error' => { recent: 0, total: 1 }
+                       } } }
+    end
+
+    it 'is able to group tasks counts by state and result' do
+      summary = subject.summary
+      expected.each do |(state, expected_state_vals)|
+        assert_summary(expected_state_vals, summary[state], "summary[#{state}]")
+        expected_state_vals.fetch(:by_result, {}).each do |result, expected_result_vals|
+          assert_summary expected_result_vals, summary[state][:by_result][result], "summary[#{state}][#{result}]"
+        end
+      end
+    end
+
+    def assert_summary(expected_summary, summary, value_desc)
+      %I[recent total].each do |key|
+        assert_equal expected_summary[key], summary[key],
+                     "#{value_desc}[#{key}] expected to be #{expected_summary[key]}, was #{summary[key]}"
+      end
+    end
+
+    # rubocop:disable Performance/TimesMap
+    def build_tasks
+      expected.each do |(state, status_summary)|
+        tasks = status_summary[:total].times.map do
+          ForemanTasks::Task.create(type: ForemanTasks::Task.name,
+                                    label: 'test',
+                                    state: state,
+                                    result: 'pending').tap do |task|
+            task.update(state_updated_at: nil)
+          end
+        end
+        recent_tasks = []
+        status_summary[:recent].times do |i|
+          task = tasks[i]
+          task.update(state_updated_at: Time.now.utc)
+          recent_tasks << task
+        end
+
+        untouched_recent_tasks = recent_tasks
+        untouched_old_tasks = tasks - recent_tasks
+        status_summary.fetch(:by_result, {}).each do |(result, result_summary)|
+          result_summary[:recent].times do |_i|
+            task = untouched_recent_tasks.shift
+            task.update(result: result)
+          end
+
+          (result_summary[:total] - result_summary[:recent]).times do |_i|
+            task = untouched_old_tasks.shift
+            task.update(result: result)
+          end
+        end
+      end
+      # rubocop:enable Performance/TimesMap
+    end
+  end
+end

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -41,6 +41,20 @@ class TasksTest < ActiveSupport::TestCase
     end
   end
 
+  describe 'state_updated_at' do
+    it 'updates the state_updated_at when the state changes' do
+      task = FactoryBot.create(:some_task)
+      assert task.state_updated_at > Time.now.utc - 1.minute, "Newly created task has to have state_updated_at set"
+      task.update(state_updated_at: nil)
+      task.result = 'error'
+      task.save
+      assert_not task.state_updated_at, "Other than state change should not affect 'state_updated_at"
+      task.state = 'running'
+      task.save
+      assert task.state_updated_at, "State change should set 'state_updated_at"
+    end
+  end
+
   describe 'authorization filtering' do
     it 'can filter by the task subject' do
       user_role  = FactoryBot.create(:user_user_role)

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -48,10 +48,10 @@ class TasksTest < ActiveSupport::TestCase
       task.update(state_updated_at: nil)
       task.result = 'error'
       task.save
-      assert_not task.state_updated_at, "Other than state change should not affect 'state_updated_at"
+      assert_not task.state_updated_at, "Other than state change should not affect 'state_updated_at'"
       task.state = 'running'
       task.save
-      assert task.state_updated_at, "State change should set 'state_updated_at"
+      assert task.state_updated_at, "State change should set 'state_updated_at'"
     end
   end
 


### PR DESCRIPTION
To support showing new tasks dashboard, we need the following endpoint:

```
GET /foreman_tasks/tasks/summary/24
{ running:   { recent: 3, total: 6 },
  paused:    { recent: 1, total: 3 },
  stopped:   { recent: 3, total: 7,
               by_result: {
                success: { recent: 2, total: 4 },
                warning: { recent: 1, total: 2 },
                error:   { recent: 0, total: 1 },
               }}
  scheduled: { recent: 0, total: 3 }}
```