### PR TITLE
Fixes #27386 - migrate to @theforeman/vendor pkg

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,11 +13,11 @@
     "transform-class-properties",
     "transform-object-rest-spread",
     "transform-object-assign",
-    "lodash",
     "syntax-dynamic-import"
   ],
   "env": {
     "test": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"],
       "plugins": [
         ["module-resolver", {
           "alias": {
@@ -27,6 +27,9 @@
         }],
         "dynamic-import-node"
       ]
+    },
+    "storybook": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"]
     }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "plugins": ["patternfly-react"],
-  "extends": ["plugin:patternfly-react/recommended"],
+  "extends": [
+    "plugin:patternfly-react/recommended",
+    "./node_modules/@theforeman/vendor-dev/eslint.extends.js"
+  ],
   "rules": {
     "prettier/prettier": ["error", {
       "singleQuote": true,
@@ -17,17 +20,5 @@
     "import/resolver": {
       "babel-module": {}
     }
-  },
-  "globals": {
-    "document": false,
-    "escape": false,
-    "navigator": false,
-    "unescape": false,
-    "window": false,
-    "$": true,
-    "_": true,
-    "__": true,
-    "n__": true,
-    "d3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,17 +21,20 @@
   "bugs": {
     "url": "http://projects.theforeman.org/projects/foreman-tasks/issues"
   },
+  "dependencies": {
+    "@theforeman/vendor": "^0.1.1"
+  },
   "devDependencies": {
     "@storybook/addon-actions": "^5.0.1",
     "@storybook/addon-knobs": "^5.0.1",
     "@storybook/react": "^5.0.1",
+    "@theforeman/vendor-dev": "^0.1.1",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-jest": "^23.6.0",
     "babel-loader": "^7.1.1",
     "babel-plugin-dynamic-import-node": "^2.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^3.2.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -60,26 +63,6 @@
     "stylelint": "^9.3.0",
     "stylelint-config-standard": "^18.0.0",
     "surge": "^0.20.3"
-  },
-  "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "bootstrap-sass": "^3.3.7",
-    "classnames": "^2.2.5",
-    "lodash": "^4.17.11",
-    "patternfly-react": "^2.29.0",
-    "prop-types": "^15.6.0",
-    "react": "^16.8.1",
-    "react-dom": "^16.8.1",
-    "react-redux": "^5.0.6",
-    "react-router": "^4.3.1",
-    "react-router-bootstrap": "^0.24.4",
-    "react-router-dom": "^4.3.1",
-    "redux": "^3.6.0",
-    "redux-thunk": "^2.3.0",
-    "reselect": "^3.0.1",
-    "seamless-immutable": "^7.1.2",
-    "urijs": "^1.19.1",
-    "uuid": "^3.3.2"
   },
   "jest": {
     "verbose": true,

--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksLabelsRow/TasksLabelsRow.scss
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksLabelsRow/TasksLabelsRow.scss
@@ -1,4 +1,4 @@
-@import '~patternfly/dist/sass/patternfly/_color-variables.scss';
+@import '~@theforeman/vendor/scss/variables';
 
 .tasks-labels-row {
   margin: 0;

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
@@ -1,5 +1,5 @@
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/_variables';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/_mixins';
+@import '~@theforeman/vendor/scss/variables';
+@import '~@theforeman/vendor/scss/mixins';
 
 @mixin create-tasks-dashboard-column($columns: 12, $screen-min: 0, $gutter: $grid-gutter-width) {
   @media (min-width: $screen-min) {


### PR DESCRIPTION
Migrate to use the new [@theforeman/vendor](https://github.com/theforeman/foreman-js/tree/master/packages/vendor) package from `npm`.

1. Don't forget to `rm -rf node_modules package-lock.json` and `npm i` before you test it.
2. The storybook is currently broken in master so don't expect it to work in this PR.

### What to test?

1. `npm run lint` should work properly with no errors.
2. `npm test` should work properly with no errors.
3. running foreman dev-server should work
4. We shouldn't notice any UI changes. especially in the scss file that changed.

Thanks