### PR TITLE
Fixes #28306 - use label as fallback for tasks action name

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -32,6 +32,7 @@ export const selectResults = state => {
   if (!results) return [];
   return results.map(result => ({
     ...result,
+    action: result.action || result.label.replace(/::/g, ' '),
     username: result.username || '',
     state: result.state + (result.frozen ? ` ${__('Disabled')}` : ''),
     duration: getDuration(result.started_at, result.ended_at),


### PR DESCRIPTION
uses label as fallback for tasks action name
and replaces '::' in the label so if the name is too long the name will be in a few lines instead of being on top of the next cell