### PR TITLE
Fixes #28152 - Link tasks with user only if the user exists

### DIFF
--- a/db/migrate/20180927120509_add_user_id.foreman_tasks.rb
+++ b/db/migrate/20180927120509_add_user_id.foreman_tasks.rb
@@ -5,8 +5,10 @@ class AddUserId < ActiveRecord::Migration[5.0]
     return if User.unscoped.find_by(:login => User::ANONYMOUS_ADMIN).nil?
     User.as_anonymous_admin do
       user_locks.select(:resource_id).distinct.pluck(:resource_id).each do |owner_id|
-        tasks = ForemanTasks::Task.joins(:locks).where(:locks => user_locks.where(:resource_id => owner_id))
-        tasks.update_all(:user_id => owner_id)
+        if User.exists?(:id => owner_id)
+          tasks = ForemanTasks::Task.joins(:locks).where(:locks => user_locks.where(:resource_id => owner_id))
+          tasks.update_all(:user_id => owner_id)
+        end
         user_locks.where(:resource_id => owner_id).delete_all
       end
     end


### PR DESCRIPTION
Commit 2f37f56957260facecdb278fffaa1b2bd7f94eb0 changed the way how we link
tasks to users. Before we used locks, but we didn't have any constraints in
place. This could lead to a situation, where a task has a lock, which links the
task to a user, which doesn't exist anymore. If we tried to perform the
migration introduced in that commit, it would fail with foreign key violation
errors.