### PR TITLE
Fixes #28095 - Make concurrency control work with batch triggering

### DIFF
--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -41,16 +41,7 @@ module Actions
       with_connection_error_handling(event) do |event|
         case event
         when nil
-          if remote_task
-            if remote_task.state == 'external'
-              trigger_remote_task
-            else
-              on_resume
-            end
-          else
-            trigger_proxy_task
-          end
-          suspend
+          start_or_resume
         when ::Dynflow::Action::Skip
           # do nothing
         when ::Dynflow::Action::Cancellable::Cancel
@@ -214,6 +205,19 @@ module Actions
     end
 
     private
+
+    def start_or_resume
+      if remote_task
+        if remote_task.state == 'external'
+          trigger_remote_task
+        else
+          on_resume
+        end
+      else
+        trigger_proxy_task
+      end
+      suspend
+    end
 
     def proxy_version(proxy)
       match = proxy.statuses[:version].version['version'].match(/(\d+)\.(\d+)\.(\d+)/)

--- a/app/models/foreman_tasks/remote_task.rb
+++ b/app/models/foreman_tasks/remote_task.rb
@@ -9,6 +9,7 @@ module ForemanTasks
 
     scope :triggered, -> { where(:state => 'triggered') }
     scope :pending,   -> { where(:state => 'new') }
+    scope :external,  -> { where(:state => 'external') }
 
     delegate :proxy_action_name, :to => :action
 


### PR DESCRIPTION
Having both concurrency control and batch triggering enabled led to various issues with tasks being triggered at wrong time. This was caused by introduction of Remote Tasks and their triggering using a middleware.

This change makes sure the two mechanisms will not conflict with each other. If use_concurrency_control is passed to the proxy action, the remote tasks are created in 'external' state, meaning the batch triggering mechanism should ignore them. This allows the concurrency control to work properly.