### PR TITLE
Fixes #29203 - Fix an edge case with excessive progress precision

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -30,7 +30,7 @@ export const selectErrors = state => {
 
 export const selectProgress = state =>
   selectTaskDetails(state).progress
-    ? selectTaskDetails(state).progress.toFixed(4) * 100
+    ? parseFloat((selectTaskDetails(state).progress * 100).toFixed(2))
     : 0;
 
 export const selectUsername = state =>


### PR DESCRIPTION
Before this patch we took a float in the range from 0 to 1, turned it into a
string with desired precision and then multiplied it with 100 to get the
percentage. However, this didn't really work for all inputs, because of the well
known issues when multiplying floats.

```javascript
> x = 0.004545454545454546
0.004545454545454546

// Old way
> x.toFixed(4) * 100
0.44999999999999996

// New way
> parseFloat((x * 100).toFixed(2))
0.45
```