### PR TITLE
Fixes #29415 - Ansible job failed when disabling batch triggering

### DIFF
--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -67,7 +67,7 @@ module Actions
     def trigger_proxy_task
       suspend do |_suspended_action|
         remote_task = prepare_remote_task
-        remote_task.trigger(proxy_action_name, proxy_input)
+        ForemanTasks::RemoteTask.batch_trigger(remote_task.operation, [remote_task])
         output[:proxy_task_id] = remote_task.remote_task_id
       end
     end

--- a/test/foreman_tasks_test_helper.rb
+++ b/test/foreman_tasks_test_helper.rb
@@ -27,3 +27,24 @@ def wait_for(waiting_message = 'something to happen')
   end
   raise "waiting for #{waiting_message} was not successful"
 end
+
+module Dynflow
+  module Testing
+    module Factories
+      def create_run_action(plan_action)
+        Match! plan_action.phase, Action::Plan, Action::Run
+        step       = DummyStep.new
+        plan_action.class.new(
+            { step:              step,
+              execution_plan_id: plan_action.execution_plan_id,
+              id:                plan_action.id,
+              plan_step_id:      plan_action.plan_step_id,
+              run_step_id:       step.id,
+              finalize_step_id:  nil,
+              phase:             Action::Run,
+              input:             plan_action.input },
+              plan_action.world)
+      end
+    end
+  end
+end

--- a/test/support/dummy_proxy_action.rb
+++ b/test/support/dummy_proxy_action.rb
@@ -25,6 +25,16 @@ module Support
         { 'task_id' => @uuid, 'result' => 'success' }
       end
 
+      def launch_tasks(*args)
+        @log[:trigger_task] << args
+        @task_triggered.fulfill(true)
+        results = {}
+        args[1].each_pair do |task_id, data|
+          results[task_id] = { 'task_id' => SecureRandom.uuid, 'result' => 'success' }
+        end
+        results
+      end
+
       def cancel_task(*args)
         @log[:cancel_task] << args
       end


### PR DESCRIPTION
Use the new API to trigger remote task when batch triggering is off.