### PR TITLE
Fixes #27858 - Add bulk resume ui to tasks

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/Components/ActionSelectButton.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ActionSelectButton.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { DropdownButton, MenuItem } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const ActionSelectButton = ({ onCancel, onResume, disabled }) => (
+  <DropdownButton
+    title={__('Select Action')}
+    disabled={disabled}
+    id="selcted-action-type"
+  >
+    <MenuItem
+      title={__('Cancel selected tasks')}
+      onClick={onCancel}
+      eventKey="1"
+    >
+      {__('Cancel Selected')}
+    </MenuItem>
+    <MenuItem
+      title={__('Resume selected tasks')}
+      onClick={onResume}
+      eventKey="2"
+    >
+      {__('Resume Selected')}
+    </MenuItem>
+  </DropdownButton>
+);
+
+ActionSelectButton.propTypes = {
+  disabled: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onResume: PropTypes.func.isRequired,
+};
+
+ActionSelectButton.defaultProps = {
+  disabled: false,
+};

--- a/webpack/ForemanTasks/Components/TasksTable/Components/CancelResumeConfirm.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/CancelResumeConfirm.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
+import { ActionConfirmation } from './ActionConfirmation';
+import { CANCEL, RESUME, CLOSED } from '../TasksTableConstants';
+
+export const CancelResumeConfirm = ({
+  closeModal,
+  modalStatus,
+  action,
+  selected,
+  selectedRowsLen,
+}) => (
+  <ActionConfirmation
+    showModal={modalStatus !== CLOSED}
+    closeModal={closeModal}
+    title={`${modalStatus === CANCEL ? __('Cancel') : __('Resume')} ${__(
+      'Selected Tasks'
+    )}`}
+    message={sprintf(
+      __(
+        `This will ${
+          modalStatus === CANCEL ? 'stop' : 'resume'
+        } %s tasks, putting them in the ${
+          modalStatus === CANCEL ? 'canceled' : 'running'
+        } state.  Are you sure?`
+      ),
+      selectedRowsLen
+    )}
+    onClick={() => {
+      if (modalStatus === CANCEL) {
+        action(CANCEL, selected);
+      } else if (modalStatus === RESUME) {
+        action(RESUME, selected);
+      }
+      closeModal();
+    }}
+    confirmAction={__('Yes')}
+    abortAction={__('No')}
+  />
+);
+
+CancelResumeConfirm.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+  modalStatus: PropTypes.oneOf([CANCEL, RESUME, CLOSED]).isRequired,
+  selectedRowsLen: PropTypes.number.isRequired,
+  action: PropTypes.func.isRequired,
+  selected: PropTypes.array.isRequired,
+};
+
+export default CancelResumeConfirm;

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/ActionSelectButton.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/ActionSelectButton.test.js
@@ -1,0 +1,13 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import { ActionSelectButton } from '../ActionSelectButton';
+
+const fixtures = {
+  'renders with minimal props': {
+    onCancel: jest.fn(),
+    onResume: jest.fn(),
+  },
+};
+
+describe('ActionSelectButton', () =>
+  testComponentSnapshotsWithFixtures(ActionSelectButton, fixtures));

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/CancelResumeConfirm.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/CancelResumeConfirm.test.js
@@ -1,0 +1,28 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import { CancelResumeConfirm } from '../CancelResumeConfirm';
+import { CANCEL, RESUME, CLOSED } from '../../TasksTableConstants';
+
+const baseProps = {
+  closeModal: () => null,
+  selectedRowsLen: 3,
+  action: () => null,
+  selected: [1, 2, 3],
+};
+const fixtures = {
+  'renders CANCEL modal': {
+    ...baseProps,
+    modalStatus: CANCEL,
+  },
+  'renders RESUME modal': {
+    ...baseProps,
+    modalStatus: RESUME,
+  },
+  'renders CLOSED modal': {
+    ...baseProps,
+    modalStatus: CLOSED,
+  },
+};
+
+describe('CancelResumeConfirm', () =>
+  testComponentSnapshotsWithFixtures(CancelResumeConfirm, fixtures));

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/ActionSelectButton.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/ActionSelectButton.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionSelectButton renders with minimal props 1`] = `
+<DropdownButton
+  disabled={false}
+  id="selcted-action-type"
+  title="Select Action"
+>
+  <MenuItem
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    eventKey="1"
+    header={false}
+    onClick={[MockFunction]}
+    title="Cancel selected tasks"
+  >
+    Cancel Selected
+  </MenuItem>
+  <MenuItem
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    eventKey="2"
+    header={false}
+    onClick={[MockFunction]}
+    title="Resume selected tasks"
+  >
+    Resume Selected
+  </MenuItem>
+</DropdownButton>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/CancelResumeConfirm.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/CancelResumeConfirm.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CancelResumeConfirm renders CANCEL modal 1`] = `
+<ActionConfirmation
+  abortAction="No"
+  closeModal={[Function]}
+  confirmAction="Yes"
+  message="This will stop 3 tasks, putting them in the canceled state.  Are you sure?"
+  onClick={[Function]}
+  showModal={true}
+  title="Cancel Selected Tasks"
+/>
+`;
+
+exports[`CancelResumeConfirm renders CLOSED modal 1`] = `
+<ActionConfirmation
+  abortAction="No"
+  closeModal={[Function]}
+  confirmAction="Yes"
+  message="This will resume 3 tasks, putting them in the running state.  Are you sure?"
+  onClick={[Function]}
+  showModal={false}
+  title="Resume Selected Tasks"
+/>
+`;
+
+exports[`CancelResumeConfirm renders RESUME modal 1`] = `
+<ActionConfirmation
+  abortAction="No"
+  closeModal={[Function]}
+  confirmAction="Yes"
+  message="This will resume 3 tasks, putting them in the running state.  Are you sure?"
+  onClick={[Function]}
+  showModal={true}
+  title="Resume Selected Tasks"
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.scss
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.scss
@@ -1,0 +1,6 @@
+.tasks-pagination {
+  margin-top: -6px;
+}
+#tasks-table {
+  margin-bottom: 70px;
+}

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.scss
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.scss
@@ -1,6 +1,0 @@
-.tasks-pagination {
-  margin-top: -6px;
-}
-#tasks-table {
-  margin-bottom: 70px;
-}

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
@@ -8,9 +8,9 @@ export const TASKS_FAILURE = 'TASKS_FAILURE';
 export const SELECT_ROWS = 'SELECT_ROWS';
 export const UNSELECT_ROWS = 'UNSELECT_ROWS';
 export const UNSELECT_ALL_ROWS = 'UNSELECT_ALL_ROWS';
+export const CANCEL = 'CANCEL';
+export const RESUME = 'RESUME';
+export const CLOSED = 'CLOSED';
 
-export const TASKS_TABLE_SHOW_CANCEL_ALL_MODAL =
-  'TASKS_TABLE_SHOW_CANCEL_ALL_MODAL';
-export const TASKS_TABLE_HIDE_CANCEL_ALL_MODAL =
-  'TASKS_TABLE_HIDE_CANCEL_ALL_MODAL';
+export const TASKS_TABLE_SELECTED_MODAL = 'TASKS_TABLE_SELECTED_MODAL';
 export const TASKS_SEARCH_PROPS = getControllerSearchProps('tasks');

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
@@ -8,13 +8,13 @@ import {
   SELECT_ROWS,
   UNSELECT_ROWS,
   UNSELECT_ALL_ROWS,
-  TASKS_TABLE_SHOW_CANCEL_ALL_MODAL,
-  TASKS_TABLE_HIDE_CANCEL_ALL_MODAL,
+  TASKS_TABLE_SELECTED_MODAL,
+  CLOSED,
 } from './TasksTableConstants';
 
 const initialState = Immutable({
   selectedRows: [],
-  isCancelAllModalOpen: false,
+  modalStatus: CLOSED,
 });
 
 export const TasksTableQueryReducer = (state = initialState, action) => {
@@ -42,10 +42,8 @@ export const TasksTableQueryReducer = (state = initialState, action) => {
       );
     case UNSELECT_ALL_ROWS:
       return state.set('selectedRows', []);
-    case TASKS_TABLE_SHOW_CANCEL_ALL_MODAL:
-      return state.set('isCancelAllModalOpen', true);
-    case TASKS_TABLE_HIDE_CANCEL_ALL_MODAL:
-      return state.set('isCancelAllModalOpen', false);
+    case TASKS_TABLE_SELECTED_MODAL:
+      return state.set('modalStatus', payload);
     default:
       return state;
   }

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -1,6 +1,7 @@
 import { translate as __ } from 'foremanReact/common/I18n';
 import { selectForemanTasks } from '../../ForemanTasksSelectors';
 import { getDuration } from './TasksTableHelpers';
+import { CLOSED } from './TasksTableConstants';
 
 export const selectTasksTable = state =>
   selectForemanTasks(state).tasksTable || {};
@@ -23,8 +24,8 @@ export const selectActionName = state =>
 export const selectSelectedRows = state =>
   selectTasksTableQuery(state).selectedRows || [];
 
-export const selectIsCancelAllModalOpen = state =>
-  selectTasksTableQuery(state).isCancelAllModalOpen || false;
+export const selectModalStatus = state =>
+  selectTasksTableQuery(state).modalStatus || CLOSED;
 
 export const selectResults = state => {
   const { results } = selectTasksTableContent(state);

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
@@ -6,7 +6,7 @@ export const minProps = {
   itemCount: 2,
   cancelTask: jest.fn(),
   resumeTask: jest.fn(),
-  cancelSelected: jest.fn(),
+  actionSelected: jest.fn(),
   selectAllRows: jest.fn(),
   unselectAllRows: jest.fn(),
   selectRow: jest.fn(),
@@ -23,9 +23,9 @@ export const minProps = {
     by: 'q',
     order: 'w',
   },
-  isCancelAllModalOpen: false,
-  showCancelAllModal: jest.fn(),
-  hideCancelAllModal: jest.fn(),
+  showResumeSelcetedModal: jest.fn(),
+  showCancelSelcetedModal: jest.fn(),
+  hideSelcetedModal: jest.fn(),
 };
 
 export default {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
@@ -1,12 +1,13 @@
 import { testActionSnapshotWithFixtures } from 'react-redux-test-utils';
 import API from 'foremanReact/API';
-import { TASKS_TABLE_ID } from '../TasksTableConstants';
+import { TASKS_TABLE_ID, CANCEL, RESUME } from '../TasksTableConstants';
 import {
   getTableItems,
   cancelTask,
   cancelTaskRequest,
   resumeTask,
   resumeTaskRequest,
+  actionSelected,
 } from '../TasksTableActions';
 
 jest.mock('foremanReact/components/common/table', () => ({
@@ -38,6 +39,50 @@ const fixtures = {
       Promise.reject(new Error('Network Error'))
     );
     return resumeTaskRequest('some-id', 'some-name', 'some-url');
+  },
+  'should actionSelected CANCEL not cancelleble': () => {
+    const selected = [
+      {
+        id: '',
+        name: '',
+        isResumeble: false,
+        isCancelleble: false,
+      },
+    ];
+    return actionSelected(CANCEL, selected, 'some-url');
+  },
+  'should actionSelected CANCEL cancelleble': () => {
+    const selected = [
+      {
+        id: '',
+        name: '',
+        isResumeble: false,
+        isCancelleble: true,
+      },
+    ];
+    return actionSelected(CANCEL, selected, 'some-url');
+  },
+  'should actionSelected RESUME not resumable': () => {
+    const selected = [
+      {
+        id: '',
+        name: '',
+        isResumeble: false,
+        isCancelleble: false,
+      },
+    ];
+    return actionSelected(RESUME, selected, 'some-url');
+  },
+  'should actionSelected RESUME resumable': () => {
+    const selected = [
+      {
+        id: '',
+        name: '',
+        isResumeble: true,
+        isCancelleble: false,
+      },
+    ];
+    return actionSelected(RESUME, selected, 'some-url');
   },
 };
 describe('TasksTable actions', () => {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableReducer.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableReducer.test.js
@@ -6,8 +6,8 @@ import {
   SELECT_ROWS,
   UNSELECT_ROWS,
   UNSELECT_ALL_ROWS,
-  TASKS_TABLE_SHOW_CANCEL_ALL_MODAL,
-  TASKS_TABLE_HIDE_CANCEL_ALL_MODAL,
+  TASKS_TABLE_SELECTED_MODAL,
+  RESUME,
 } from '../TasksTableConstants';
 import reducer from '../TasksTableReducer';
 
@@ -53,14 +53,10 @@ const fixtures = {
       type: UNSELECT_ALL_ROWS,
     },
   },
-  'should handle TASKS_TABLE_SHOW_CANCEL_ALL_MODAL': {
+  'should handle TASKS_TABLE_SELECTED_MODAL': {
     action: {
-      type: TASKS_TABLE_SHOW_CANCEL_ALL_MODAL,
-    },
-  },
-  'should handle TASKS_TABLE_HIDE_CANCEL_ALL_MODAL': {
-    action: {
-      type: TASKS_TABLE_HIDE_CANCEL_ALL_MODAL,
+      type: TASKS_TABLE_SELECTED_MODAL,
+      payload: RESUME,
     },
   },
 };

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`SubTasksPage rendering render with minimal props 1`] = `
 <Connect(TasksTablePage)
-  cancelSelected={[MockFunction]}
+  actionSelected={[MockFunction]}
   cancelTask={[MockFunction]}
   getBreadcrumbs={[MockFunction]}
   getTableItems={[MockFunction]}
-  hideCancelAllModal={[MockFunction]}
+  hideSelcetedModal={[MockFunction]}
   history={
     Object {
       "location": Object {
@@ -14,7 +14,6 @@ exports[`SubTasksPage rendering render with minimal props 1`] = `
       },
     }
   }
-  isCancelAllModalOpen={false}
   itemCount={2}
   match={
     Object {
@@ -39,7 +38,8 @@ exports[`SubTasksPage rendering render with minimal props 1`] = `
   selectAllRows={[MockFunction]}
   selectRow={[MockFunction]}
   selectedRows={Array []}
-  showCancelAllModal={[MockFunction]}
+  showCancelSelcetedModal={[MockFunction]}
+  showResumeSelcetedModal={[MockFunction]}
   sort={
     Object {
       "by": "q",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`TasksIndexPage rendering render with minimal props 1`] = `
 <Connect(TasksTablePage)
-  cancelSelected={[MockFunction]}
+  actionSelected={[MockFunction]}
   cancelTask={[MockFunction]}
   getBreadcrumbs={[MockFunction]}
   getTableItems={[MockFunction]}
-  hideCancelAllModal={[MockFunction]}
+  hideSelcetedModal={[MockFunction]}
   history={
     Object {
       "location": Object {
@@ -14,7 +14,6 @@ exports[`TasksIndexPage rendering render with minimal props 1`] = `
       },
     }
   }
-  isCancelAllModalOpen={false}
   itemCount={2}
   pagination={
     Object {
@@ -32,7 +31,8 @@ exports[`TasksIndexPage rendering render with minimal props 1`] = `
   selectAllRows={[MockFunction]}
   selectRow={[MockFunction]}
   selectedRows={Array []}
-  showCancelAllModal={[MockFunction]}
+  showCancelSelcetedModal={[MockFunction]}
+  showResumeSelcetedModal={[MockFunction]}
   sort={
     Object {
       "by": "q",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableActions.test.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TasksTable actions should actionSelected CANCEL cancelleble 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    "TASKS_TABLE",
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`TasksTable actions should actionSelected CANCEL not cancelleble 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Not all the selected tasks can be canceled",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable actions should actionSelected RESUME not resumable 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Not all the selected tasks can be resumed",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable actions should actionSelected RESUME resumable 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    "TASKS_TABLE",
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`TasksTable actions should cancelTask 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    "TASKS_TABLE",
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;
+
 exports[`TasksTable actions should cancelTaskRequest and fail 1`] = `
 Array [
   Array [
@@ -54,7 +128,7 @@ Array [
 ]
 `;
 
-exports[`TasksTable actions should cancelTask 1`] = `
+exports[`TasksTable actions should resumeTask 1`] = `
 Array [
   Array [
     [Function],
@@ -96,20 +170,6 @@ Array [
       },
       "type": "TOASTS_ADD",
     },
-  ],
-]
-`;
-
-exports[`TasksTable actions should resumeTask 1`] = `
-Array [
-  Array [
-    [Function],
-  ],
-  Array [
-    "TASKS_TABLE",
-  ],
-  Array [
-    [Function],
   ],
 ]
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -4,14 +4,12 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
 <div
   className="tasks-table-wrapper"
 >
-  <ActionConfirmation
-    abortAction="No"
+  <CancelResumeConfirm
+    action={[Function]}
     closeModal={[MockFunction]}
-    confirmAction="Yes"
-    message="This will stop 0 tasks, putting them in the \\"canceled\\" state.  Are you sure?"
-    onClick={[Function]}
-    showModal={false}
-    title="Cancel Selected Tasks"
+    modalStatus="CLOSED"
+    selected={Array []}
+    selectedRowsLen={0}
   />
   <PageLayout
     beforeToolbarComponent={
@@ -68,26 +66,21 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
           title="Export All"
           url="/foreman_tasks/tasks.csv?include_permissions=true"
         />
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="default"
+        <ActionSelectButton
           disabled={true}
-          onClick={[MockFunction]}
-        >
-          Cancel Selected
-        </Button>
+          onCancel={[MockFunction]}
+          onResume={[MockFunction]}
+        />
       </React.Fragment>
     }
   >
     <TasksTable
       actionName=""
-      cancelSelected={[MockFunction]}
+      actionSelected={[MockFunction]}
       cancelTask={[MockFunction]}
       error={null}
       getTableItems={[MockFunction]}
-      hideCancelAllModal={[MockFunction]}
+      hideSelcetedModal={[MockFunction]}
       history={
         Object {
           "location": Object {
@@ -95,9 +88,9 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
           },
         }
       }
-      isCancelAllModalOpen={false}
       isSubTask={false}
       itemCount={2}
+      modalStatus="CLOSED"
       pagination={
         Object {
           "page": 1,
@@ -114,7 +107,8 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
       selectAllRows={[MockFunction]}
       selectRow={[MockFunction]}
       selectedRows={Array []}
-      showCancelAllModal={[MockFunction]}
+      showCancelSelcetedModal={[MockFunction]}
+      showResumeSelcetedModal={[MockFunction]}
       sort={
         Object {
           "by": "q",
@@ -133,14 +127,12 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
 <div
   className="tasks-table-wrapper"
 >
-  <ActionConfirmation
-    abortAction="No"
+  <CancelResumeConfirm
+    action={[Function]}
     closeModal={[MockFunction]}
-    confirmAction="Yes"
-    message="This will stop 0 tasks, putting them in the \\"canceled\\" state.  Are you sure?"
-    onClick={[Function]}
-    showModal={false}
-    title="Cancel Selected Tasks"
+    modalStatus="CLOSED"
+    selected={Array []}
+    selectedRowsLen={0}
   />
   <PageLayout
     beforeToolbarComponent={
@@ -180,26 +172,21 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
           title="Export All"
           url="/foreman_tasks/tasks.csv?include_permissions=true"
         />
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="default"
+        <ActionSelectButton
           disabled={true}
-          onClick={[MockFunction]}
-        >
-          Cancel Selected
-        </Button>
+          onCancel={[MockFunction]}
+          onResume={[MockFunction]}
+        />
       </React.Fragment>
     }
   >
     <TasksTable
       actionName=""
-      cancelSelected={[MockFunction]}
+      actionSelected={[MockFunction]}
       cancelTask={[MockFunction]}
       error={null}
       getTableItems={[MockFunction]}
-      hideCancelAllModal={[MockFunction]}
+      hideSelcetedModal={[MockFunction]}
       history={
         Object {
           "location": Object {
@@ -207,9 +194,9 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
           },
         }
       }
-      isCancelAllModalOpen={false}
       isSubTask={false}
       itemCount={2}
+      modalStatus="CLOSED"
       pagination={
         Object {
           "page": 1,
@@ -226,7 +213,8 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
       selectAllRows={[MockFunction]}
       selectRow={[MockFunction]}
       selectedRows={Array []}
-      showCancelAllModal={[MockFunction]}
+      showCancelSelcetedModal={[MockFunction]}
+      showResumeSelcetedModal={[MockFunction]}
       sort={
         Object {
           "by": "q",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableReducer.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableReducer.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TasksTableReducer reducer should handle SELECT_ROWS 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [
       1,
       2,
@@ -17,10 +17,10 @@ Object {
 }
 `;
 
-exports[`TasksTableReducer reducer should handle TASKS_TABLE_HIDE_CANCEL_ALL_MODAL 1`] = `
+exports[`TasksTableReducer reducer should handle TASKS_TABLE_SELECTED_MODAL 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "RESUME",
     "selectedRows": Array [],
   },
 }
@@ -29,7 +29,7 @@ Object {
 exports[`TasksTableReducer reducer should handle TASKS_TABLE_SET_PAGINATION 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [],
   },
 }
@@ -38,16 +38,7 @@ Object {
 exports[`TasksTableReducer reducer should handle TASKS_TABLE_SET_SORT 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
-    "selectedRows": Array [],
-  },
-}
-`;
-
-exports[`TasksTableReducer reducer should handle TASKS_TABLE_SHOW_CANCEL_ALL_MODAL 1`] = `
-Object {
-  "tasksTableQuery": Object {
-    "isCancelAllModalOpen": true,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [],
   },
 }
@@ -57,8 +48,8 @@ exports[`TasksTableReducer reducer should handle TASKS_TABLE_SUCCESS 1`] = `
 Object {
   "tasksTableQuery": Object {
     "actionName": undefined,
-    "isCancelAllModalOpen": false,
     "itemCount": 120,
+    "modalStatus": "CLOSED",
     "pagination": Object {
       "page": 3,
       "perPage": 12,
@@ -71,7 +62,7 @@ Object {
 exports[`TasksTableReducer reducer should handle UNSELECT_ALL_ROWS 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [],
   },
 }
@@ -80,7 +71,7 @@ Object {
 exports[`TasksTableReducer reducer should handle UNSELECT_ROWS 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [],
   },
 }
@@ -89,7 +80,7 @@ Object {
 exports[`TasksTableReducer reducer should return the initial state 1`] = `
 Object {
   "tasksTableQuery": Object {
-    "isCancelAllModalOpen": false,
+    "modalStatus": "CLOSED",
     "selectedRows": Array [],
   },
 }

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionCellFormatter.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actionCellFormatter render 1`] = `
+<ActionButton
+  availableActions={
+    Object {
+      "cancellable": true,
+    }
+  }
+  id="some-id"
+  name="some-name"
+  taskActions={Object {}}
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionNameCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionNameCellFormatter.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actionNameCellFormatter render 1`] = `
+<a
+  href="/some-url/some-id"
+>
+  action-name
+</a>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/dateCellFormmatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/dateCellFormmatter.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dateCellFormmatter render 1`] = `
+<LongDateTime
+  date="some-value"
+  defaultValue="N/A"
+  seconds={true}
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/durationCellFormmatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/durationCellFormmatter.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`durationCellFormmatter render with tooltip 1`] = `
+<span
+  className="param-value"
+  title="some-tooltip"
+>
+  some-value
+</span>
+`;
+
+exports[`durationCellFormmatter render without tooltip 1`] = `
+<span
+  className="param-value"
+>
+  some-value
+</span>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionCellFormatter.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selectionCellFormatter render 1`] = `
+<TableSelectionCell
+  checked={true}
+  id="selectsome-index"
+  label="Select row"
+  onChange={[Function]}
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionHeaderCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionHeaderCellFormatter.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selectionHeaderCellFormatter render 1`] = `
+<TableSelectionHeaderCell
+  checked={true}
+  id="selectAll"
+  label="some-label"
+  onChange={[Function]}
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionCellFormatter.test.js
@@ -1,0 +1,11 @@
+import { actionCellFormatter } from '../actionCellFormatter';
+
+describe('actionCellFormatter', () => {
+  it('render', () => {
+    const data = [
+      { cancellable: true },
+      { rowData: { action: 'some-name', id: 'some-id' } },
+    ];
+    expect(actionCellFormatter({})(...data)).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionNameCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionNameCellFormatter.test.js
@@ -1,0 +1,8 @@
+import { actionNameCellFormatter } from '../actionNameCellFormatter';
+
+describe('actionNameCellFormatter', () => {
+  it('render', () => {
+    const data = ['action-name', { rowData: { id: 'some-id' } }];
+    expect(actionNameCellFormatter('some-url')(...data)).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/dateCellFormmatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/dateCellFormmatter.test.js
@@ -1,0 +1,7 @@
+import { dateCellFormmatter } from '../dateCellFormmatter';
+
+describe('dateCellFormmatter', () => {
+  it('render', () => {
+    expect(dateCellFormmatter('some-value')).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/durationCellFormmatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/durationCellFormmatter.test.js
@@ -1,0 +1,12 @@
+import { durationCellFormmatter } from '../durationCellFormmatter';
+
+describe('durationCellFormmatter', () => {
+  it('render with tooltip', () => {
+    expect(
+      durationCellFormmatter({ text: 'some-value', tooltip: 'some-tooltip' })
+    ).toMatchSnapshot();
+  });
+  it('render without tooltip', () => {
+    expect(durationCellFormmatter({ text: 'some-value' })).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionCellFormatter.test.js
@@ -1,0 +1,12 @@
+import selectionCellFormatter from '../selectionCellFormatter';
+
+describe('selectionCellFormatter', () => {
+  it('render', () => {
+    expect(
+      selectionCellFormatter(
+        { isSelected: () => true },
+        { rowIndex: 'some-index' }
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionHeaderCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionHeaderCellFormatter.test.js
@@ -1,0 +1,12 @@
+import selectionHeaderCellFormatter from '../selectionHeaderCellFormatter';
+
+describe('selectionHeaderCellFormatter', () => {
+  it('render', () => {
+    expect(
+      selectionHeaderCellFormatter(
+        { allRowsSelected: () => true },
+        'some-label'
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/index.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/index.js
@@ -1,6 +1,4 @@
-export {
-  default as selectionHeaderCellFormatter,
-} from './selectionHeaderCellFormatter';
+export { default as selectionHeaderCellFormatter } from './selectionHeaderCellFormatter';
 export { default as selectionCellFormatter } from './selectionCellFormatter';
 
 export { actionNameCellFormatter } from './actionNameCellFormatter';

--- a/webpack/ForemanTasks/Components/TasksTable/index.js
+++ b/webpack/ForemanTasks/Components/TasksTable/index.js
@@ -12,7 +12,7 @@ import {
   selectSort,
   selectActionName,
   selectSelectedRows,
-  selectIsCancelAllModalOpen,
+  selectModalStatus,
 } from './TasksTableSelectors';
 
 const mapStateToProps = state => ({
@@ -24,7 +24,7 @@ const mapStateToProps = state => ({
   itemCount: selectItemCount(state),
   actionName: selectActionName(state),
   selectedRows: selectSelectedRows(state),
-  isCancelAllModalOpen: selectIsCancelAllModalOpen(state),
+  modalStatus: selectModalStatus(state),
 });
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 

--- a/webpack/__mocks__/foremanReact/components/common/table.js
+++ b/webpack/__mocks__/foremanReact/components/common/table.js
@@ -2,3 +2,4 @@ import React from 'react';
 
 export const Table = () => <div className="table" />;
 export const createTableReducer = jest.fn(controller => controller);
+export const cellFormatter = cell => cell;


### PR DESCRIPTION
Select the tasks you want to resume/cancel by using select boxes in the table and choose the action with the 'select action' button drop down
If one of the selected tasks is not cancelable/resumable that task will not be attempted to be canceled/resumed.
Select all button will select only the tasks in the page