### PR TITLE
Fixes #28485 - Fix PG::AmbiguousColumn error on tasks search

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -238,9 +238,10 @@ module ForemanTasks
 
       def ordering_scope(scope, ordering_params)
         sort_by = ordering_params[:sort_by] || 'started_at'
+        sort_by = 'foreman_tasks_tasks.' + sort_by if sort_by == 'started_at'
         sort_order = ordering_params[:sort_order] || 'DESC'
         scope = scope.select("*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration")
-        scope.order(sort_by => sort_order)
+        scope.order("#{sort_by} #{sort_order}")
       end
 
       def task_hash(task)

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -12,8 +12,8 @@ module ForemanTasks
       end
 
       describe 'GET /api/tasks' do
+        before { FactoryBot.create_list(:dynflow_task, 5, :user_create_task) }
         it 'lists all tasks with default sorting' do
-          FactoryBot.create_list(:dynflow_task, 5, :user_create_task)
           get :index
           assert_response :success
           data = JSON.parse(response.body)
@@ -21,10 +21,17 @@ module ForemanTasks
         end
 
         it 'supports searching' do
-          FactoryBot.create_list(:dynflow_task, 5, :user_create_task)
           get :index, params: { :search => 'label = Actions::User::Create' }
           assert_response :success
           data = JSON.parse(response.body)
+          _(data['results'].count).must_equal 5
+        end
+
+        it 'supports ordering by duration' do
+          get :index, params: { :sort_by => 'duration' }
+          assert_response :success
+          data = JSON.parse(response.body)
+          _(data.dig('sort', 'by')).must_equal 'duration'
           _(data['results'].count).must_equal 5
         end
       end


### PR DESCRIPTION
The original error was
PG::UndefinedColumn: ERROR: column foreman_tasks_tasks.duration does not exist |
LINE 1: ...) as duration FROM "foreman_tasks_tasks"