### PR TITLE
Fixes #27292 - workaround for c3 destroy issue

### DIFF
--- a/webpack/ForemanTasks/Components/Chart/Chart.js
+++ b/webpack/ForemanTasks/Components/Chart/Chart.js
@@ -42,6 +42,8 @@ class C3Chart extends React.Component {
       // phase while unmounting/destroying - destroying right away leads
       // to issue described in https://github.com/bcbcarl/react-c3js/issues/22.
       // Delaying the destroy a bit seems to resolve the issue.
+      // The chart API methods are already bind explicitly, therefore we don't need
+      // any special handling when passing the function.
       setTimeout(this.chart.destroy, 1000);
       this.chart = null;
     } catch (err) {

--- a/webpack/ForemanTasks/Components/Chart/Chart.js
+++ b/webpack/ForemanTasks/Components/Chart/Chart.js
@@ -38,7 +38,12 @@ class C3Chart extends React.Component {
 
   destroyChart() {
     try {
-      this.chart = this.chart.destroy();
+      // A workaround for a case, where the chart might be still in transition
+      // phase while unmounting/destroying - destroying right away leads
+      // to issue described in https://github.com/bcbcarl/react-c3js/issues/22.
+      // Delaying the destroy a bit seems to resolve the issue.
+      setTimeout(this.chart.destroy, 1000);
+      this.chart = null;
     } catch (err) {
       throw new Error('Internal C3 error', err);
     }


### PR DESCRIPTION
There is a known issue in react-c3js that can lead to the charts to
disappear due to some race condition during component unmounting/destroy
phase https://github.com/bcbcarl/react-c3js/issues/22, with this error procuder
in the console log:

```
c3.js:9223 Uncaught TypeError: Cannot read property 'data_types' of null
    at ChartInternal.c3_chart_internal_fn.isPieType (c3.js:9223)
    at ChartInternal.c3_chart_internal_fn.isArcType (c3.js:9234)
    at ChartInternal.c3_chart_internal_fn.getArc (c3.js:4473)
    at c3.js:4816
    at SVGPathElement.<anonymous> (d3.js:8775)
    at Object.tick [as c] (d3.js:8956)
    at d3_timer_mark (d3.js:2166)
    at d3_timer_step (d3.js:2147)
```

Delaying the actual destroy a bit seems to help with workarounding the
issue.