### PR TITLE
Fixes #28623 - fix table reducer action structure

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
@@ -18,9 +18,9 @@ const initialState = Immutable({
 });
 
 export const TasksTableQueryReducer = (state = initialState, action) => {
-  const { type, payload } = action;
+  const { type, payload, response } = action;
   const { subtotal, page, per_page: perPageString, action_name: actionName } =
-    payload || {};
+    response || {};
   const ACTION_TYPES = createTableActionTypes(TASKS_TABLE_ID);
   switch (type) {
     case ACTION_TYPES.SUCCESS:

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableReducer.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableReducer.test.js
@@ -16,7 +16,7 @@ const fixtures = {
   'should handle TASKS_TABLE_SUCCESS': {
     action: {
       type: `${TASKS_TABLE_ID}_SUCCESS`,
-      payload: {
+      response: {
         subtotal: 120,
         page: 3,
         per_page: 12,


### PR DESCRIPTION
After Foreman updated the API middleware structure,
we forgot to update the foreman-tasks table that uses it.