### PR TITLE
Fixes #27091 - Skip missed scheduled tasks on server start

### DIFF
--- a/app/lib/actions/recurring_action.rb
+++ b/app/lib/actions/recurring_action.rb
@@ -17,7 +17,8 @@ module Actions
       if execution_plan.delay_record && recurring_logic_task_group
         args = execution_plan.delay_record.args
         logic = recurring_logic_task_group.recurring_logic
-        logic.trigger_repeat_after(task.start_at, self.class, *args)
+        task_start_at = [task.start_at, Time.zone.now].max
+        logic.trigger_repeat_after(task_start_at, self.class, *args)
       end
     ensure
       ::Logging.mdc['request'] = request_id


### PR DESCRIPTION
**Issue:**
Today if a recurring logic schedules a task and the server goes down leading to the start_at of the task being in the past, whenever the server comes up, the logic picks up from the past and steps to the present time. This results in running the task as many times as it skipped during server downtime.

We want to remove these extraneous runs as one run should be enough on startup to make up for all the lost runs and then schedule the next run as per the cron.
