### PR TITLE
Fixes #26527 - support for filtering by dashboard fields

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -133,6 +133,7 @@ module ForemanTasks
     def filter(scope, paginate: true)
       search = current_taxonomy_search
       search = [search, params[:search]].select(&:present?).join(' AND ')
+      scope = DashboardTableFilter.new(scope, params).scope
       scope = scope.search_for(search, :order => params[:order])
       scope = scope.paginate(:page => params[:page], :per_page => params[:per_page]) if paginate
       scope.distinct

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -40,6 +40,7 @@ module ForemanTasks
     scoped_search :on => :state, :complete_value => true
     scoped_search :on => :result, :complete_value => true
     scoped_search :on => :started_at, :complete_value => false
+    scoped_search :on => :state_updated_at, :complete_value => false
     scoped_search :on => :start_at, :complete_value => false
     scoped_search :on => :ended_at, :complete_value => false
     scoped_search :on => :parent_task_id, :complete_value => true

--- a/app/services/foreman_tasks/dashboard_table_filter.rb
+++ b/app/services/foreman_tasks/dashboard_table_filter.rb
@@ -5,8 +5,8 @@ module ForemanTasks
   #
   #  * :result
   #  * :state
-  #  * :time - expected format of Hxy, where the xy is the time horizon in hours we're interested in
-  #      :time can be set to 'last' to filter the recent tasks, or 'older' (default) to filter earlier ones
+  #  * :time_horizon - expected format of Hxy, where the xy is the time horizon in hours we're interested in
+  #      :time_mode can be set to 'recent' to filter the recent tasks, or 'older' (default) to filter earlier ones
   class DashboardTableFilter
     def initialize(scope, params)
       @scope = scope
@@ -32,14 +32,14 @@ module ForemanTasks
     end
 
     def scope_by_time
-      return unless @params[:time].present?
-      hours = @params[:time][/\A(H)(\d{1,2})$/i, 2]
+      return unless @params[:time_horizon].present?
+      hours = @params[:time_horizon][/\A(H)(\d{1,2})$/i, 2]
       unless hours
         raise Foreman::Exception, 'Unexpected format of time: should be in form of "H24"'
       end
       timestamp = Time.now - hours.to_i.hours
-      case @params[:mode]
-      when 'last'
+      case @params[:time_mode]
+      when 'recent'
         operator = '>'
       else
         operator = '<'

--- a/app/services/foreman_tasks/dashboard_table_filter.rb
+++ b/app/services/foreman_tasks/dashboard_table_filter.rb
@@ -15,25 +15,21 @@ module ForemanTasks
 
     def scope
       @new_scope = @scope
-      scope_by_result
-      scope_by_state
+      scope_by(:result)
+      scope_by(:state)
       scope_by_time
       @new_scope
     end
 
     private
 
-    def scope_by_result
-      @new_scope = @new_scope.where(result: @params[:result]) if @params[:result].present?
-    end
-
-    def scope_by_state
-      @new_scope = @new_scope.where(state: @params[:state]) if @params[:state].present?
+    def scope_by(field)
+      @new_scope = @new_scope.where(field => @params[field]) if @params[field].present?
     end
 
     def scope_by_time
       return if @params[:time_horizon].blank?
-      hours = @params[:time_horizon][/\A(H)(\d{1,2})$/i, 2]
+      hours = @params[:time_horizon][/\AH(\d{1,2})$/i, 1]
       unless hours
         raise Foreman::Exception, 'Unexpected format of time: should be in form of "H24"'
       end

--- a/app/services/foreman_tasks/dashboard_table_filter.rb
+++ b/app/services/foreman_tasks/dashboard_table_filter.rb
@@ -32,12 +32,12 @@ module ForemanTasks
     end
 
     def scope_by_time
-      return unless @params[:time_horizon].present?
+      return if @params[:time_horizon].blank?
       hours = @params[:time_horizon][/\A(H)(\d{1,2})$/i, 2]
       unless hours
         raise Foreman::Exception, 'Unexpected format of time: should be in form of "H24"'
       end
-      timestamp = Time.now - hours.to_i.hours
+      timestamp = Time.now.utc - hours.to_i.hours
       case @params[:time_mode]
       when 'recent'
         operator = '>'

--- a/app/services/foreman_tasks/dashboard_table_filter.rb
+++ b/app/services/foreman_tasks/dashboard_table_filter.rb
@@ -1,0 +1,51 @@
+module ForemanTasks
+  # narrows the scope for the tasks table based on params coming from tasks dashboard
+  #
+  # Supported filters:
+  #
+  #  * :result
+  #  * :state
+  #  * :time - expected format of Hxy, where the xy is the time horizon in hours we're interested in
+  #      :time can be set to 'last' to filter the recent tasks, or 'older' (default) to filter earlier ones
+  class DashboardTableFilter
+    def initialize(scope, params)
+      @scope = scope
+      @params = params
+    end
+
+    def scope
+      @new_scope = @scope
+      scope_by_result
+      scope_by_state
+      scope_by_time
+      @new_scope
+    end
+
+    private
+
+    def scope_by_result
+      @new_scope = @new_scope.where(result: @params[:result]) if @params[:result].present?
+    end
+
+    def scope_by_state
+      @new_scope = @new_scope.where(state: @params[:state]) if @params[:state].present?
+    end
+
+    def scope_by_time
+      return unless @params[:time].present?
+      hours = @params[:time][/\A(H)(\d{1,2})$/i, 2]
+      unless hours
+        raise Foreman::Exception, 'Unexpected format of time: should be in form of "H24"'
+      end
+      timestamp = Time.now - hours.to_i.hours
+      case @params[:mode]
+      when 'last'
+        operator = '>'
+      else
+        operator = '<'
+        search_suffix = 'OR state_updated_at IS NULL'
+      end
+      @new_scope = @new_scope.where("state_updated_at #{operator} ? #{search_suffix}", timestamp)
+    end
+  end
+end

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -4,6 +4,7 @@ require_relative './support/dummy_dynflow_action'
 require_relative './support/dummy_recurring_dynflow_action'
 require_relative './support/dummy_proxy_action'
 require_relative './support/dummy_task_group'
+require_relative './support/history_tasks_builder'
 
 require 'dynflow/testing'
 

--- a/test/support/history_tasks_builder.rb
+++ b/test/support/history_tasks_builder.rb
@@ -1,7 +1,4 @@
 class HistoryTasksBuilder
-  def initialize
-  end
-
   def distribution
     { 'running' => { recent: 3, total: 6 },
       'stopped' => { recent: 3, total: 7,

--- a/test/support/history_tasks_builder.rb
+++ b/test/support/history_tasks_builder.rb
@@ -1,0 +1,45 @@
+class HistoryTasksBuilder
+  def initialize
+  end
+
+  def distribution
+    { 'running' => { recent: 3, total: 6 },
+      'stopped' => { recent: 3, total: 7,
+                     by_result: {
+                       'success' => { recent: 2, total: 4 },
+                       'warning' => { recent: 1, total: 2 },
+                       'error' => { recent: 0, total: 1 }
+                     } } }
+  end
+
+  # rubocop:disable Performance/TimesMap
+  def build
+    distribution.each do |(state, status_summary)|
+      tasks = status_summary[:total].times.map do
+        ForemanTasks::Task.create(type: ForemanTasks::Task.name,
+                                  label: 'test',
+                                  state: state,
+                                  result: 'pending').tap do |task|
+          task.update(state_updated_at: nil)
+        end
+      end
+      recent_tasks = tasks.take(status_summary[:recent])
+      recent_tasks.each { |t| t.update(state_updated_at: Time.now.utc) }
+
+      untouched_recent_tasks = recent_tasks
+      untouched_old_tasks = tasks - recent_tasks
+      status_summary.fetch(:by_result, {}).each do |(result, result_summary)|
+        result_summary[:recent].times do |_i|
+          task = untouched_recent_tasks.shift
+          task.update(result: result)
+        end
+
+        (result_summary[:total] - result_summary[:recent]).times do |_i|
+          task = untouched_old_tasks.shift
+          task.update(result: result)
+        end
+      end
+    end
+    # rubocop:enable Performance/TimesMap
+  end
+end

--- a/test/unit/dashboard_table_filter_test.rb
+++ b/test/unit/dashboard_table_filter_test.rb
@@ -38,8 +38,8 @@ class DashboardTableFilterTest < ActiveSupport::TestCase
 
     describe 'recent' do
       let(:params) { { state: 'running',
-                       time: 'H24',
-                       mode: 'last'} }
+                       time_horizon: 'H24',
+                       time_mode: 'recent'} }
 
       it 'filters' do
         filtered_scope.count.must_equal @tasks_builder.distribution['running'][:recent]
@@ -48,8 +48,8 @@ class DashboardTableFilterTest < ActiveSupport::TestCase
 
     describe 'older' do
       let(:params) { { state: 'running',
-                       time: 'H24',
-                       mode: 'older'} }
+                       time_horizon: 'H24',
+                       time_mode: 'older'} }
 
       it 'filters' do
         old_tasks_count = @tasks_builder.distribution['running'][:total] -

--- a/test/unit/dashboard_table_filter_test.rb
+++ b/test/unit/dashboard_table_filter_test.rb
@@ -37,9 +37,11 @@ class DashboardTableFilterTest < ActiveSupport::TestCase
     end
 
     describe 'recent' do
-      let(:params) { { state: 'running',
-                       time_horizon: 'H24',
-                       time_mode: 'recent'} }
+      let(:params) do
+        { state: 'running',
+          time_horizon: 'H24',
+          time_mode: 'recent' }
+      end
 
       it 'filters' do
         filtered_scope.count.must_equal @tasks_builder.distribution['running'][:recent]
@@ -47,9 +49,11 @@ class DashboardTableFilterTest < ActiveSupport::TestCase
     end
 
     describe 'older' do
-      let(:params) { { state: 'running',
-                       time_horizon: 'H24',
-                       time_mode: 'older'} }
+      let(:params) do
+        { state: 'running',
+          time_horizon: 'H24',
+          time_mode: 'older' }
+      end
 
       it 'filters' do
         old_tasks_count = @tasks_builder.distribution['running'][:total] -

--- a/test/unit/dashboard_table_filter_test.rb
+++ b/test/unit/dashboard_table_filter_test.rb
@@ -1,0 +1,61 @@
+require 'foreman_tasks_test_helper'
+
+class DashboardTableFilterTest < ActiveSupport::TestCase
+  before do
+    ::ForemanTasks::Task.delete_all
+  end
+
+  describe ForemanTasks::DashboardTableFilter do
+    before do
+      @tasks_builder = HistoryTasksBuilder.new
+      @scope = ForemanTasks::Task.all
+      @tasks_builder.build
+    end
+
+    let :subject do
+      ForemanTasks::DashboardTableFilter.new(@scope, params)
+    end
+
+    let :filtered_scope do
+      subject.scope
+    end
+
+    describe 'by result' do
+      let(:params) { { result: 'warning' } }
+
+      it 'filters' do
+        filtered_scope.count.must_equal @tasks_builder.distribution['stopped'][:by_result]['warning'][:total]
+      end
+    end
+
+    describe 'by state' do
+      let(:params) { { state: 'running' } }
+
+      it 'filters' do
+        filtered_scope.count.must_equal @tasks_builder.distribution['running'][:total]
+      end
+    end
+
+    describe 'recent' do
+      let(:params) { { state: 'running',
+                       time: 'H24',
+                       mode: 'last'} }
+
+      it 'filters' do
+        filtered_scope.count.must_equal @tasks_builder.distribution['running'][:recent]
+      end
+    end
+
+    describe 'older' do
+      let(:params) { { state: 'running',
+                       time: 'H24',
+                       mode: 'older'} }
+
+      it 'filters' do
+        old_tasks_count = @tasks_builder.distribution['running'][:total] -
+                          @tasks_builder.distribution['running'][:recent]
+        filtered_scope.count.must_equal old_tasks_count
+      end
+    end
+  end
+end

--- a/test/unit/summarizer_test.rb
+++ b/test/unit/summarizer_test.rb
@@ -7,7 +7,8 @@ class SummarizerTest < ActiveSupport::TestCase
 
   describe ForemanTasks::Task::Summarizer do
     before do
-      build_tasks
+      @tasks_builder = HistoryTasksBuilder.new
+      @tasks_builder.build
     end
 
     let :subject do
@@ -15,13 +16,7 @@ class SummarizerTest < ActiveSupport::TestCase
     end
 
     let :expected do
-      { 'running' => { recent: 3, total: 6 },
-        'stopped' => { recent: 3, total: 7,
-                       by_result: {
-                         'success' => { recent: 2, total: 4 },
-                         'warning' => { recent: 1, total: 2 },
-                         'error' => { recent: 0, total: 1 }
-                       } } }
+      @tasks_builder.distribution
     end
 
     it 'is able to group tasks counts by state and result' do
@@ -39,37 +34,6 @@ class SummarizerTest < ActiveSupport::TestCase
         assert_equal expected_summary[key], summary[key],
                      "#{value_desc}[#{key}] expected to be #{expected_summary[key]}, was #{summary[key]}"
       end
-    end
-
-    # rubocop:disable Performance/TimesMap
-    def build_tasks
-      expected.each do |(state, status_summary)|
-        tasks = status_summary[:total].times.map do
-          ForemanTasks::Task.create(type: ForemanTasks::Task.name,
-                                    label: 'test',
-                                    state: state,
-                                    result: 'pending').tap do |task|
-            task.update(state_updated_at: nil)
-          end
-        end
-        recent_tasks = tasks.take(status_summary[:recent])
-        recent_tasks.each { |t| t.update(state_updated_at: Time.now.utc) }
-
-        untouched_recent_tasks = recent_tasks
-        untouched_old_tasks = tasks - recent_tasks
-        status_summary.fetch(:by_result, {}).each do |(result, result_summary)|
-          result_summary[:recent].times do |_i|
-            task = untouched_recent_tasks.shift
-            task.update(result: result)
-          end
-
-          (result_summary[:total] - result_summary[:recent]).times do |_i|
-            task = untouched_old_tasks.shift
-            task.update(result: result)
-          end
-        end
-      end
-      # rubocop:enable Performance/TimesMap
     end
   end
 end


### PR DESCRIPTION
Support for additional params in tasks index page that influence the filtering:

* result
* state
* time_horizon (e.g. H24)
* time_mode (recent/older)

Required for https://github.com/theforeman/foreman-tasks/pull/399