### PR TITLE
Fixes #28933 - add api to delete recurring logics

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Foreman::Application.routes.draw do
         member do
           post :cancel
         end
+        collection do
+          post :bulk_destroy
+        end
       end
 
       resources :tasks, :only => [:show, :index] do

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -61,7 +61,7 @@ module ForemanTasks
                                                :'foreman_tasks/api/recurring_logics' => [:index, :show] }, :resource_type => ForemanTasks::RecurringLogic.name
 
           permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel, :enable, :disable, :clear_cancelled],
-                                               :'foreman_tasks/api/recurring_logics' => [:cancel, :update] }, :resource_type => ForemanTasks::RecurringLogic.name
+                                               :'foreman_tasks/api/recurring_logics' => [:cancel, :update, :bulk_destroy] }, :resource_type => ForemanTasks::RecurringLogic.name
         end
 
         add_all_permissions_to_default_roles


### PR DESCRIPTION
recurring logics by search query, to prevent accidental removal of all the recurring logics the search is required.
 