### PR TITLE
Fixes #29045 - HTML tags visible on paused task page

### DIFF
--- a/app/helpers/foreman_tasks/foreman_tasks_helper.rb
+++ b/app/helpers/foreman_tasks/foreman_tasks_helper.rb
@@ -28,7 +28,7 @@ module ForemanTasks
     def troubleshooting_info_text
       return if @task.state != 'paused' || @task.main_action.nil?
       helper = TroubleshootingHelpGenerator.new(@task.main_action)
-      helper.generate_text
+      helper.generate_html
     end
 
     def username_link_task(owner, username)

--- a/app/services/foreman_tasks/troubleshooting_help_generator.rb
+++ b/app/services/foreman_tasks/troubleshooting_help_generator.rb
@@ -44,10 +44,6 @@ module ForemanTasks
       # rubocop:enable Rails/OutputSafety
     end
 
-    def generate_text
-      (description + link_descriptions_html).join("\n")
-    end
-
     def link_descriptions_html
       links.map do |link|
         link.description % { link: %(<a href="%{href}">%{title}</a>) % link.to_h }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "c3": "^0.4.11",
     "humanize-duration": "^3.20.1",
+    "react-html-parser": "^2.0.2",
     "react-intl": "^2.8.0"
   },
   "devDependencies": {

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/TaskInfo.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/TaskInfo.js
@@ -4,6 +4,7 @@ import { Grid, Row, Col, ProgressBar } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import ReactHtmlParser from 'react-html-parser';
 
 class TaskInfo extends Component {
   isDelayed = () => {
@@ -173,14 +174,7 @@ class TaskInfo extends Component {
                   <b>{__('Troubleshooting')}</b>
                 </span>
               </p>
-              <p>
-                {help.split('\n').map((item, i) => (
-                  <React.Fragment key={i}>
-                    {item}
-                    <br />
-                  </React.Fragment>
-                ))}
-              </p>
+              <p>{ReactHtmlParser(help)}</p>
             </Col>
           </Row>
         )}


### PR DESCRIPTION
adds the `react-html-parser` library that "Converts HTML strings directly into React components avoiding the need to use dangerouslySetInnerHTML"
and uses it for the troubleshooting 