### PR TITLE
Fixes #26560 - paused tasks notification and troubleshooting info

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,3 +107,6 @@ Style/RegexpLiteral:
 
 Layout/AlignHash:
   Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false

--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -1,5 +1,4 @@
 module ForemanTasks
-  # rubocop:disable Metrics/ClassLength
   module Api
     class TasksController < ::Api::V2::BaseController
       include ::Foreman::Controller::SmartProxyAuth
@@ -285,5 +284,4 @@ module ForemanTasks
       end
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/helpers/foreman_tasks/foreman_tasks_helper.rb
+++ b/app/helpers/foreman_tasks/foreman_tasks_helper.rb
@@ -17,6 +17,14 @@ module ForemanTasks
       content_tag(:i, '&nbsp'.html_safe, :class => "glyphicon #{icon}") + content_tag(:span, recurring_logic.humanized_state, :class => status)
     end
 
+    def troubleshooting_info
+      return if @task.state != 'paused' || @task.main_action.nil?
+      helper = TroubleshootingHelpGenerator.new(@task.main_action)
+      ret = '<p><b>Troubleshooting</b></p>'
+      ret += '<p>%{help}</p>' % { help: helper.generate_html }
+      ret.html_safe
+    end
+
     def task_result_icon_class(task)
       return 'task-status pficon-help' if task.state != 'stopped'
 

--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -2,6 +2,8 @@ module Actions
   class Base < Dynflow::Action
     middleware.use ::Actions::Middleware::RailsExecutorWrap
 
+    execution_plan_hooks.use :notify_paused, :on => [:paused]
+
     def task
       @task ||= ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first!
     end
@@ -51,6 +53,10 @@ module Actions
 
     def serializer_class
       ::Actions::Serializers::ActiveRecordSerializer
+    end
+
+    def notify_paused(*_args)
+      task.build_notifications.each(&:deliver!)
     end
   end
 end

--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -56,7 +56,7 @@ module Actions
     end
 
     def notify_paused(*_args)
-      task.build_notifications.each(&:deliver!)
+      task.build_notifications.each(&:deliver!) if root_action?
     end
   end
 end

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -148,6 +148,22 @@ module ForemanTasks
       end
     end
 
+    def notification_recipients_ids
+      owner_ids
+    end
+
+    def build_notifications
+      notifications = []
+      if state == 'paused'
+        owner = self.owner
+        if owner && !owner.hidden?
+          notifications << UINotifications::Tasks::TaskPausedOwner.new(self)
+        end
+        notifications << UINotifications::Tasks::TaskPausedAdmin.new(self)
+      end
+      notifications
+    end
+
     def self.search_by_generic_resource(key, operator, value)
       key = 'resource_type' if key.blank?
       key_name = connection.quote_column_name(key.sub(/^.*\./, ''))

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -148,13 +148,14 @@ module ForemanTasks
       end
     end
 
+    # used by Foreman notifications framework
     def notification_recipients_ids
       owner_ids
     end
 
     def build_notifications
       notifications = []
-      if state == 'paused'
+      if paused?
         owner = self.owner
         if owner && !owner.hidden?
           notifications << UINotifications::Tasks::TaskPausedOwner.new(self)

--- a/app/models/setting/foreman_tasks.rb
+++ b/app/models/setting/foreman_tasks.rb
@@ -3,6 +3,8 @@ class Setting::ForemanTasks < Setting
     # Check the table exists
     return unless super
 
+    Setting::BLANK_ATTRS.push('foreman_tasks_troubleshooting_url')
+
     transaction do
       [
         set('foreman_tasks_sync_task_timeout', N_('Number of seconds to wait for synchronous task to finish.'), 120),
@@ -12,7 +14,12 @@ class Setting::ForemanTasks < Setting
         set('foreman_tasks_proxy_action_retry_count', N_('Number of attempts to start a task on the smart proxy before failing'), 4),
         set('foreman_tasks_proxy_action_retry_interval', N_('Time in seconds between retries'), 15),
         set('foreman_tasks_proxy_batch_trigger', N_('Allow triggering tasks on the smart proxy in batches'), true),
-        set('foreman_tasks_proxy_batch_size', N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'), 100)
+        set('foreman_tasks_proxy_batch_size', N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'), 100),
+        set('foreman_tasks_troubleshooting_url',
+            N_('Url pointing to the task troubleshooting documentation. '\
+               'It should contain %{label} placeholder, that will be replaced with normalized task label '\
+               '(restricted to only alphanumeric characters)). %{version} placeholder is also available.'),
+            nil)
       ].each { |s| create! s.update(:category => 'Setting::ForemanTasks') }
     end
 

--- a/app/services/foreman_tasks/troubleshooting_help_generator.rb
+++ b/app/services/foreman_tasks/troubleshooting_help_generator.rb
@@ -1,0 +1,92 @@
+module ForemanTasks
+  class TroubleshootingHelpGenerator
+    class Link
+      attr_accessor :name, :title, :description, :href
+
+      def initialize(name:, title:, description:, href:)
+        @name = name
+        @title = title
+        @description = description
+        @href = href
+      end
+
+      def to_h(capitalize_title: false)
+        title = capitalize_title ? self.title.titlecase : self.title
+        { name: name, title: title, description: description, href: href, external: true }
+      end
+    end
+
+    class Info
+      attr_reader :links, :description_lines
+
+      def initialize
+        @description_lines = []
+        @links = []
+      end
+
+      def add_line(line)
+        @description_lines << line
+      end
+
+      def add_link(link)
+        @links << link
+      end
+    end
+
+    def initialize(action)
+      @action = action
+      @custom_info = action.troubleshooting_info if action.respond_to?(:troubleshooting_info)
+    end
+
+    def generate_html
+      # rubocop:disable Rails/OutputSafety
+      (description + link_descriptions_html).join('<br/>').html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
+
+    def link_descriptions_html
+      links.map do |link|
+        link.description % { link: %(<a href="%{href}">%{title}</a>) % link.to_h }
+      end
+    end
+
+    def description
+      ret = generic_info.description_lines
+      ret += @custom_info.description_lines if @custom_info
+      ret
+    end
+
+    def links
+      links = generic_info.links
+      links += @custom_info.links if @custom_info
+      links
+    end
+
+    def generic_info
+      @generic_info ||= Info.new.tap do |i|
+        i.add_line _('A paused task represents a process that has not finished properly. '\
+                        'Any task in paused state can lead to potential inconsistency '\
+                        'and to be resolved.')
+        i.add_line _("The recommended approach is to investigate the error messages below and in 'errors' tab, "\
+                     'address the primary cause of the issue and resume the task.')
+        if (link = troubleshooting_link)
+          i.add_link(link)
+        end
+      end
+    end
+
+    def troubleshooting_link(generic_only: false)
+      url_template = Setting[:foreman_tasks_troubleshooting_url]
+      return if url_template.blank?
+      url = url_template % { label: generic_only ? '' : link_anchor, version: SETTINGS[:version].short }
+      Link.new(name: :troubleshooting,
+               title: _('troubleshooting documentation'),
+               description: _('See %{link} for more details on how to resolve the issue'),
+               href: url)
+    end
+
+    def link_anchor
+      @action.label.to_s.tr('::', '')
+    end
+  end
+end

--- a/app/services/foreman_tasks/troubleshooting_help_generator.rb
+++ b/app/services/foreman_tasks/troubleshooting_help_generator.rb
@@ -66,7 +66,7 @@ module ForemanTasks
       @generic_info ||= Info.new.tap do |i|
         i.add_line _('A paused task represents a process that has not finished properly. '\
                         'Any task in paused state can lead to potential inconsistency '\
-                        'and to be resolved.')
+                        'and needs to be resolved.')
         i.add_line _("The recommended approach is to investigate the error messages below and in 'errors' tab, "\
                      'address the primary cause of the issue and resume the task.')
         if (link = troubleshooting_link)

--- a/app/services/foreman_tasks/troubleshooting_help_generator.rb
+++ b/app/services/foreman_tasks/troubleshooting_help_generator.rb
@@ -86,7 +86,7 @@ module ForemanTasks
     end
 
     def link_anchor
-      @action.label.to_s.tr('::', '')
+      @action.label.to_s
     end
   end
 end

--- a/app/services/ui_notifications/tasks.rb
+++ b/app/services/ui_notifications/tasks.rb
@@ -1,0 +1,20 @@
+module UINotifications
+  module Tasks
+    class Base < ::UINotifications::Base
+      def initialize(task)
+        @subject = @task = task
+      end
+
+      def initiator
+        User.anonymous_admin
+      end
+
+      def troubleshooting_help_generator
+        return @troubleshooting_help_generator if defined? @troubleshooting_help_generator
+        @troubleshooting_help_generator = if @task.main_action
+                                            ForemanTasks::TroubleshootingHelpGenerator.new(@task.main_action)
+                                          end
+      end
+    end
+  end
+end

--- a/app/services/ui_notifications/tasks/task_paused_admin.rb
+++ b/app/services/ui_notifications/tasks/task_paused_admin.rb
@@ -1,0 +1,43 @@
+module UINotifications
+  module Tasks
+    class TaskPausedAdmin < Tasks::Base
+      def deliver!
+        # delete previous notifications about paused tasks first
+        Notification.where(notification_blueprint_id: blueprint.id).each(&:destroy)
+        notification = ::Notification.new(
+          :audience => Notification::AUDIENCE_ADMIN,
+          :notification_blueprint => blueprint,
+          :initiator => initiator,
+          :subject => subject,
+          :message => message
+        )
+
+        notification.send(:set_custom_attributes) # to add links from blueprint
+        notification.actions['links'] ||= []
+        if troubleshooting_help_generator
+          troubleshooting_link = troubleshooting_help_generator.troubleshooting_link(generic_only: true)
+          notification.actions['links'] << troubleshooting_link.to_h(capitalize_title: true) if troubleshooting_link
+        end
+        notification.save!
+        notification
+      end
+
+      def initiator
+        User.anonymous_admin
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => 'tasks_paused_admin')
+      end
+
+      def message
+        return @message if @message
+
+        tasks_count = ForemanTasks::Task.where(state: 'paused').count
+        @message = n_('There is %{count} paused task in the system that need attention',
+                      'There are %{count} paused tasks in the system that need attention',
+                      tasks_count) % { count: tasks_count }
+      end
+    end
+  end
+end

--- a/app/services/ui_notifications/tasks/task_paused_owner.rb
+++ b/app/services/ui_notifications/tasks/task_paused_owner.rb
@@ -1,0 +1,30 @@
+module UINotifications
+  module Tasks
+    class TaskPausedOwner < Tasks::Base
+      def deliver!
+        notification = ::Notification.new(
+          :audience => Notification::AUDIENCE_USER,
+          :notification_blueprint => blueprint,
+          :initiator => initiator,
+          :message => message,
+          :subject => subject
+        )
+        notification.send(:set_custom_attributes) # to add links from blueprint
+        notification.actions['links'] ||= []
+        if troubleshooting_help_generator
+          notification.actions['links'].concat(troubleshooting_help_generator.links.map { |l| l.to_h(capitalize_title: true) })
+        end
+        notification.save!
+        notification
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => 'tasks_paused_owner')
+      end
+
+      def message
+        StringParser.new(blueprint.message, subject: subject.action).to_s
+      end
+    end
+  end
+end

--- a/app/views/foreman_tasks/tasks/_details.html.erb
+++ b/app/views/foreman_tasks/tasks/_details.html.erb
@@ -174,6 +174,8 @@
   </div>
 </div>
 
+<%= troubleshooting_info %>
+
 <% unless @task.humanized[:output].blank? %>
 <div>
   <span class="param-name list-group-item-heading"><%= _("Output") %>:</span>
@@ -184,10 +186,10 @@
 <% end %>
 
 <% unless @task.humanized[:errors].blank? %>
-<div>
-  <span class="param-name"><%= _("Errors") %>:</span>
+<p>
+  <span class="param-name"><b><%= _("Errors") %>:</b></span>
   <span class="param-value">
     <pre><%=Array(@task.humanized[:errors]).join("\n") %></pre>
   </span>
-</div>
+</p>
 <% end %>

--- a/db/seeds.d/30-notification_blueprints.rb
+++ b/db/seeds.d/30-notification_blueprints.rb
@@ -1,0 +1,33 @@
+blueprints = [
+  {
+    group: N_('Tasks'),
+    name: 'tasks_paused_admin',
+    message: "DYNAMIC",
+    level: 'warning',
+    actions:
+      {
+        links:
+          [
+            href: "/foreman_tasks/tasks?search=#{CGI.escape('state=paused')}",
+            title: N_('List of tasks')
+          ]
+      }
+  },
+
+  {
+    group: N_('Tasks'),
+    name: 'tasks_paused_owner',
+    message: "The task '%{subject}' got paused",
+    level: 'warning',
+    actions:
+      {
+        links:
+          [
+            path_method: :foreman_tasks_task_path,
+            title: N_('Task Details')
+          ]
+      }
+  }
+]
+
+blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -29,7 +29,7 @@ same resource. It also optionally provides Dynflow infrastructure for using it f
   s.extra_rdoc_files = Dir['README*', 'LICENSE']
 
   s.add_dependency "foreman-tasks-core"
-  s.add_dependency "dynflow", '>= 1.2.2'
+  s.add_dependency "dynflow", '>= 1.2.3'
   s.add_dependency "sinatra" # for Dynflow web console
   s.add_dependency "parse-cron", '~> 0.1.4'
   s.add_dependency "get_process_mem" # for memory polling

--- a/lib/foreman_tasks/test_helpers.rb
+++ b/lib/foreman_tasks/test_helpers.rb
@@ -1,9 +1,19 @@
 require 'dynflow/testing'
 module ForemanTasks
   module TestHelpers
+    def self.use_in_memory_sqlite!
+      raise 'the in thread world have already been initialized' if @test_in_thread_world
+      @use_in_memory_sqlite = true
+    end
+
     def self.test_in_thread_world
       return @test_in_thread_world if @test_in_thread_world
       world_config = ForemanTasks.dynflow.config.world_config
+      if @use_in_memory_sqlite
+        world_config.persistence_adapter = lambda do |*_args|
+          ::ForemanTasks::Dynflow::Persistence.new('adapter' => 'sqlite', 'database' => ':memory:')
+        end
+      end
       @test_in_thread_world = ::Dynflow::Testing::InThreadWorld.new(world_config)
     end
 

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -7,12 +7,15 @@ require_relative './support/dummy_task_group'
 require_relative './support/history_tasks_builder'
 
 require 'dynflow/testing'
+require 'foreman_tasks/test_helpers'
 
 FactoryBot.definition_file_paths = ["#{ForemanTasks::Engine.root}/test/factories"]
 FactoryBot.find_definitions
 
 ForemanTasks.dynflow.require!
 ForemanTasks.dynflow.config.disable_active_record_actions = true
+
+ForemanTasks::TestHelpers.use_in_memory_sqlite!
 
 # waits for the passed block to return non-nil value and reiterates it while getting false
 # (till some reasonable timeout). Useful for forcing the tests for some event to occur

--- a/test/support/dummy_dynflow_action.rb
+++ b/test/support/dummy_dynflow_action.rb
@@ -3,6 +3,11 @@ module Support
   end
 
   class DummyPauseAction < Actions::EntryAction
+    def plan
+      plan_action(DummyPauseActionWithCustomTroubleshooting)
+      plan_self
+    end
+
     def run
       error! "This is an error"
     end

--- a/test/support/dummy_dynflow_action.rb
+++ b/test/support/dummy_dynflow_action.rb
@@ -1,4 +1,28 @@
 module Support
   class DummyDynflowAction < Dynflow::Action
   end
+
+  class DummyPauseAction < Actions::EntryAction
+    def run
+      error! "This is an error"
+    end
+  end
+
+  class DummyPauseActionWithCustomTroubleshooting < Actions::EntryAction
+    def run
+      error! "This is an error"
+    end
+
+    def troubleshooting_info
+      ForemanTasks::TroubleshootingHelpGenerator::Info.new.tap do |i|
+        i.add_line _('This task requires special handling.')
+        i.add_link(ForemanTasks::TroubleshootingHelpGenerator::Link.new(
+                     name: :custom_link,
+                     title: _('custom link'),
+                     href: "/additional_troubleshooting_page",
+                     description: _("Investigate %{link} on more details for this custom error.")
+                   ))
+      end
+    end
+  end
 end

--- a/test/unit/actions/action_with_sub_plans_test.rb
+++ b/test/unit/actions/action_with_sub_plans_test.rb
@@ -35,7 +35,7 @@ module ForemanTasks
         user = FactoryBot.create(:user)
         triggered = ForemanTasks.trigger(ParentAction, user)
         raise triggered.error if triggered.respond_to?(:error)
-        triggered.finished.wait(2)
+        triggered.finished.wait(30)
         ForemanTasks::Task.where(:external_id => triggered.id).first
       end
 

--- a/test/unit/troubleshooting_help_generator_test.rb
+++ b/test/unit/troubleshooting_help_generator_test.rb
@@ -1,5 +1,4 @@
 require 'foreman_tasks_test_helper'
-require 'foreman_tasks/test_helpers'
 
 module ForemanTasks
   class TroubleshootingHelpGeneratorTest < ActiveSupport::TestCase

--- a/test/unit/troubleshooting_help_generator_test.rb
+++ b/test/unit/troubleshooting_help_generator_test.rb
@@ -1,0 +1,72 @@
+require 'foreman_tasks_test_helper'
+require 'foreman_tasks/test_helpers'
+
+module ForemanTasks
+  class TroubleshootingHelpGeneratorTest < ActiveSupport::TestCase
+    include ForemanTasks::TestHelpers::WithInThreadExecutor
+
+    subject do
+      TroubleshootingHelpGenerator.new(@task.main_action)
+    end
+
+    let :sample_troubleshooting_url do
+      'https://theforeman.org/manuals/%{version}/tasks_troubleshooting.html#%{label}'
+    end
+
+    let :expected_troubleshooting_url do
+      "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#SupportDummyPauseAction"
+    end
+
+    let :action_class do
+      Support::DummyPauseAction
+    end
+
+    before do
+      Setting::ForemanTasks.load_defaults
+      ::ForemanTasks::Task.delete_all
+      @task = trigger_task
+      Setting[:foreman_tasks_troubleshooting_url] = sample_troubleshooting_url
+    end
+
+    it 'generates html from the main action troubleshooting_info' do
+      generated_html = subject.generate_html
+      generated_html.must_include "A paused task represents a process that has not finished properly"
+      generated_html.must_include %(See <a href="#{expected_troubleshooting_url}">troubleshooting documentation</a> for more details on how to resolve the issue)
+    end
+
+    it 'exposes link details' do
+      link = subject.links.find do |l|
+        l.name == :troubleshooting && l.title == 'troubleshooting documentation' &&
+          l.href == expected_troubleshooting_url
+      end
+      assert link, "#{subject.links} doesn't contain expected link"
+    end
+
+    describe 'additional troubleshooting info' do
+      let(:action_class) do
+        Support::DummyPauseActionWithCustomTroubleshooting
+      end
+
+      it 'includes additional description in generated html' do
+        generated_html = subject.generate_html
+        generated_html.must_include 'A paused task represents a process that has not finished properly'
+        generated_html.must_match %r{See <a href=".*">troubleshooting documentation</a> for more details on how to resolve the issue}
+        generated_html.must_include 'This task requires special handling'
+        generated_html.must_include 'Investigate <a href="/additional_troubleshooting_page">custom link</a> on more details for this custom error'
+      end
+
+      it 'includes additional links' do
+        link = subject.links.find do |l|
+          l.name == :custom_link && l.title == 'custom link' && l.href == '/additional_troubleshooting_page'
+        end
+        assert link, "#{subject.links} doesn't contain expected link"
+      end
+    end
+
+    def trigger_task
+      t = ForemanTasks.trigger(action_class)
+      t.finished.wait
+      ForemanTasks::Task.find_by(external_id: t.execution_plan_id)
+    end
+  end
+end

--- a/test/unit/troubleshooting_help_generator_test.rb
+++ b/test/unit/troubleshooting_help_generator_test.rb
@@ -14,7 +14,7 @@ module ForemanTasks
     end
 
     let :expected_troubleshooting_url do
-      "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#SupportDummyPauseAction"
+      "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#Support::DummyPauseAction"
     end
 
     let :action_class do

--- a/test/unit/ui_notifications_test.rb
+++ b/test/unit/ui_notifications_test.rb
@@ -57,7 +57,9 @@ module ForemanTasks
     describe UINotifications::Tasks::TaskPausedOwner do
       it 'notifies the owner about the paused task' do
         task = trigger_task
-        notification = user_notifications(task_owner).first
+        notifications = user_notifications(task_owner)
+        assert_equal 1, notifications.size, 'Only notification for the main action should be triggered'
+        notification = notifications.first
         notification.message.must_equal "The task 'Dummy pause action' got paused"
         links = notification.actions['links']
         links.must_include("href" => "/foreman_tasks/tasks/#{task.id}",

--- a/test/unit/ui_notifications_test.rb
+++ b/test/unit/ui_notifications_test.rb
@@ -1,0 +1,85 @@
+require 'foreman_tasks_test_helper'
+require 'foreman_tasks/test_helpers'
+
+module ForemanTasks
+  class UiNotificationsTest < ActiveSupport::TestCase
+    include ForemanTasks::TestHelpers::WithInThreadExecutor
+
+    let(:admin_user) { @admin_user }
+    let(:task_owner) { FactoryBot.create(:user) }
+
+    let :sample_troubleshooting_url do
+      'https://theforeman.org/manuals/%{version}/tasks_troubleshooting.html#%{label}'
+    end
+
+    before do
+      Setting::ForemanTasks.load_defaults
+      ::ForemanTasks::Task.delete_all
+      load File.join(ForemanTasks::Engine.root, 'db', 'seeds.d', '30-notification_blueprints.rb')
+      @admin_user = FactoryBot.create(:user, :admin)
+      Setting[:foreman_tasks_troubleshooting_url] = sample_troubleshooting_url
+    end
+
+    describe UINotifications::Tasks::TaskPausedAdmin do
+      it 'notifies all admins about current amount of paused tasks when some paused task occurs' do
+        trigger_task
+        notification = user_notifications(admin_user).first
+        notification.message.must_equal "There is 1 paused task in the system that need attention"
+        links = notification.actions['links']
+        links.must_include('href' => '/foreman_tasks/tasks?search=state%3Dpaused',
+                           'title' => 'List of tasks')
+        links.must_include('name' => 'troubleshooting',
+                           'title' => 'Troubleshooting Documentation',
+                           'description' => 'See %{link} for more details on how to resolve the issue',
+                           'href' => "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#",
+                           'external' => true)
+      end
+
+      it 'aggregates the notification when multiple tasks get paused' do
+        trigger_task
+        recipient1 = NotificationRecipient.find_by(user_id: admin_user)
+        recipient1.notification.message.must_match(/1 paused task/)
+
+        new_admin_user = FactoryBot.create(:user, :admin)
+
+        trigger_task
+
+        NotificationRecipient.find_by(id: recipient1.id).must_be_nil
+        Notification.find_by(id: recipient1.notification.id).must_be_nil
+        recipient2 = NotificationRecipient.find_by(user_id: admin_user)
+        recipient2.notification.message.must_match(/2 paused tasks/)
+
+        new_recipient = NotificationRecipient.find_by(user_id: new_admin_user)
+        new_recipient.notification.must_equal recipient2.notification
+      end
+    end
+
+    describe UINotifications::Tasks::TaskPausedOwner do
+      it 'notifies the owner about the paused task' do
+        task = trigger_task
+        notification = user_notifications(task_owner).first
+        notification.message.must_equal "The task 'Dummy pause action' got paused"
+        links = notification.actions['links']
+        links.must_include("href" => "/foreman_tasks/tasks/#{task.id}",
+                           "title" => "Task Details")
+        links.must_include('name' => 'troubleshooting',
+                           'title' => 'Troubleshooting Documentation',
+                           'description' => 'See %{link} for more details on how to resolve the issue',
+                           'href' => "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#SupportDummyPauseAction",
+                           'external' => true)
+      end
+    end
+
+    def trigger_task
+      as_user task_owner do
+        t = ForemanTasks.trigger(::Support::DummyPauseAction)
+        t.finished.wait
+        ForemanTasks::Task.find_by(external_id: t.execution_plan_id)
+      end
+    end
+
+    def user_notifications(user)
+      Notification.joins(:notification_recipients).where('notification_recipients.user_id' => user.id)
+    end
+  end
+end

--- a/test/unit/ui_notifications_test.rb
+++ b/test/unit/ui_notifications_test.rb
@@ -1,5 +1,4 @@
 require 'foreman_tasks_test_helper'
-require 'foreman_tasks/test_helpers'
 
 module ForemanTasks
   class UiNotificationsTest < ActiveSupport::TestCase

--- a/test/unit/ui_notifications_test.rb
+++ b/test/unit/ui_notifications_test.rb
@@ -67,7 +67,7 @@ module ForemanTasks
         links.must_include('name' => 'troubleshooting',
                            'title' => 'Troubleshooting Documentation',
                            'description' => 'See %{link} for more details on how to resolve the issue',
-                           'href' => "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#SupportDummyPauseAction",
+                           'href' => "https://theforeman.org/manuals/#{SETTINGS[:version].short}/tasks_troubleshooting.html#Support::DummyPauseAction",
                            'external' => true)
       end
     end


### PR DESCRIPTION
This path adds notifications and troubleshooting info for pauses tasks

Troubleshooting info
--------------------

A new `TroubleshootingHelpGenerator` service class has been added to
provide troubleshooting info for paused tasks. By default, it provides
generic information explaining the situation and link to troubleshooting
documentation (in case Setting[:foreman_tasks_troubleshooting_url] is
set.

The troubleshooting_url can contain macros for foreman version and
normalized task label (the label without non-alhpanumeric characters).
For example, for the following url setting:

      https://tfm.org/%{version}/tasks_troubleshooting.html#%{label}

and task 'Plugin::MyTask', the generated url would be:

      https://tfm.org/1.22/tasks_troubleshooting.html#PluginMyTask

The setting is currently not set (which means the troubleshooting link to
currently generated. We will add the setting once the page is ready in
docs.

It's also possible to extend the troubleshooting info and links on
per-action basis, by defining specific action method (see
`test/support/dummy_dynflow_action.rb` for example on how to define it.

Admin notifications
-------------------

Every time there is paused task, an admin gets a notification about
current amount of paused tasks with links to:

1. list of paused tasks
2. troubleshooting links from `TroubleshootingHelpGenerator`
  - the label for the troubleshooting url is filled with `''` in this
  case.

In case new paused task is added, the previous notification is removed
and an update notification is generated, so that the user's notification
is not overloaded with data.

Owner notification
------------------

In case the task is triggered by some user (the host-related tasks are
out of scope), the owner should the notification about the single task
being paused, with links to

1. details of the task
2. troubleshooting info for the task

How to test
-----------

1. set the `foreman_tasks_troubleshooting_url` config to some url
(as example might be
https://access.redhat.com/solutions/satellite6-tasks)
2. make some tasks to get paused
3. look at the notification drawer
4. loot the the details of the task