### PR TITLE
Fixes #26653 - cards-grid doesnt supports all screen sizes

### DIFF
--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/Components/StoppedTasksCard/StoppedTasksCard.stories.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/Components/StoppedTasksCard/StoppedTasksCard.stories.js
@@ -38,11 +38,6 @@ storiesOf('TasksDashboard/TasksCardsGrid', module)
     );
     return (
       <div>
-        <link
-          rel="stylesheet"
-          type="text/css"
-          href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css"
-        />
         <StoppedTasksCard
           data={{
             error: {

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/TasksCardsGrid.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/TasksCardsGrid.js
@@ -23,7 +23,7 @@ const TasksCardsGrid = ({ time, query, data, updateQuery }) => (
         [TASKS_DASHBOARD_AVAILABLE_QUERY_STATES.STOPPED, StoppedTasksCard],
         [TASKS_DASHBOARD_AVAILABLE_QUERY_STATES.SCHEDULED, ScheduledTasksCard],
       ].map(([key, Card]) => (
-        <CardGrid.Col sm={6} lg={3} key={key}>
+        <CardGrid.Col key={key}>
           <Card
             matchHeight
             data={data[key]}

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/TasksCardsGrid.stories.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/TasksCardsGrid.stories.js
@@ -37,16 +37,18 @@ storiesOf('TasksDashboard/TasksCardsGrid', module)
     );
 
     return (
-      <TasksCardsGrid
-        time={selectTime}
-        query={{
-          state: selectState,
-          result: selectResult,
-          mode: selectMode,
-          time: selectTime,
-        }}
-        data={object('data', MOCKED_DATA)}
-        updateQuery={action('updateQuery')}
-      />
+      <div>
+        <TasksCardsGrid
+          time={selectTime}
+          query={{
+            state: selectState,
+            result: selectResult,
+            mode: selectMode,
+            time: selectTime,
+          }}
+          data={object('data', MOCKED_DATA)}
+          updateQuery={action('updateQuery')}
+        />
+      </div>
     );
   });

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/__snapshots__/TasksCardsGrid.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksCardsGrid/__snapshots__/TasksCardsGrid.test.js.snap
@@ -14,8 +14,6 @@ exports[`TasksCardsGrid render with minimal props 1`] = `
       bsClass="col"
       componentClass="div"
       key="running"
-      lg={3}
-      sm={6}
     >
       <RunningTasksCard
         className=""
@@ -35,8 +33,6 @@ exports[`TasksCardsGrid render with minimal props 1`] = `
       bsClass="col"
       componentClass="div"
       key="paused"
-      lg={3}
-      sm={6}
     >
       <PausedTasksCard
         className=""
@@ -56,8 +52,6 @@ exports[`TasksCardsGrid render with minimal props 1`] = `
       bsClass="col"
       componentClass="div"
       key="stopped"
-      lg={3}
-      sm={6}
     >
       <StoppedTasksCard
         className=""
@@ -87,8 +81,6 @@ exports[`TasksCardsGrid render with minimal props 1`] = `
       bsClass="col"
       componentClass="div"
       key="scheduled"
-      lg={3}
-      sm={6}
     >
       <ScheduledTasksCard
         className=""
@@ -117,8 +109,6 @@ exports[`TasksCardsGrid render with props 1`] = `
       bsClass="col"
       componentClass="div"
       key="running"
-      lg={3}
-      sm={6}
     >
       <RunningTasksCard
         className=""
@@ -142,8 +132,6 @@ exports[`TasksCardsGrid render with props 1`] = `
       bsClass="col"
       componentClass="div"
       key="paused"
-      lg={3}
-      sm={6}
     >
       <PausedTasksCard
         className=""
@@ -167,8 +155,6 @@ exports[`TasksCardsGrid render with props 1`] = `
       bsClass="col"
       componentClass="div"
       key="stopped"
-      lg={3}
-      sm={6}
     >
       <StoppedTasksCard
         className=""
@@ -202,8 +188,6 @@ exports[`TasksCardsGrid render with props 1`] = `
       bsClass="col"
       componentClass="div"
       key="scheduled"
-      lg={3}
-      sm={6}
     >
       <ScheduledTasksCard
         className=""

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
@@ -1,6 +1,26 @@
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/_variables';
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/_mixins';
+
+@mixin create-tasks-dashboard-column($columns: 12, $screen-min: 0, $gutter: $grid-gutter-width) {
+  @media (min-width: $screen-min) {
+    width: percentage(($columns / $grid-columns));
+    float: left;
+    position: relative;
+    min-height: 1px;
+    padding-right: ($gutter / 2);
+    padding-left: ($gutter / 2);
+  }
+}
+
 .tasks-dashboard-grid {
   min-height: 200px;
-  background-color: #F5F5F5;
+  background-color: #f5f5f5;
   margin: 5px -60px 20px -60px;
   padding: 20px 50px;
+
+  .row > div {
+    @include create-tasks-dashboard-column(12, 0);
+    @include create-tasks-dashboard-column(6, 900px);
+    @include create-tasks-dashboard-column(3, 1500px);
+  }
 }

--- a/webpack/stories/index.scss
+++ b/webpack/stories/index.scss
@@ -4,3 +4,4 @@ $icon-font-path: '~patternfly/dist/fonts/';
 
 @import '~patternfly/dist/sass/patternfly';
 @import '~patternfly-react/dist/sass/patternfly-react';
+@import '~font-awesome-sass/assets/stylesheets/_font-awesome';


### PR DESCRIPTION
The issue is that the cards aren't shown as they should when viewport width is 1200-1500.
Please note that in the storybook the grid is rendered inside an iframe, which causes the viewport to be only the grid container, but in foreman the viewport is the whole page.
So in foreman, when the screen is 1300px this is the view:
![image](https://user-images.githubusercontent.com/30431079/56468211-74f68980-6431-11e9-8d40-1966968bde71.png)
but in the storybook:
![image](https://user-images.githubusercontent.com/30431079/56468215-7b850100-6431-11e9-8590-96c274edb856.png)

Chose to break point of 1530px because on 1518px this is the stopped table :
![1518pxCARD](https://user-images.githubusercontent.com/30431079/56468217-92c3ee80-6431-11e9-9efb-8f13a8722332.png)
and in 1530px the icons are shown as intended:
![image](https://user-images.githubusercontent.com/30431079/56468240-e9c9c380-6431-11e9-98e1-1b904b61ea5d.png)
