### PR TITLE
Fixes #27176 - adds subtask filter to tasks dashboard

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -37,6 +37,8 @@ module ForemanTasks
         parent_task = resource_scope.find(params[:id])
         filtered_scope = parent_task.sub_tasks
         action_name = { "action_name" => parent_task.action }
+
+        filtered_scope = DashboardTableFilter.new(filtered_scope, params).scope
         render :json => action_name.merge(tasks_list(filtered_scope))
       end
 
@@ -253,16 +255,16 @@ module ForemanTasks
         task_hash
       end
 
+      def resource_class
+        @resource_class ||= ForemanTasks::Task
+      end
+
       def find_task
         @task = resource_scope.find(params[:id])
       end
 
       def resource_scope(_options = {})
         @resource_scope ||= ForemanTasks::Task.authorized("#{action_permission}_foreman_tasks")
-      end
-
-      def resource_class
-        @resource_class ||= ForemanTasks::Task
       end
 
       def action_permission

--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -20,6 +20,11 @@ module ForemanTasks
       render json: Task::Summarizer.new(Task.where(:id => scope), params[:recent_timeframe].to_i).summary
     end
 
+    def summary_sub_tasks
+      filtered_scope = resource_base.find(params[:id]).sub_tasks
+      render :json => Task::Summarizer.new(filtered_scope, params[:recent_timeframe].to_i).summary
+    end
+
     def sub_tasks
       # @task is used when rendering breadcrumbs
       @task = resource_base.find(params[:id])
@@ -108,7 +113,7 @@ module ForemanTasks
 
     def action_permission
       case params[:action]
-      when 'sub_tasks', 'summary'
+      when 'sub_tasks', 'summary', 'summary_sub_tasks'
         :view
       when 'resume', 'unlock', 'force_unlock', 'cancel_step', 'cancel', 'abort'
         :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Foreman::Application.routes.draw do
       collection do
         get 'auto_complete_search'
         get '/summary/:recent_timeframe', action: 'summary'
+        get '/summary/:id/sub_tasks/:recent_timeframe', action: 'summary_sub_tasks'
       end
       member do
         post :abort
@@ -49,6 +50,7 @@ Foreman::Application.routes.draw do
           post :bulk_search
           post :bulk_resume
           get :summary
+          get '/summary/:id/sub_tasks/', action: 'summary_sub_tasks'
           post :callback
         end
       end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -56,9 +56,9 @@ module ForemanTasks
              :last     => true
 
         security_block :foreman_tasks do |_map|
-          permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :summary, :show],
+          permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :summary, :summary_sub_tasks, :show],
                                             :'foreman_tasks/react' => [:index],
-                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :details, :sub_tasks] }, :resource_type => ForemanTasks::Task.name
+                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :summary_sub_tasks, :details, :sub_tasks] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],
                                             :'foreman_tasks/api/tasks' => [:bulk_resume] }, :resource_type => ForemanTasks::Task.name
 

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.js
@@ -14,7 +14,12 @@ import './TasksDashboard.scss';
 
 class TasksDashboard extends React.Component {
   componentDidMount() {
-    const { time, initializeDashboard, fetchTasksSummary } = this.props;
+    const {
+      time,
+      initializeDashboard,
+      fetchTasksSummary,
+      parentTaskID,
+    } = this.props;
     const query = getQueryFromUrl();
 
     initializeDashboard({
@@ -24,15 +29,15 @@ class TasksDashboard extends React.Component {
 
     // dont fetch if time is going to be changed
     if (!query.time || query.time === time) {
-      fetchTasksSummary(time);
+      fetchTasksSummary(time, parentTaskID);
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { time, fetchTasksSummary } = this.props;
+    const { time, fetchTasksSummary, parentTaskID } = this.props;
 
     if (time !== prevProps.time) {
-      fetchTasksSummary(time);
+      fetchTasksSummary(time, parentTaskID);
     }
   }
 
@@ -65,6 +70,7 @@ TasksDashboard.propTypes = {
   updateQuery: PropTypes.func,
   fetchTasksSummary: PropTypes.func,
   history: PropTypes.object.isRequired,
+  parentTaskID: PropTypes.string,
 };
 
 TasksDashboard.defaultProps = {
@@ -75,6 +81,7 @@ TasksDashboard.defaultProps = {
   updateTime: noop,
   updateQuery: noop,
   fetchTasksSummary: noop,
+  parentTaskID: '',
 };
 
 export default TasksDashboard;

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardActions.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardActions.js
@@ -32,13 +32,15 @@ export const updateQuery = (query, history) => (dispatch, getState) => {
   });
 };
 
-export const fetchTasksSummary = time => async dispatch => {
+export const fetchTasksSummary = (time, parentTaskID) => async dispatch => {
   try {
     dispatch(startRequest());
 
     const hours = timeToHoursNumber(time);
-
-    const { data } = await API.get(`/foreman_tasks/tasks/summary/${hours}`);
+    const url = parentTaskID
+      ? `/foreman_tasks/tasks/summary/${parentTaskID}/sub_tasks/${hours}`
+      : `/foreman_tasks/tasks/summary/${hours}`;
+    const { data } = await API.get(url);
 
     return dispatch(requestSuccess(data));
   } catch (error) {

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TaskDashboard.fixtures.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TaskDashboard.fixtures.js
@@ -1,0 +1,93 @@
+export const correctTime = 'H24';
+export const wrongTime = 'H25';
+export const parentTaskID = 7;
+export const taskSummary = {
+  tasksSummary: {
+    running: {
+      recent: 0,
+      total: 3,
+    },
+    paused: {
+      recent: 0,
+      total: 54,
+    },
+    stopped: {
+      recent: 0,
+      total: 768,
+      by_result: {
+        success: {
+          recent: 0,
+          total: 532,
+        },
+        error: {
+          recent: 0,
+          total: 121,
+        },
+        warning: {
+          recent: 0,
+          total: 10,
+        },
+        cancelled: {
+          recent: 0,
+          total: 105,
+        },
+      },
+    },
+    scheduled: {
+      recent: 0,
+      total: 7,
+    },
+  },
+};
+
+export const subtaskSummary = {
+  tasksSummary: {
+    running: {
+      recent: 0,
+      total: 3,
+    },
+    paused: {
+      recent: 0,
+      total: 7,
+    },
+    stopped: {
+      recent: 0,
+      total: 0,
+      by_result: {
+        success: {
+          recent: 0,
+          total: 0,
+        },
+        error: {
+          recent: 0,
+          total: 0,
+        },
+        warning: {
+          recent: 0,
+          total: 0,
+        },
+        cancelled: {
+          recent: 0,
+          total: 0,
+        },
+      },
+    },
+    scheduled: {
+      recent: 0,
+      total: 7,
+    },
+  },
+};
+
+export const apiGetMock = async path => {
+  if (path === `/foreman_tasks/tasks/summary/${correctTime}`) {
+    return { data: taskSummary };
+  } else if (
+    path ===
+    `/foreman_tasks/tasks/summary/${parentTaskID}/sub_tasks/${correctTime}`
+  ) {
+    return { data: subtaskSummary };
+  }
+
+  throw new Error('wrong time');
+};

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardActions.test.js
@@ -7,21 +7,18 @@ import {
   updateQuery,
   fetchTasksSummary,
 } from '../TasksDashboardActions';
+import {
+  correctTime,
+  wrongTime,
+  parentTaskID,
+  apiGetMock,
+} from './TaskDashboard.fixtures';
 
 jest.mock('foremanReact/API');
 jest.mock('../TasksDashboardHelper');
 
-const correctTime = 'H24';
-const wrongTime = 'H25';
-
 timeToHoursNumber.mockImplementation(arg => arg);
-API.get.mockImplementation(async path => {
-  if (path === `/foreman_tasks/tasks/summary/${correctTime}`) {
-    return { data: 'some-data' };
-  }
-
-  throw new Error('wrong time');
-});
+API.get.mockImplementation(apiGetMock);
 
 const fixtures = {
   'should initialize-dashboard': () =>
@@ -30,6 +27,8 @@ const fixtures = {
   'should update-query': () => updateQuery('some-query'),
   'should fetch-tasks-summary and success': () =>
     fetchTasksSummary(correctTime),
+  'should fetch-tasks-summary for subtasks and success': () =>
+    fetchTasksSummary(correctTime, parentTaskID),
   'should fetch-tasks-summary and fail': () => fetchTasksSummary(wrongTime),
 };
 

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardSelectors.test.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardSelectors.test.js
@@ -7,36 +7,38 @@ import {
 } from '../TasksDashboardSelectors';
 
 const state = {
-  tasksDashboard: {
-    time: 'some-time',
-    query: 'some-query',
-    tasksSummary: {
-      running: {
-        recent: 3,
-        total: 8,
-      },
-      paused: {
-        recent: 2,
-        total: 9,
-      },
-      stopped: {
-        by_result: {
-          error: {
-            total: 9,
-            recent: 1,
-          },
-          warning: {
-            total: 8,
-            recent: 2,
-          },
-          success: {
-            total: 7,
-            recent: 3,
+  foremanTasks: {
+    tasksDashboard: {
+      time: 'some-time',
+      query: 'some-query',
+      tasksSummary: {
+        running: {
+          recent: 3,
+          total: 8,
+        },
+        paused: {
+          recent: 2,
+          total: 9,
+        },
+        stopped: {
+          by_result: {
+            error: {
+              total: 9,
+              recent: 1,
+            },
+            warning: {
+              total: 8,
+              recent: 2,
+            },
+            success: {
+              total: 7,
+              recent: 3,
+            },
           },
         },
-      },
-      scheduled: {
-        total: 6,
+        scheduled: {
+          total: 6,
+        },
       },
     },
   },

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/__snapshots__/TasksDashboardActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/__snapshots__/TasksDashboardActions.test.js.snap
@@ -25,7 +25,97 @@ Array [
   ],
   Array [
     Object {
-      "payload": "some-data",
+      "payload": Object {
+        "tasksSummary": Object {
+          "paused": Object {
+            "recent": 0,
+            "total": 54,
+          },
+          "running": Object {
+            "recent": 0,
+            "total": 3,
+          },
+          "scheduled": Object {
+            "recent": 0,
+            "total": 7,
+          },
+          "stopped": Object {
+            "by_result": Object {
+              "cancelled": Object {
+                "recent": 0,
+                "total": 105,
+              },
+              "error": Object {
+                "recent": 0,
+                "total": 121,
+              },
+              "success": Object {
+                "recent": 0,
+                "total": 532,
+              },
+              "warning": Object {
+                "recent": 0,
+                "total": 10,
+              },
+            },
+            "recent": 0,
+            "total": 768,
+          },
+        },
+      },
+      "type": "FOREMAN_TASKS_DASHBOARD_FETCH_TASKS_SUMMARY_SUCCESS",
+    },
+  ],
+]
+`;
+
+exports[`TasksDashboard - Actions should fetch-tasks-summary for subtasks and success 1`] = `
+Array [
+  Array [
+    Object {
+      "type": "FOREMAN_TASKS_DASHBOARD_FETCH_TASKS_SUMMARY_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "tasksSummary": Object {
+          "paused": Object {
+            "recent": 0,
+            "total": 7,
+          },
+          "running": Object {
+            "recent": 0,
+            "total": 3,
+          },
+          "scheduled": Object {
+            "recent": 0,
+            "total": 7,
+          },
+          "stopped": Object {
+            "by_result": Object {
+              "cancelled": Object {
+                "recent": 0,
+                "total": 0,
+              },
+              "error": Object {
+                "recent": 0,
+                "total": 0,
+              },
+              "success": Object {
+                "recent": 0,
+                "total": 0,
+              },
+              "warning": Object {
+                "recent": 0,
+                "total": 0,
+              },
+            },
+            "recent": 0,
+            "total": 0,
+          },
+        },
+      },
       "type": "FOREMAN_TASKS_DASHBOARD_FETCH_TASKS_SUMMARY_SUCCESS",
     },
   ],

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/__snapshots__/TasksDashboardSelectors.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/__snapshots__/TasksDashboardSelectors.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TasksDashboard - Selectors should select query 1`] = `"some-query"`;
+
+exports[`TasksDashboard - Selectors should select query when state is empty 1`] = `Object {}`;
+
+exports[`TasksDashboard - Selectors should select tasks-dashboard 1`] = `
+Object {
+  "query": "some-query",
+  "tasksSummary": Object {
+    "paused": Object {
+      "recent": 2,
+      "total": 9,
+    },
+    "running": Object {
+      "recent": 3,
+      "total": 8,
+    },
+    "scheduled": Object {
+      "total": 6,
+    },
+    "stopped": Object {
+      "by_result": Object {
+        "error": Object {
+          "recent": 1,
+          "total": 9,
+        },
+        "success": Object {
+          "recent": 3,
+          "total": 7,
+        },
+        "warning": Object {
+          "recent": 2,
+          "total": 8,
+        },
+      },
+    },
+  },
+  "time": "some-time",
+}
+`;
+
+exports[`TasksDashboard - Selectors should select tasks-dashboard when state is empty 1`] = `Object {}`;
+
+exports[`TasksDashboard - Selectors should select tasks-summary 1`] = `
+Object {
+  "paused": Object {
+    "last": 2,
+    "older": 7,
+  },
+  "running": Object {
+    "last": 3,
+    "older": 5,
+  },
+  "scheduled": 6,
+  "stopped": Object {
+    "error": Object {
+      "last": 1,
+      "total": 9,
+    },
+    "success": Object {
+      "last": 3,
+      "total": 7,
+    },
+    "warning": Object {
+      "last": 2,
+      "total": 8,
+    },
+  },
+}
+`;
+
+exports[`TasksDashboard - Selectors should select tasks-summary when state is empty 1`] = `
+Object {
+  "paused": Object {
+    "last": 0,
+    "older": 0,
+  },
+  "running": Object {
+    "last": 0,
+    "older": 0,
+  },
+  "scheduled": 0,
+  "stopped": Object {
+    "error": Object {
+      "last": 0,
+      "total": 0,
+    },
+    "success": Object {
+      "last": 0,
+      "total": 0,
+    },
+    "warning": Object {
+      "last": 0,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`TasksDashboard - Selectors should select time 1`] = `"some-time"`;
+
+exports[`TasksDashboard - Selectors should select time when state is empty 1`] = `"H24"`;

--- a/webpack/ForemanTasks/Components/TasksTable/SubTasksPage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/SubTasksPage.js
@@ -4,17 +4,24 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import TasksTablePage from './';
 
 export const SubTasksPage = props => {
+  const parentTaskID = props.match.params.id;
   const getBreadcrumbs = actionName => ({
     breadcrumbItems: [
       { caption: __('Tasks'), url: `/foreman_tasks/tasks` },
       {
         caption: actionName,
-        url: `/foreman_tasks/tasks/${props.match.params.id}`,
+        url: `/foreman_tasks/tasks/${parentTaskID}`,
       },
       { caption: __('Sub tasks') },
     ],
   });
-  return <TasksTablePage getBreadcrumbs={getBreadcrumbs} {...props} />;
+  return (
+    <TasksTablePage
+      getBreadcrumbs={getBreadcrumbs}
+      parentTaskID={parentTaskID}
+      {...props}
+    />
+  );
 };
 
 SubTasksPage.propTypes = {

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
@@ -24,6 +24,7 @@ const TasksTable = ({
   unselectAllRows,
   selectRow,
   unselectRow,
+  parentTaskID,
 }) => {
   const url = history.location.pathname + history.location.search;
   const uriQuery = getURIQuery(url);
@@ -82,10 +83,10 @@ const TasksTable = ({
 
   const taskActions = {
     cancel: (id, name) => {
-      cancelTask(id, name, url);
+      cancelTask(id, name, url, parentTaskID);
     },
     resume: (id, name) => {
-      resumeTask(id, name, url);
+      resumeTask(id, name, url, parentTaskID);
     },
   };
 
@@ -132,6 +133,7 @@ TasksTable.propTypes = {
   unselectAllRows: PropTypes.func.isRequired,
   selectRow: PropTypes.func.isRequired,
   unselectRow: PropTypes.func.isRequired,
+  parentTaskID: PropTypes.string,
 };
 
 TasksTable.defaultProps = {
@@ -142,6 +144,7 @@ TasksTable.defaultProps = {
     perPage: 20,
   },
   selectedRows: [],
+  parentTaskID: null,
 };
 
 export default TasksTable;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
@@ -19,10 +19,10 @@ import { fetchTasksSummary } from '../TasksDashboard/TasksDashboardActions';
 export const getTableItems = url =>
   getTableItemsAction(TASKS_TABLE_ID, getURIQuery(url), getApiPathname(url));
 
-export const cancelTask = (id, name, url) => async dispatch => {
+export const cancelTask = (id, name, url, parentTaskID) => async dispatch => {
   await dispatch(cancelTaskRequest(id, name));
   dispatch(getTableItems(url));
-  dispatch(fetchTasksSummary(getURIQuery(url).time));
+  dispatch(fetchTasksSummary(getURIQuery(url).time, parentTaskID));
 };
 
 export const cancelTaskRequest = (id, name) => async dispatch => {
@@ -50,10 +50,10 @@ export const cancelTaskRequest = (id, name) => async dispatch => {
   }
 };
 
-export const resumeTask = (id, name, url) => async dispatch => {
+export const resumeTask = (id, name, url, parentTaskID) => async dispatch => {
   await dispatch(resumeTaskRequest(id, name));
   dispatch(getTableItems(url));
-  dispatch(fetchTasksSummary(getURIQuery(url).time));
+  dispatch(fetchTasksSummary(getURIQuery(url).time), parentTaskID);
 };
 
 export const resumeTaskRequest = (id, name) => async dispatch => {

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -74,7 +74,9 @@ const TasksTablePage = ({ getBreadcrumbs, history, ...props }) => {
           </React.Fragment>
         }
         searchQuery={getURIsearch()}
-        beforeToolbarComponent={<TasksDashboard history={history} />}
+        beforeToolbarComponent={
+          <TasksDashboard history={history} parentTaskID={props.parentTaskID} />
+        }
       >
         <TasksTable history={history} {...props} />
       </PageLayout>
@@ -87,7 +89,6 @@ TasksTablePage.propTypes = {
   getTableItems: PropTypes.func.isRequired,
   getBreadcrumbs: PropTypes.func.isRequired,
   actionName: PropTypes.string,
-  isSubTask: PropTypes.bool,
   status: PropTypes.oneOf(Object.keys(STATUS)),
   history: PropTypes.object.isRequired,
   actionSelected: PropTypes.func.isRequired,
@@ -96,14 +97,15 @@ TasksTablePage.propTypes = {
   showCancelSelcetedModal: PropTypes.func.isRequired,
   hideSelcetedModal: PropTypes.func.isRequired,
   modalStatus: PropTypes.oneOf([CANCEL, RESUME, CLOSED]),
+  parentTaskID: PropTypes.string,
 };
 
 TasksTablePage.defaultProps = {
   actionName: '',
-  isSubTask: false,
   status: STATUS.PENDING,
   selectedRows: [],
   modalStatus: CLOSED,
+  parentTaskID: null,
 };
 
 export default TasksTablePage;

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
@@ -28,6 +28,7 @@ exports[`SubTasksPage rendering render with minimal props 1`] = `
       "perPage": 10,
     }
   }
+  parentTaskID="some-id"
   results={
     Array [
       "a",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
@@ -138,6 +138,7 @@ Array [
   ],
   Array [
     [Function],
+    undefined,
   ],
 ]
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -21,6 +21,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
             },
           }
         }
+        parentTaskID={null}
       />
     }
     breadcrumbOptions={
@@ -88,7 +89,6 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
           },
         }
       }
-      isSubTask={false}
       itemCount={2}
       modalStatus="CLOSED"
       pagination={
@@ -97,6 +97,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
           "perPage": 10,
         }
       }
+      parentTaskID={null}
       results={
         Array [
           "a",
@@ -144,6 +145,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
             },
           }
         }
+        parentTaskID={null}
       />
     }
     onSearch={[Function]}
@@ -194,7 +196,6 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
           },
         }
       }
-      isSubTask={false}
       itemCount={2}
       modalStatus="CLOSED"
       pagination={
@@ -203,6 +204,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
           "perPage": 10,
         }
       }
+      parentTaskID={null}
       results={
         Array [
           "a",


### PR DESCRIPTION
adds new paths to get the info about the summary of sub tasks to use in the tasks dashboard:
`/tasks/summary/:id/sub_tasks`, 
 `/summary/:id/sub_tasks/:recent_timeframe`
to the existing paths:
`/tasks/summary/`,  `/summary/:recent_timeframe`

based on: https://github.com/theforeman/foreman-tasks/pull/445