### PR TITLE
Fixes #26827 - Add name to menu divider

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -42,7 +42,7 @@ module ForemanTasks
     initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :"foreman-tasks" do
         requires_foreman '>= 1.16.0'
-        divider :top_menu, :parent => :monitor_menu, :last => true
+        divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
         menu :top_menu, :tasks,
              :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },
              :caption  => N_('Tasks'),


### PR DESCRIPTION
Otherwise, it will be filtered out and the tasks menu items will look
like they belong to the previous submenu.