### PR TITLE
Fixes #29030 - dynflow console button is no longer disabled

### DIFF
--- a/app/views/foreman_tasks/api/tasks/details.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/details.json.rabl
@@ -16,3 +16,4 @@ node(:locks) do
   end
 end
 node(:username_path) { username_link_task(@task.owner, @task.username) }
+node(:dynflow_enable_console ) { Setting['dynflow_enable_console'] }

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
@@ -42,6 +42,7 @@ class Task extends Component {
       cancelTaskRequest,
       resumeTaskRequest,
       action,
+      dynflowEnableConsole,
     } = this.props;
     const modalUnlock = (
       <ClickConfirmation
@@ -99,6 +100,7 @@ class Task extends Component {
               <Button
                 bsSize="small"
                 href={`/foreman_tasks/dynflow/${externalId}`}
+                disabled={!dynflowEnableConsole}
               >
                 {__('Dynflow console')}
               </Button>
@@ -188,6 +190,7 @@ Task.propTypes = {
   toggleForceUnlockModal: PropTypes.func,
   cancelTaskRequest: PropTypes.func,
   resumeTaskRequest: PropTypes.func,
+  dynflowEnableConsole: PropTypes.bool,
 };
 
 Task.defaultProps = {
@@ -210,6 +213,7 @@ Task.defaultProps = {
   toggleForceUnlockModal: () => null,
   cancelTaskRequest: () => null,
   resumeTaskRequest: () => null,
+  dynflowEnableConsole: false,
 };
 
 export default Task;

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/Task.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/Task.test.js
@@ -9,6 +9,7 @@ const fixtures = {
     state: 'paused',
     hasSubTasks: true,
     allowDangerousActions: true,
+    dynflowEnableConsole: true,
   },
 };
 

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
@@ -115,6 +115,7 @@ exports[`Task rendering render with some Props 1`] = `
       allowDangerousActions={true}
       cancelTaskRequest={[Function]}
       cancellable={false}
+      dynflowEnableConsole={true}
       endedAt=""
       error={Array []}
       externalId=""
@@ -205,7 +206,7 @@ exports[`Task rendering render without Props 1`] = `
           bsClass="btn"
           bsSize="small"
           bsStyle="default"
-          disabled={false}
+          disabled={true}
           href="/foreman_tasks/dynflow/"
         >
           Dynflow console
@@ -229,6 +230,7 @@ exports[`Task rendering render without Props 1`] = `
       allowDangerousActions={false}
       cancelTaskRequest={[Function]}
       cancellable={false}
+      dynflowEnableConsole={false}
       endedAt=""
       error={Array []}
       externalId=""

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -83,3 +83,6 @@ export const selectShowForceUnlockModal = state =>
 
 export const selectExternalId = state =>
   selectTaskDetails(state).external_id || null;
+
+export const selectDynflowEnableConsole = state =>
+  selectTaskDetails(state).dynflow_enable_console || false;

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
@@ -18,6 +18,7 @@ exports[`TaskDetails rendering render without Props 1`] = `
         allowDangerousActions={false}
         cancelTaskRequest={[Function]}
         cancellable={false}
+        dynflowEnableConsole={false}
         endedAt=""
         error={Array []}
         executionPlan={Object {}}

--- a/webpack/ForemanTasks/Components/TaskDetails/index.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/index.js
@@ -33,6 +33,7 @@ import {
   selectShowUnlockModal,
   selectShowForceUnlockModal,
   selectExternalId,
+  selectDynflowEnableConsole,
 } from './TaskDetailsSelectors';
 
 const mapStateToProps = state => ({
@@ -65,6 +66,7 @@ const mapStateToProps = state => ({
   showUnlockModal: selectShowUnlockModal(state),
   showForceUnlockModal: selectShowForceUnlockModal(state),
   externalId: selectExternalId(state),
+  dynflowEnableConsole: selectDynflowEnableConsole(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
@@ -5,6 +5,7 @@ exports[`SubTasksPage rendering render with minimal props 1`] = `
   bulkCancel={[MockFunction]}
   bulkResume={[MockFunction]}
   cancelTask={[MockFunction]}
+  createHeader={[Function]}
   getBreadcrumbs={[MockFunction]}
   getTableItems={[MockFunction]}
   history={

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -69,6 +69,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
         ],
       }
     }
+    header="Tasks"
     onSearch={[Function]}
     searchProps={
       Object {
@@ -226,6 +227,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
         parentTaskID={null}
       />
     }
+    header="Tasks"
     onSearch={[Function]}
     searchProps={
       Object {


### PR DESCRIPTION
Now rails sends the `dynflow_enable_console` info to react.
fixes the snapshots for the new prop and also for the header PR