### PR TITLE
Fixes #28748 - task id fallback when there is no label

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -32,7 +32,9 @@ export const selectResults = createSelector(
   ({ results }) =>
     results.map(result => ({
       ...result,
-      action: result.action || result.label.replace(/::/g, ' '),
+      action:
+        result.action ||
+        (result.label ? result.label.replace(/::/g, ' ') : result.id),
       username: result.username || '',
       state: result.state + (result.frozen ? ` ${__('Disabled')}` : ''),
       duration: getDuration(result.started_at, result.ended_at),


### PR DESCRIPTION
When result.label the page would crash as it can run the `replace` function on it.
Users still need something to click on in the table to get to the task so I added the result.id as a fallback if there is no label and no action