### PR TITLE
Fixes #28666 - adds support vendor v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.7.0",
     "@theforeman/builder": "^4.0.2",
     "@theforeman/stories": "^4.0.2",
+    "@theforeman/test": "^4.0.2",
     "@theforeman/vendor-dev": "^4.0.2",
     "babel-eslint": "^10.0.3",
     "eslint": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,18 @@
   "bugs": {
     "url": "http://projects.theforeman.org/projects/foreman-tasks/issues"
   },
+  "peerDependencies": {
+    "@theforeman/vendor": ">= 4.0.2"
+  },
   "dependencies": {
-    "@theforeman/vendor": "^4.0.2",
     "c3": "^0.4.11",
     "humanize-duration": "^3.20.1",
     "react-intl": "^2.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/test": "^4.0.2",
     "@theforeman/builder": "^4.0.2",
+    "@theforeman/stories": "^4.0.2",
     "@theforeman/vendor-dev": "^4.0.2",
     "babel-eslint": "^10.0.3",
     "eslint": "^4.10.0",
@@ -38,7 +40,6 @@
     "eslint-plugin-patternfly-react": "0.2.0",
     "identity-obj-proxy": "^3.0.0",
     "jed": "^1.1.1",
-    "patternfly": "^3.58.0",
     "prettier": "^1.13.5",
     "react-remarkable": "^1.1.3",
     "stylelint": "^9.3.0",


### PR DESCRIPTION
1. It won't download `vendor` anymore
2. It will support version 3 and 4