### PR TITLE
Refs #26073 - fix params docs

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -156,13 +156,15 @@ module ForemanTasks
       end
 
       def_param_group :callback do
-        param_group :callback_target
+        param_group :callback_target, TasksController
         param :data, Hash, :desc => N_('Data to be sent to the action')
       end
 
       api :POST, '/tasks/callback', N_('Send data to the task from external executor (such as smart_proxy_dynflow)')
       param_group :callback
-      param :callbacks, Array, :of => param_group(:callback)
+      param :callbacks, Array do
+        param_group :callback, TasksController
+      end
       def callback
         callbacks = params.key?(:callback) ? Array(params) : params[:callbacks]
         ids = callbacks.map { |payload| payload[:callback][:task_id] }


### PR DESCRIPTION
Without this patch, the docs for callback says something like:

```
<p>Must be an array of [[:callback, Hash, nil,
{:param_group=&gt;{:scope=&gt;ForemanTasks::Api::TasksController,
:name=&gt;:callback_target, :options=&gt;{}, :from_concern=&gt;false}},
/.../foreman-tasks/app/controllers/foreman_tasks/api/
tasks_controller.rb:152&gt;],
[:data, Hash, {:desc=&gt;“Data to be sent to the action”},
{:param_group=&gt;nil}, nil], [:callback, Hash, nil,
{:param_group=&gt;{:scope=&gt;ForemanTasks::Api::TasksController,
```

Among others, this actually causes RPM packaging to fail, because
it leaks the buildroot path inside the output.