### PR TITLE
Fixes #26626 - log task state and result changes

### DIFF
--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -1,6 +1,7 @@
 module Actions
   class Base < Dynflow::Action
     middleware.use ::Actions::Middleware::RailsExecutorWrap
+    include Actions::Helpers::LifecycleLogging
 
     execution_plan_hooks.use :notify_paused, :on => [:paused]
 

--- a/app/lib/actions/helpers/lifecycle_logging.rb
+++ b/app/lib/actions/helpers/lifecycle_logging.rb
@@ -1,0 +1,21 @@
+module Actions
+  module Helpers
+    module LifecycleLogging
+      def self.included(base)
+        base.execution_plan_hooks.use :log_task_state_change
+      end
+
+      def log_task_state_change(execution_plan)
+        return unless root_action?
+        logger = Rails.application.dynflow.world.action_logger
+        task_id = ForemanTasks::Task::DynflowTask.where(external_id: execution_plan.id).pluck(:id).first
+
+        task_id_parts = []
+        task_id_parts << "id: #{task_id}" if task_id
+        task_id_parts << "execution_plan_id: #{execution_plan.id}"
+        result_info = " result: #{execution_plan.result}" if [:stopped, :paused].include?(execution_plan.state)
+        logger.info("Task {label: #{execution_plan.label}, #{task_id_parts.join(', ')}} state changed: #{execution_plan.state} #{result_info}")
+      end
+    end
+  end
+end

--- a/test/unit/actions/action_with_sub_plans_test.rb
+++ b/test/unit/actions/action_with_sub_plans_test.rb
@@ -1,4 +1,5 @@
 require 'foreman_tasks_test_helper'
+require 'foreman_tasks/test_helpers'
 
 module ForemanTasks
   class ActionWithSubPlansTest < ActiveSupport::TestCase
@@ -31,6 +32,8 @@ module ForemanTasks
     end
 
     describe Actions::ActionWithSubPlans do
+      include ForemanTasks::TestHelpers::WithInThreadExecutor
+
       let(:task) do
         user = FactoryBot.create(:user)
         triggered = ForemanTasks.trigger(ParentAction, user)

--- a/test/unit/actions/bulk_action_test.rb
+++ b/test/unit/actions/bulk_action_test.rb
@@ -17,6 +17,8 @@ module ForemanTasks
     end
 
     describe Actions::BulkAction do
+      include ForemanTasks::TestHelpers::WithInThreadExecutor
+
       let(:targets) { (1..5).map { |i| Target.new i } }
       let(:task) do
         triggered = ForemanTasks.trigger(ParentAction, ChildAction, targets)


### PR DESCRIPTION
This PR adds additional logging aroudn state and result change, so that at the end, something like this gest produced in the logs:

```
2019-04-16T14:22:10 [I|bac|] Task {label: Actions::Try::Pause, id: 759dfb3d-f14a-4112-b336-e6f65e3e5eb9, execution_plan_id: 75d6e6fc-bc18-4e60-8d34-5a5a7d5dccb0} state changed: planning 
2019-04-16T14:22:10 [I|bac|] Task {label: Actions::Try::Pause, id: 759dfb3d-f14a-4112-b336-e6f65e3e5eb9, execution_plan_id: 75d6e6fc-bc18-4e60-8d34-5a5a7d5dccb0} state changed: planned 
2019-04-16T14:22:10 [I|bac|] Task {label: Actions::Try::Pause, id: 759dfb3d-f14a-4112-b336-e6f65e3e5eb9, execution_plan_id: 75d6e6fc-bc18-4e60-8d34-5a5a7d5dccb0} state changed: running 
2019-04-16T14:22:10 [I|bac|] Task {label: Actions::Try::Pause, id: 759dfb3d-f14a-4112-b336-e6f65e3e5eb9, execution_plan_id: 75d6e6fc-bc18-4e60-8d34-5a5a7d5dccb0} state changed: paused  result: error
```