### PR TITLE
Fixes #26444 - Creates time-period-dropdown

### DIFF
--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DropdownButton, MenuItem } from 'patternfly-react';
+
+import { TASKS_DASHBOARD_AVAILABLE_TIMES } from '../../TasksDashboardConstants';
+import { getTimeText } from '../../TasksDashboardHelper';
+
+const TimeDropDown = ({ id, className, selectedTime, onChange, ...props }) => {
+  const availableTimes = Object.keys(TASKS_DASHBOARD_AVAILABLE_TIMES).map(
+    key => ({
+      key,
+      text: getTimeText(key),
+      active: key === selectedTime,
+    })
+  );
+
+  return (
+    <DropdownButton
+      id={id}
+      className={className}
+      title={getTimeText(selectedTime)}
+      {...props}
+    >
+      {availableTimes.map(({ key, text, active }) => (
+        <MenuItem
+          key={key}
+          active={active}
+          onClick={() => active || onChange(key)}
+        >
+          {text}
+        </MenuItem>
+      ))}
+    </DropdownButton>
+  );
+};
+
+TimeDropDown.propTypes = {
+  id: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  selectedTime: PropTypes.oneOf(Object.keys(TASKS_DASHBOARD_AVAILABLE_TIMES)),
+  onChange: PropTypes.func,
+};
+
+TimeDropDown.defaultProps = {
+  className: '',
+  selectedTime: TASKS_DASHBOARD_AVAILABLE_TIMES.H24,
+  onChange: () => null,
+};
+
+export default TimeDropDown;

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.stories.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.stories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { withCardsDecorator } from '../../../../../stories/decorators';
+
+import { TASKS_DASHBOARD_AVAILABLE_TIMES } from '../../TasksDashboardConstants';
+import TimeDropDown from './TimeDropDown';
+
+storiesOf('TasksDashboard', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withCardsDecorator)
+  .add('TimeDropDown', () => (
+    <TimeDropDown
+      id="time-period-dropdown"
+      selectedTime={select(
+        'selectedTime',
+        TASKS_DASHBOARD_AVAILABLE_TIMES,
+        TASKS_DASHBOARD_AVAILABLE_TIMES.H24
+      )}
+      onChange={action('onChange')}
+    />
+  ));

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.test.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/TimeDropDown.test.js
@@ -1,0 +1,19 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import { TASKS_DASHBOARD_AVAILABLE_TIMES } from '../../TasksDashboardConstants';
+import TimeDropDown from './TimeDropDown';
+
+const createRequiredProps = () => ({ id: 'some-id' });
+
+const fixtures = {
+  'render with minimal props': { ...createRequiredProps() },
+  'render with all props': {
+    ...createRequiredProps(),
+    className: 'some-class',
+    selectedTime: TASKS_DASHBOARD_AVAILABLE_TIMES.WEEK,
+    onChange: jest.fn(),
+  },
+};
+
+describe('TimeDropDown', () =>
+  testComponentSnapshotsWithFixtures(TimeDropDown, fixtures));

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/__snapshots__/TimeDropDown.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TimeDropDown/__snapshots__/TimeDropDown.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeDropDown render with all props 1`] = `
+<DropdownButton
+  className="some-class"
+  id="some-id"
+  title="week"
+>
+  <MenuItem
+    active={false}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="H24"
+    onClick={[Function]}
+  >
+    24h
+  </MenuItem>
+  <MenuItem
+    active={false}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="H12"
+    onClick={[Function]}
+  >
+    12h
+  </MenuItem>
+  <MenuItem
+    active={true}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="WEEK"
+    onClick={[Function]}
+  >
+    week
+  </MenuItem>
+</DropdownButton>
+`;
+
+exports[`TimeDropDown render with minimal props 1`] = `
+<DropdownButton
+  className=""
+  id="some-id"
+  title="24h"
+>
+  <MenuItem
+    active={true}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="H24"
+    onClick={[Function]}
+  >
+    24h
+  </MenuItem>
+  <MenuItem
+    active={false}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="H12"
+    onClick={[Function]}
+  >
+    12h
+  </MenuItem>
+  <MenuItem
+    active={false}
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="WEEK"
+    onClick={[Function]}
+  >
+    week
+  </MenuItem>
+</DropdownButton>
+`;

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardConstants.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardConstants.js
@@ -1,0 +1,13 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const TASKS_DASHBOARD_AVAILABLE_TIMES = {
+  H24: 'H24',
+  H12: 'H12',
+  WEEK: 'WEEK',
+};
+
+export const TASKS_DASHBOARD_AVAILABLE_TIMES_TEXT = {
+  [TASKS_DASHBOARD_AVAILABLE_TIMES.H24]: __('24h'),
+  [TASKS_DASHBOARD_AVAILABLE_TIMES.H12]: __('12h'),
+  [TASKS_DASHBOARD_AVAILABLE_TIMES.WEEK]: __('week'),
+};

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardHelper.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardHelper.js
@@ -1,0 +1,3 @@
+import { TASKS_DASHBOARD_AVAILABLE_TIMES_TEXT } from './TasksDashboardConstants';
+
+export const getTimeText = time => TASKS_DASHBOARD_AVAILABLE_TIMES_TEXT[time];


### PR DESCRIPTION
Adds `TimePeriodDropDown` component to the storybook

[storybook](https://trashy-activity.surge.sh/?path=/story/tasksdashboard--timeperioddropdown)