### PR TITLE
Add a duration column to the tasks table

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -237,6 +237,7 @@ module ForemanTasks
       def ordering_scope(scope, ordering_params)
         sort_by = ordering_params[:sort_by] || 'started_at'
         sort_order = ordering_params[:sort_order] || 'DESC'
+        scope = scope.select("*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration")
         scope.order("#{sort_by} #{sort_order}")
       end
 

--- a/webpack/ForemanTasks/Components/TasksTable/TaskTableFormmatters.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TaskTableFormmatters.js
@@ -45,3 +45,9 @@ export const actionCellFormatter = taskActions => (
       name={action}
     />
   );
+
+export const durationCellFormmatter = value => (
+  <span className="param-value" title={value.tooltip}>
+    {value.text}
+  </span>
+);

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableHelpers.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableHelpers.js
@@ -1,4 +1,7 @@
 import URI from 'urijs';
+import { translate as __, documentLocale } from 'foremanReact/common/I18n';
+import humanizeDuration from 'humanize-duration';
+import { isoCompatibleDate } from 'foremanReact/common/helpers';
 
 export const updateURlQuery = (query, history) => {
   const uri = new URI(history.location.pathname + history.location.search);
@@ -23,4 +26,39 @@ export const addSearchToURL = (path, query) => {
   const url = new URI(path);
   url.addSearch({ ...query, include_permissions: true });
   return url.toString();
+};
+
+export const getDuration = (start, finish) => {
+  if (!start && !finish)
+    return { text: __('N/A'), tooltip: __('No start or end dates') };
+
+  if (!start && finish) {
+    return { text: __('N/A'), tooltip: __('Task was canceled') };
+  }
+
+  const dateOptions = {
+    largest: 1,
+    language: documentLocale(),
+    fallbacks: ['en'],
+    round: true,
+  };
+
+  const startDate = new Date(isoCompatibleDate(start));
+
+  if (!finish) {
+    const finishDate = new Date();
+    const duration = finishDate - startDate;
+    return {
+      text: `${__('More than')} ${humanizeDuration(duration, dateOptions)}`,
+    };
+  }
+
+  const finishDate = new Date(isoCompatibleDate(finish));
+  const duration = finishDate - startDate;
+  return {
+    text:
+      duration > 0 && duration < 1000
+        ? __('Less than a second')
+        : humanizeDuration(duration, dateOptions),
+  };
 };

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
@@ -9,6 +9,7 @@ import {
   dateCellFormmatter,
   actionCellFormatter,
   actionNameCellFormatter,
+  durationCellFormmatter,
 } from './TaskTableFormmatters';
 
 const headFormat = [headerFormatterWithProps];
@@ -48,8 +49,8 @@ const createTasksTableSchema = (setSort, by, order, taskActions) => {
     sortableColumn('started_at', __('Started at'), 3, sortController, [
       dateCellFormmatter,
     ]),
-    sortableColumn('ended_at', __('Ended at'), 3, sortController, [
-      dateCellFormmatter,
+    sortableColumn('duration', __('Duration'), 3, sortController, [
+      durationCellFormmatter,
     ]),
     column(
       'available_actions',

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -1,5 +1,6 @@
 import { translate as __ } from 'foremanReact/common/I18n';
 import { selectForemanTasks } from '../../ForemanTasksSelectors';
+import { getDuration } from './TasksTableHelpers';
 
 export const selectTasksTable = state =>
   selectForemanTasks(state).tasksTable || {};
@@ -26,6 +27,7 @@ export const selectResults = state => {
     ...result,
     username: result.username || '',
     state: result.state + (result.frozen ? ` ${__('Disabled')}` : ''),
+    duration: getDuration(result.started_at, result.ended_at),
   }));
 };
 

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableHelpers.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableHelpers.test.js
@@ -1,4 +1,4 @@
-import { updateURlQuery } from '../TasksTableHelpers';
+import { updateURlQuery, getDuration } from '../TasksTableHelpers';
 
 describe('updateURlQuery', () => {
   it('should use url with new query', () => {
@@ -14,5 +14,15 @@ describe('updateURlQuery', () => {
     const newURL =
       '?state=stopped&result=error&page=1&per_page=35&time_mode=recent';
     expect(history.push).toBeCalledWith(newURL);
+  });
+  it('getDuration should work', () => {
+    const duration = getDuration('1/1/2000 11:00', '1/1/2000 11:25');
+    expect(duration.text).toEqual('25 minutes');
+    expect(duration.tooltip).toEqual(undefined);
+  });
+  it('getDuration should work without start date', () => {
+    const duration = getDuration('', '1/1/2000 11:25');
+    expect(duration.text).toEqual('N/A');
+    expect(duration.tooltip).toEqual('Task was canceled');
   });
 });


### PR DESCRIPTION
The duration column replaces ended at column.
Duration text is in the same format as in task details.
For running tasks the duration is presented with a + (2 minutes +)
For Canceled tasks duration is presented as N\A with a tool tip that says that the task is canceled
For tasks without a start and end time, duration is presented as N\A with a tool tip about it
For sorting purposes N\A is the shortest time.
