### PR TITLE
Refs #22602 - Add implicit casting from VARCHAR to UUID on postgres

### DIFF
--- a/db/migrate/20190404132157_add_implicit_varchar_uuid_cast.rb
+++ b/db/migrate/20190404132157_add_implicit_varchar_uuid_cast.rb
@@ -1,0 +1,25 @@
+class AddImplicitVarcharUuidCast < ActiveRecord::Migration[5.2]
+  def up
+    if on_postgresql?
+      ActiveRecord::Base.connection.execute <<~SQL
+        CREATE CAST (varchar AS uuid)
+        WITH INOUT
+        AS IMPLICIT
+      SQL
+    end
+  end
+
+  def down
+    if on_postgresql?
+      ActiveRecord::Base.connection.execute <<~SQL
+        DROP CAST (varchar AS uuid)
+      SQL
+    end
+  end
+
+  private
+
+  def on_postgresql?
+    ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+  end
+end


### PR DESCRIPTION
Before this patch foreman_tasks:cleanup rake task would fail when trying
to delete orphaned execution plans.

The error was:
```
Sequel::DatabaseError: PG::UndefinedFunction: ERROR: operator does not exist:
uuid = character varying LINE 1: ...unt" FROM "dynflow_execution_plans"
WHERE ("uuid" NOT IN (SE...
```