### PR TITLE
Fixes #27801 - Add cancel button to the tasks table

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -36,11 +36,10 @@ module ForemanTasks
     def cancel
       task = find_dynflow_task
       if task.cancel
-        flash[:info] = _('Trying to cancel the task')
+        render json: { statusText: 'OK' }
       else
-        flash[:warning] = _('The task cannot be cancelled at the moment.')
+        render json: {}, status: :bad_request
       end
-      redirect_back(:fallback_location => foreman_tasks_task_path(task))
     end
 
     def abort

--- a/app/views/foreman_tasks/api/tasks/show.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/show.json.rabl
@@ -3,3 +3,4 @@ object @task if @task
 attributes :id, :label, :pending, :action
 attributes :username, :started_at, :ended_at, :state, :result, :progress
 attributes :input, :output, :humanized, :cli_example
+node(:cancellable) { |t| t.execution_plan&.cancellable? }

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
@@ -4,6 +4,7 @@ import { Grid, Row, Col, Button } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import TaskInfo from './TaskInfo';
 import { ClickConfirmation } from '../../common/ClickConfirmation';
+import { Cancel } from '../../common/Cancel/Cancel';
 
 class Task extends Component {
   taskProgressToggle = () => {
@@ -37,6 +38,8 @@ class Task extends Component {
       showForceUnlockModal,
       toggleUnlockModal,
       toggleForceUnlockModal,
+      cancelTask,
+      action,
     } = this.props;
     const modalUnlock = (
       <ClickConfirmation
@@ -106,14 +109,17 @@ class Task extends Component {
               >
                 {__('Resume')}
               </Button>
-              <Button
-                bsSize="small"
-                data-method="post"
-                href={`/foreman_tasks/tasks/${id}/cancel`}
-                disabled={!cancellable}
-              >
-                {__('Cancel')}
-              </Button>
+              <Cancel
+                id={id}
+                name={action}
+                cancellable={cancellable}
+                cancelTaskAction={() => {
+                  if (!taskReload) {
+                    this.taskProgressToggle();
+                  }
+                  cancelTask(id, action);
+                }}
+              />
 
               {parentTask && (
                 <Button
@@ -177,6 +183,7 @@ Task.propTypes = {
   showForceUnlockModal: PropTypes.bool,
   toggleUnlockModal: PropTypes.func,
   toggleForceUnlockModal: PropTypes.func,
+  cancelTask: PropTypes.func,
 };
 
 Task.defaultProps = {
@@ -197,6 +204,7 @@ Task.defaultProps = {
   showForceUnlockModal: false,
   toggleUnlockModal: () => null,
   toggleForceUnlockModal: () => null,
+  cancelTask: () => null,
 };
 
 export default Task;

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
@@ -75,18 +75,12 @@ exports[`Task rendering render with some Props 1`] = `
         >
           Resume
         </Button>
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsSize="small"
-          bsStyle="default"
-          data-method="post"
-          disabled={true}
-          href="/foreman_tasks/tasks/test/cancel"
-        >
-          Cancel
-        </Button>
+        <Cancel
+          cancelTaskAction={[Function]}
+          cancellable={false}
+          id="test"
+          name=""
+        />
         <Button
           active={false}
           block={false}
@@ -125,6 +119,7 @@ exports[`Task rendering render with some Props 1`] = `
     <TaskInfo
       action=""
       allowDangerousActions={true}
+      cancelTask={[Function]}
       cancellable={false}
       endedAt=""
       error={Array []}
@@ -232,23 +227,18 @@ exports[`Task rendering render without Props 1`] = `
         >
           Resume
         </Button>
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsSize="small"
-          bsStyle="default"
-          data-method="post"
-          disabled={true}
-          href="/foreman_tasks/tasks/test/cancel"
-        >
-          Cancel
-        </Button>
+        <Cancel
+          cancelTaskAction={[Function]}
+          cancellable={false}
+          id="test"
+          name=""
+        />
       </Col>
     </Row>
     <TaskInfo
       action=""
       allowDangerousActions={false}
+      cancelTask={[Function]}
       cancellable={false}
       endedAt=""
       error={Array []}

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
@@ -12,6 +12,7 @@ import {
   FOREMAN_TASK_DETAILS_TOGGLE_UNLOCK_MODAL,
   FOREMAN_TASK_DETAILS_TOGGLE_FORCE_UNLOCK_MODAL,
 } from './TaskDetailsConstants';
+import { cancelTask } from '../TasksTable/TasksTableActions';
 
 export const taskReloadStop = timeoutId => {
   if (timeoutId) {
@@ -107,3 +108,5 @@ export const toggleUnlockModal = () => ({
 export const toggleForceUnlockModal = () => ({
   type: FOREMAN_TASK_DETAILS_TOGGLE_FORCE_UNLOCK_MODAL,
 });
+
+export { cancelTask };

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -58,7 +58,7 @@ export const selectLocks = state => selectTaskDetails(state).locks || [];
 export const selectUsernamePath = state =>
   selectTaskDetails(state).username_path || null;
 
-export const selectAction = state => selectTaskDetails(state).action || null;
+export const selectAction = state => selectTaskDetails(state).action || '';
 
 export const selectState = state => selectTaskDetails(state).state || null;
 

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
@@ -16,6 +16,7 @@ exports[`TaskDetails rendering render without Props 1`] = `
       <Task
         action=""
         allowDangerousActions={false}
+        cancelTask={[Function]}
         cancellable={false}
         endedAt=""
         error={Array []}

--- a/webpack/ForemanTasks/Components/TasksTable/TaskTableFormmatters.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TaskTableFormmatters.js
@@ -4,6 +4,7 @@ import { isoCompatibleDate } from 'foremanReact/common/helpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import { cellFormatter } from 'foremanReact/components/common/table';
+import { Cancel } from '../common/Cancel/Cancel';
 
 export const dateCellFormmatter = value => {
   if (value) {
@@ -30,4 +31,17 @@ export const actionCellFormatter = url => (value, { rowData: { id } }) =>
     <EllipsisWithTooltip>
       <a href={`/${url}/${id}`}>{value}</a>
     </EllipsisWithTooltip>
+  );
+
+export const cancelCellFormatter = cancelTaskAction => (
+  value,
+  { rowData: { action, id } }
+) =>
+  cellFormatter(
+    <Cancel
+      id={id}
+      name={action}
+      cancellable={value}
+      cancelTaskAction={cancelTaskAction}
+    />
   );

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
@@ -17,6 +17,7 @@ const TasksTable = ({
   history,
   itemCount,
   pagination,
+  cancelTaskAction,
 }) => {
   const url = history.location.pathname + history.location.search;
   const uriQuery = getURIQuery(url);
@@ -57,6 +58,10 @@ const TasksTable = ({
     updateURlQuery({ sort_by: by, sort_order: order }, history);
   };
 
+  const cancelTask = (id, name) => {
+    cancelTaskAction(id, name, url);
+  };
+
   return (
     <div className="tasks-table">
       <Table
@@ -64,7 +69,8 @@ const TasksTable = ({
         columns={createTasksTableSchema(
           setSortHistory,
           uriQuery.sort_by,
-          uriQuery.sort_order
+          uriQuery.sort_order,
+          cancelTask
         )}
         rows={results}
       />
@@ -83,6 +89,7 @@ const TasksTable = ({
 TasksTable.propTypes = {
   results: PropTypes.array.isRequired,
   getTableItems: PropTypes.func.isRequired,
+  cancelTaskAction: PropTypes.func.isRequired,
   status: PropTypes.oneOf(Object.keys(STATUS)),
   error: PropTypes.instanceOf(Error),
   itemCount: PropTypes.number.isRequired,

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
@@ -1,7 +1,42 @@
 import { getURIQuery } from 'foremanReact/common/helpers';
 import { getTableItemsAction } from 'foremanReact/components/common/table';
+import API from 'foremanReact/API';
+import { addToast } from 'foremanReact/redux/actions/toasts';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { TASKS_TABLE_ID } from './TasksTableConstants';
 import { getApiPathname } from './TasksTableHelpers';
+import { fetchTasksSummary } from '../TasksDashboard/TasksDashboardActions';
 
 export const getTableItems = url =>
   getTableItemsAction(TASKS_TABLE_ID, getURIQuery(url), getApiPathname(url));
+
+export const cancelTaskAction = (id, name, url) => async dispatch => {
+  await dispatch(cancelTask(id, name));
+  dispatch(getTableItems(url));
+  dispatch(fetchTasksSummary(getURIQuery(url).time));
+};
+
+export const cancelTask = (id, name) => async dispatch => {
+  dispatch(
+    addToast({
+      type: 'info',
+      message: `${__('Trying to cancel')} "${name}" ${__('task')}`,
+    })
+  );
+  try {
+    await API.post(`/foreman_tasks/tasks/${id}/cancel`);
+    dispatch(
+      addToast({
+        type: 'success',
+        message: `"${name}" ${__('task cancelled')}`,
+      })
+    );
+  } catch ({ response }) {
+    dispatch(
+      addToast({
+        type: 'error',
+        message: `"${name}" ${__('task cannot be cancelled at the moment.')}`,
+      })
+    );
+  }
+};

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -27,6 +27,7 @@ const TasksTablePage = ({ getBreadcrumbs, history, ...props }) => {
         searchProps={TASKS_SEARCH_PROPS}
         onSearch={onSearch}
         breadcrumbOptions={getBreadcrumbs(props.actionName)}
+        toastNotifications="foreman-tasks-cancel"
         toolbarButtons={
           <React.Fragment>
             {props.status === STATUS.PENDING && <Spinner size="lg" loading />}

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
@@ -8,6 +8,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import {
   dateCellFormmatter,
   actionCellFormatter,
+  cancelCellFormatter,
 } from './TaskTableFormmatters';
 
 const headFormat = [headerFormatterWithProps];
@@ -15,14 +16,15 @@ const cellFormat = [cellFormatter];
 
 /**
  * Generate a table schema to the Hardware Tasks page.
- * @param  {Function} setSort a Redux async action that sets new sort values
- * @param  {String}   by      by which column the table is sorted.
- *                            If none then set it to undefined/null.
- * @param  {String}   order   in what order to sort a column. If none then set it to undefined/null.
- *                            Otherwise, 'ASC' for ascending and 'DESC' for descending
+ * @param  {Function} setSort          a Redux async action that sets new sort values
+ * @param  {String}   by               by which column the table is sorted.
+ *                                     If none then set it to undefined/null.
+ * @param  {String}   order            in what order to sort a column. If none then set it to undefined/null.
+ *                                     Otherwise, 'ASC' for ascending and 'DESC' for descending
+ * @param  {function} cancelTaskAction A function to run when the cancel cell is clicked
  * @return {Array}
  */
-const createTasksTableSchema = (setSort, by, order) => {
+const createTasksTableSchema = (setSort, by, order, cancelTaskAction) => {
   const sortController = {
     apply: setSort,
     property: by,
@@ -49,9 +51,15 @@ const createTasksTableSchema = (setSort, by, order) => {
     sortableColumn('ended_at', __('Ended at'), 3, sortController, [
       dateCellFormmatter,
     ]),
-    column('username', __('User'), headFormat, cellFormat, {
-      className: 'col-md-2',
-    }),
+    column(
+      'cancellable',
+      'Cancel',
+      headFormat,
+      [cancelCellFormatter(cancelTaskAction)],
+      {
+        className: 'col-md-2',
+      }
+    ),
   ];
 };
 

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
@@ -4,6 +4,7 @@ export const minProps = {
   getTableItems: jest.fn(),
   getBreadcrumbs: jest.fn(),
   itemCount: 2,
+  cancelTaskAction: jest.fn(),
   pagination: {
     page: 1,
     perPage: 10,

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
@@ -1,12 +1,35 @@
+import { testActionSnapshotWithFixtures } from 'react-redux-test-utils';
+import API from 'foremanReact/API';
 import { TASKS_TABLE_ID } from '../TasksTableConstants';
-import { getTableItems } from '../TasksTableActions';
+import {
+  getTableItems,
+  cancelTaskAction,
+  cancelTask,
+} from '../TasksTableActions';
 
 jest.mock('foremanReact/components/common/table', () => ({
   getTableItemsAction: jest.fn(controller => controller),
 }));
 
+jest.mock('foremanReact/API');
+
+API.post.mockImplementation(() => ({ data: 'some-data' }));
+
+const fixtures = {
+  'should cancelTaskAction': () =>
+    cancelTaskAction('some-id', 'some-name', 'some-url'),
+  'should cancelTask and succeed': () =>
+    cancelTask('some-id', 'some-name', 'some-url'),
+  'should cancelTask and fail': () => {
+    API.post.mockImplementation(() =>
+      Promise.reject(new Error('Network Error'))
+    );
+    return cancelTask('some-id', 'some-name');
+  },
+};
 describe('TasksTable actions', () => {
   it('getTableItems should reuse common/table/getTableItemsAction', () => {
     expect(getTableItems('')).toEqual(TASKS_TABLE_ID);
   });
+  testActionSnapshotWithFixtures(fixtures);
 });

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`SubTasksPage rendering render with minimal props 1`] = `
 <Connect(TasksTablePage)
+  cancelTaskAction={[MockFunction]}
   getBreadcrumbs={[MockFunction]}
   getTableItems={[MockFunction]}
   history={

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TasksIndexPage rendering render with minimal props 1`] = `
 <Connect(TasksTablePage)
+  cancelTaskAction={[MockFunction]}
   getBreadcrumbs={[MockFunction]}
   getTableItems={[MockFunction]}
   history={

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TasksTable actions should cancelTask and fail 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Trying to cancel \\"some-name\\" task",
+          "type": "info",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "\\"some-name\\" task cannot be cancelled at the moment.",
+          "type": "error",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable actions should cancelTask and succeed 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Trying to cancel \\"some-name\\" task",
+          "type": "info",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "\\"some-name\\" task cancelled",
+          "type": "success",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable actions should cancelTaskAction 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    "TASKS_TABLE",
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -52,6 +52,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
     }
     searchQuery="a=b"
     searchable={true}
+    toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
         <ExportButton
@@ -62,6 +63,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
   >
     <TasksTable
       actionName=""
+      cancelTaskAction={[MockFunction]}
       error={null}
       getTableItems={[MockFunction]}
       history={
@@ -137,6 +139,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
     }
     searchQuery="a=b"
     searchable={true}
+    toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
         <ExportButton
@@ -147,6 +150,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
   >
     <TasksTable
       actionName=""
+      cancelTaskAction={[MockFunction]}
       error={null}
       getTableItems={[MockFunction]}
       history={

--- a/webpack/ForemanTasks/Components/common/Cancel/Cancel.js
+++ b/webpack/ForemanTasks/Components/common/Cancel/Cancel.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const Cancel = ({ id, name, cancellable, cancelTaskAction }) => (
+  <Button
+    bsSize="small"
+    onClick={() => cancelTaskAction(id, name)}
+    disabled={!cancellable}
+  >
+    {__('Cancel')}
+  </Button>
+);
+
+Cancel.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  cancellable: PropTypes.bool.isRequired,
+  cancelTaskAction: PropTypes.func.isRequired,
+};

--- a/webpack/ForemanTasks/Components/common/Cancel/Cancel.test.js
+++ b/webpack/ForemanTasks/Components/common/Cancel/Cancel.test.js
@@ -1,0 +1,20 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import { Cancel } from './Cancel';
+
+const fixtures = {
+  'render with cancellable true props': {
+    id: 'id',
+    name: 'some-name',
+    cancellable: true,
+    cancelTaskAction: jest.fn(),
+  },
+  'render with cancellable false props': {
+    id: 'id',
+    name: 'some-name',
+    cancellable: false,
+    cancelTaskAction: jest.fn(),
+  },
+};
+
+describe('Cancel', () => testComponentSnapshotsWithFixtures(Cancel, fixtures));

--- a/webpack/ForemanTasks/Components/common/Cancel/__snapshots__/Cancel.test.js.snap
+++ b/webpack/ForemanTasks/Components/common/Cancel/__snapshots__/Cancel.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cancel render with cancellable false props 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsSize="small"
+  bsStyle="default"
+  disabled={true}
+  onClick={[Function]}
+>
+  Cancel
+</Button>
+`;
+
+exports[`Cancel render with cancellable true props 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsSize="small"
+  bsStyle="default"
+  disabled={false}
+  onClick={[Function]}
+>
+  Cancel
+</Button>
+`;

--- a/webpack/__mocks__/foremanReact/redux/actions/toasts.js
+++ b/webpack/__mocks__/foremanReact/redux/actions/toasts.js
@@ -1,0 +1,8 @@
+export const addToast = toast => ({
+  type: 'TOASTS_ADD',
+  payload: {
+    message: toast,
+  },
+});
+
+export default addToast;


### PR DESCRIPTION
Adds a button that will cancel a task in the table (if the task can be canceled) and display a toast notification based on the answer
Based on: https://github.com/theforeman/foreman-tasks/pull/452