### PR TITLE
Refs #26653 - add bootstrap-sass to npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
+    "bootstrap-sass": "^3.3.7",
     "classnames": "^2.2.5",
     "lodash": "^4.17.11",
     "patternfly-react": "^2.29.0",


### PR DESCRIPTION
in 0eacaf8587bf88986a675f4b5acecb93cc9b58f6 we started using variables
and mixins from bootstrap-sass, but didn't add it to our dependencies