### PR TITLE
Fixes #28634 - adjusts select for nulls ids

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -240,7 +240,7 @@ module ForemanTasks
         sort_by = ordering_params[:sort_by] || 'started_at'
         sort_by = 'foreman_tasks_tasks.' + sort_by if sort_by == 'started_at'
         sort_order = ordering_params[:sort_order] || 'DESC'
-        scope = scope.select("*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration")
+        scope = scope.select("foreman_tasks_tasks.*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration")
         scope.order("#{sort_by} #{sort_order}")
       end
 

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -27,6 +27,15 @@ module ForemanTasks
           _(data['results'].count).must_equal 5
         end
 
+        it 'renders task ids when searching by resource id' do
+          task = FactoryBot.create(:dynflow_task, :product_create_task)
+          ForemanTasks::Lock.create!(name: "create", resource_type: "Katello::Product", resource_id: 1, task_id: task.id)
+          get :index, params: { :search => "label = Actions::Katello::Product::Create and resource_id = 1" }
+          assert_response :success
+          data = JSON.parse(response.body)
+          _(data['results'].first["id"]).must_equal task.id
+        end
+
         it 'supports ordering by duration' do
           get :index, params: { :sort_by => 'duration' }
           assert_response :success


### PR DESCRIPTION
This PR modifies a `'select` in the `ordering_scope` method, as previously the results would return NULLs for each task id. This was an issue for the monitor task list display, as the links generated for each task would be incorrect.