### PR TITLE
Fixes #28822 - task Search requires clicking twice on Search

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -27,7 +27,6 @@ const TasksTablePage = ({ getBreadcrumbs, history, clicked, ...props }) => {
   const uriQuery = getURIQuery(url);
   const onSearch = searchQuery => {
     resolveSearchQuery(searchQuery, history);
-    props.getTableItems(url);
   };
 
   const getSelectedTasks = () => {


### PR DESCRIPTION
The url got updated and then the get tasks api was called twice - once with the right url and once with the old url.
So on the second click the old url was already the new url so when it was called twice it was called with the right info