### PR TITLE
Fixes #20042 - add a clear button to recurring logics

### DIFF
--- a/app/controllers/foreman_tasks/recurring_logics_controller.rb
+++ b/app/controllers/foreman_tasks/recurring_logics_controller.rb
@@ -22,6 +22,12 @@ module ForemanTasks
       redirect_to :action => :index
     end
 
+    def clear_cancelled
+      scope = resource_base.search_for('state=cancelled')
+      scope.destroy_all
+      redirect_to :action => :index
+    end
+
     def controller_name
       'foreman_tasks_recurring_logics'
     end
@@ -48,6 +54,15 @@ module ForemanTasks
     def filter(scope)
       scope.search_for(params[:search])
            .paginate(:page => params[:page], :per_page => params[:per_page])
+    end
+
+    def action_permission
+      case params[:action]
+      when 'clear_cancelled'
+        'edit'
+      else
+        super
+      end
     end
   end
 end

--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -14,6 +14,7 @@ module ForemanTasks
     scoped_search :on => :max_iteration, :complete_value => false, :rename => :iteration_limit
     scoped_search :on => :iteration, :complete_value => false
     scoped_search :on => :cron_line, :complete_value => true
+    scoped_search :on => :state, :complete_value => true
 
     before_create do
       task_group.save

--- a/app/views/foreman_tasks/recurring_logics/index.html.erb
+++ b/app/views/foreman_tasks/recurring_logics/index.html.erb
@@ -5,6 +5,36 @@
 <%= alert(:class => 'alert-info', :id => 'multiple-alert', :close => false, :header => '', :text => @errors) %>
 <% end %>
 
+<% if authorized_for(:permission => :edit_recurring_logics, :auth_object => @recurring_logics) %>
+  <% title_actions link_to(_('Clear Cancelled'),
+              clear_cancelled_foreman_tasks_recurring_logics_path,
+              class:  ['btn', 'btn-sm', 'btn-danger'],                  
+              :'data-toggle' => "modal",
+              :'data-target' => "#clear_modal") 
+              %>
+
+  <div class="modal fade" id="clear_modal" tabindex="-1" role="dialog" aria-labelledby="Deploy" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <h2 class="modal-title" id="deploy_modal_label">
+            <span class="glyphicon glyphicon-warning-sign"></span>
+            <%= _("Clear Cancelled") %>
+          </h2>
+        </div>
+        <div class="modal-body">
+          <%= _("This action will delete all cancelled recurring logics. Please note that this action can't be reversed.") %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= _("Cancel") %></button>
+          <%= link_to(_('Clear Cancelled'), clear_cancelled_foreman_tasks_recurring_logics_path, method: :post, class: 'btn btn-danger modal-submit') %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <table class="<%= table_css_classes('table-condensed table-fixed') %>">
   <thead>
     <th><%= N_("Cron line") %></th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Foreman::Application.routes.draw do
         put :enable
         put :disable
       end
+      collection do
+        post :clear_cancelled
+      end
     end
 
     resources :tasks, :only => [:show] do

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -60,7 +60,7 @@ module ForemanTasks
           permission :view_recurring_logics, { :'foreman_tasks/recurring_logics' => [:index, :show],
                                                :'foreman_tasks/api/recurring_logics' => [:index, :show] }, :resource_type => ForemanTasks::RecurringLogic.name
 
-          permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel, :enable, :disable],
+          permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel, :enable, :disable, :clear_cancelled],
                                                :'foreman_tasks/api/recurring_logics' => [:cancel, :update] }, :resource_type => ForemanTasks::RecurringLogic.name
         end
 


### PR DESCRIPTION
In the index of recurring logics there should be a button to clear cancelled recurring logics
![image](https://user-images.githubusercontent.com/30431079/73610225-c4333280-45dd-11ea-9ede-1ada90fa3858.png)
