### PR TITLE
Fixes #28415 - Fix PG::AmbiguousColumn error on tasks search

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -240,7 +240,7 @@ module ForemanTasks
         sort_by = ordering_params[:sort_by] || 'started_at'
         sort_order = ordering_params[:sort_order] || 'DESC'
         scope = scope.select("*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration")
-        scope.order("#{sort_by} #{sort_order}")
+        scope.order(sort_by => sort_order)
       end
 
       def task_hash(task)

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -11,6 +11,24 @@ module ForemanTasks
         @request.env['CONTENT_TYPE'] = 'application/json'
       end
 
+      describe 'GET /api/tasks' do
+        it 'lists all tasks with default sorting' do
+          FactoryBot.create_list(:dynflow_task, 5, :user_create_task)
+          get :index
+          assert_response :success
+          data = JSON.parse(response.body)
+          _(data['results'].count).must_equal 5
+        end
+
+        it 'supports searching' do
+          FactoryBot.create_list(:dynflow_task, 5, :user_create_task)
+          get :index, params: { :search => 'label = Actions::User::Create' }
+          assert_response :success
+          data = JSON.parse(response.body)
+          _(data['results'].count).must_equal 5
+        end
+      end
+
       describe 'GET /api/tasks/show' do
         it 'searches for task' do
           task = FactoryBot.create(:dynflow_task, :user_create_task)


### PR DESCRIPTION
The original error was
```
'Action failed' error (ActiveRecord::StatementInvalid): PG::AmbiguousColumn:
ERROR: ORDER BY "started_at" is ambiguous | LINE 1: ...,4))
```