### PR TITLE
Fixes #28246 - Create bulk cancel api

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Foreman::Application.routes.draw do
         collection do
           post :bulk_search
           post :bulk_resume
+          post :bulk_cancel
           get :summary
           get '/summary/:id/sub_tasks/', action: 'summary_sub_tasks'
           post :callback

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -53,7 +53,7 @@ module ForemanTasks
                                             :'foreman_tasks/react' => [:index],
                                             :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :summary_sub_tasks, :details, :sub_tasks] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],
-                                            :'foreman_tasks/api/tasks' => [:bulk_resume] }, :resource_type => ForemanTasks::Task.name
+                                            :'foreman_tasks/api/tasks' => [:bulk_resume, :bulk_cancel] }, :resource_type => ForemanTasks::Task.name
 
           permission :create_recurring_logics, {}, :resource_type => ForemanTasks::RecurringLogic.name
 


### PR DESCRIPTION
Adds a way to bulk cancel tasks using a query or an array of ids.
Return information about canceled tasks and failed to cancel tasks