### PR TITLE
Fixes #27991 - Decreasing precision in Task Progress

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -29,7 +29,9 @@ export const selectErrors = state => {
 };
 
 export const selectProgress = state =>
-  selectTaskDetails(state).progress * 100 || 0;
+  selectTaskDetails(state).progress
+    ? selectTaskDetails(state).progress.toFixed(4) * 100
+    : 0;
 
 export const selectUsername = state =>
   selectTaskDetails(state).username || null;


### PR DESCRIPTION
This PR changes the precision of the individual task progress. The progress bar is accompanied by a numeric value as "n% Complete". (i.e.: 10.06661732050331% Complete). Reduced the precision from 14 to 2.
