### PR TITLE
Fixes #29457 - hide task actions for user with no permission

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -315,6 +315,10 @@ module ForemanTasks
         @resource_scope ||= ForemanTasks::Task.authorized("#{action_permission}_foreman_tasks")
       end
 
+      def controller_permission
+        'foreman_tasks'
+      end
+
       def action_permission
         case params[:action]
         when 'bulk_search', 'summary', 'details', 'sub_tasks'

--- a/app/views/foreman_tasks/api/tasks/show.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/show.json.rabl
@@ -1,5 +1,7 @@
 object @task if @task
 
+extends 'api/v2/layouts/permissions'
+
 attributes :id, :label, :pending, :action
 attributes :username, :started_at, :ended_at, :state, :result, :progress
 attributes :input, :output, :humanized, :cli_example, :start_at

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
@@ -34,6 +34,7 @@ const Task = props => {
     action,
     dynflowEnableConsole,
     taskProgressToggle,
+    canEdit,
   } = props;
   const forceUnlock = () => {
     if (!taskReload) {
@@ -47,6 +48,12 @@ const Task = props => {
     }
     unlockTaskRequest(id, action);
   };
+  const editActionsTitle = canEdit
+    ? undefined
+    : __('You do not have permission');
+  const dynflowTitle = dynflowEnableConsole
+    ? undefined
+    : `dynflow_enable_console ${__('Setting is off')}`;
   return (
     <React.Fragment>
       <UnlockModal onClick={unlock} />
@@ -74,12 +81,16 @@ const Task = props => {
               rel="noopener noreferrer"
               target="_blank"
             >
-              {__('Dynflow console')}
+              <span title={dynflowTitle} data-original-title={dynflowTitle}>
+                {__('Dynflow console')}
+              </span>
             </Button>
             <Button
               className="resume-button"
               bsSize="small"
-              disabled={!resumable}
+              title={editActionsTitle}
+              data-original-title={editActionsTitle}
+              disabled={!canEdit || !resumable}
               onClick={() => {
                 if (!taskReload) {
                   taskProgressToggle();
@@ -92,7 +103,9 @@ const Task = props => {
             <Button
               className="cancel-button"
               bsSize="small"
-              disabled={!cancellable}
+              title={editActionsTitle}
+              data-original-title={editActionsTitle}
+              disabled={!canEdit || !cancellable}
               onClick={() => {
                 if (!taskReload) {
                   taskProgressToggle();
@@ -123,16 +136,20 @@ const Task = props => {
             <Button
               className="unlock-button"
               bsSize="small"
-              disabled={state !== 'paused'}
+              disabled={!canEdit || state !== 'paused'}
               onClick={unlockModalActions.setModalOpen}
+              title={editActionsTitle}
+              data-original-title={editActionsTitle}
             >
               {__('Unlock')}
             </Button>
             <Button
               className="force-unlock-button"
               bsSize="small"
-              disabled={state === 'stopped'}
+              disabled={!canEdit || state === 'stopped'}
               onClick={forceUnlockModalActions.setModalOpen}
+              title={editActionsTitle}
+              data-original-title={editActionsTitle}
             >
               {__('Force Unlock')}
             </Button>
@@ -160,6 +177,7 @@ Task.propTypes = {
   cancelTaskRequest: PropTypes.func,
   resumeTaskRequest: PropTypes.func,
   dynflowEnableConsole: PropTypes.bool,
+  canEdit: PropTypes.bool,
 };
 
 Task.defaultProps = {
@@ -177,6 +195,7 @@ Task.defaultProps = {
   cancelTaskRequest: () => null,
   resumeTaskRequest: () => null,
   dynflowEnableConsole: false,
+  canEdit: false,
 };
 
 export default Task;

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/Task.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/Task.test.js
@@ -20,6 +20,7 @@ const fixtures = {
     dynflowEnableConsole: true,
     parentTask: 'parent-id',
     taskReload: true,
+    canEdit: true,
   },
 };
 

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
@@ -51,7 +51,9 @@ exports[`Task rendering render with some Props 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          Dynflow console
+          <span>
+            Dynflow console
+          </span>
         </Button>
         <Button
           active={false}
@@ -129,6 +131,7 @@ exports[`Task rendering render with some Props 1`] = `
     </Row>
     <TaskInfo
       action=""
+      canEdit={true}
       cancelTaskRequest={[Function]}
       cancellable={false}
       dynflowEnableConsole={true}
@@ -210,7 +213,12 @@ exports[`Task rendering render without Props 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          Dynflow console
+          <span
+            data-original-title="dynflow_enable_console Setting is off"
+            title="dynflow_enable_console Setting is off"
+          >
+            Dynflow console
+          </span>
         </Button>
         <Button
           active={false}
@@ -219,8 +227,10 @@ exports[`Task rendering render without Props 1`] = `
           bsSize="small"
           bsStyle="default"
           className="resume-button"
+          data-original-title="You do not have permission"
           disabled={true}
           onClick={[Function]}
+          title="You do not have permission"
         >
           Resume
         </Button>
@@ -231,8 +241,10 @@ exports[`Task rendering render without Props 1`] = `
           bsSize="small"
           bsStyle="default"
           className="cancel-button"
+          data-original-title="You do not have permission"
           disabled={true}
           onClick={[Function]}
+          title="You do not have permission"
         >
           Cancel
         </Button>
@@ -243,8 +255,10 @@ exports[`Task rendering render without Props 1`] = `
           bsSize="small"
           bsStyle="default"
           className="unlock-button"
+          data-original-title="You do not have permission"
           disabled={true}
           onClick={[MockFunction]}
+          title="You do not have permission"
         >
           Unlock
         </Button>
@@ -255,8 +269,10 @@ exports[`Task rendering render without Props 1`] = `
           bsSize="small"
           bsStyle="default"
           className="force-unlock-button"
-          disabled={false}
+          data-original-title="You do not have permission"
+          disabled={true}
           onClick={[MockFunction]}
+          title="You do not have permission"
         >
           Force Unlock
         </Button>
@@ -264,6 +280,7 @@ exports[`Task rendering render without Props 1`] = `
     </Row>
     <TaskInfo
       action=""
+      canEdit={false}
       cancelTaskRequest={[Function]}
       cancellable={false}
       dynflowEnableConsole={false}

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.scss
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.scss
@@ -10,20 +10,6 @@
   .container {
     margin: 0;
   }
-  /*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the top of the
- * compiled file, but it's generally better to create a new file per style scope.
- *
- *= require_self
- *= require_tree .
- */
-
   .spin {
     -webkit-animation: spin 1s infinite linear;
     -moz-animation: spin 1s infinite linear;
@@ -59,5 +45,8 @@
     to {
       transform: rotate(360deg);
     }
+  }
+  .dynflow-button > span {
+    pointer-events: auto;
   }
 }

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
@@ -56,7 +56,9 @@ export const refetchTaskDetails = (id, loading) => dispatch => {
 
 const reloadTasksDetails = async (id, dispatch) => {
   try {
-    const { data } = await API.get(`/foreman_tasks/api/tasks/${id}/details`);
+    const { data } = await API.get(
+      `/foreman_tasks/api/tasks/${id}/details?include_permissions`
+    );
     dispatch(requestSuccess(data));
   } catch (error) {
     dispatch(requestFailure(error));
@@ -83,7 +85,9 @@ const getTasksDetails = async (
   refetchTaskDetailsAction
 ) => {
   try {
-    const { data } = await API.get(`/foreman_tasks/api/tasks/${id}/details`);
+    const { data } = await API.get(
+      `/foreman_tasks/api/tasks/${id}/details?include_permissions`
+    );
     dispatch(requestSuccess(data));
     if (data.state !== 'stopped') {
       dispatch(taskReloadStart(timeoutId, refetchTaskDetailsAction, id));

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -77,3 +77,6 @@ export const selectExternalId = state =>
 
 export const selectDynflowEnableConsole = state =>
   selectTaskDetails(state).dynflow_enable_console || false;
+
+export const selectCanEdit = state =>
+  selectTaskDetails(state).can_edit || false;

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/__snapshots__/TaskDetails.test.js.snap
@@ -15,6 +15,7 @@ exports[`TaskDetails rendering render with min Props 1`] = `
     >
       <Task
         action=""
+        canEdit={false}
         cancelStep={[MockFunction]}
         cancelTaskRequest={[Function]}
         cancellable={false}

--- a/webpack/ForemanTasks/Components/TaskDetails/index.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/index.js
@@ -32,6 +32,7 @@ import {
   selectParentTask,
   selectExternalId,
   selectDynflowEnableConsole,
+  selectCanEdit,
 } from './TaskDetailsSelectors';
 
 const mapStateToProps = state => ({
@@ -62,6 +63,7 @@ const mapStateToProps = state => ({
   parentTask: selectParentTask(state),
   externalId: selectExternalId(state),
   dynflowEnableConsole: selectDynflowEnableConsole(state),
+  canEdit: selectCanEdit(state),
 });
 
 const mapDispatchToProps = dispatch =>

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalSelectors.js
@@ -27,6 +27,7 @@ export const selectSelectedTasks = state => {
     id: item.id,
     isCancellable: item.availableActions.cancellable,
     isResumable: item.availableActions.resumable,
+    canEdit: item.canEdit,
   }));
 };
 

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalSelectors.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalSelectors.test.js
@@ -22,6 +22,7 @@ const state = {
             id: 1,
             action: 'action1',
             available_actions: { cancellable: true },
+            can_edit: true,
           },
           { id: 2, action: 'action2', available_actions: { resumable: true } },
         ],

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/__snapshots__/ConfirmModalSelectors.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/__snapshots__/ConfirmModalSelectors.test.js.snap
@@ -15,12 +15,14 @@ exports[`TasksDashboard - Selectors should select selectedRowsLen some 1`] = `3`
 exports[`TasksDashboard - Selectors should select selectedTasks 1`] = `
 Array [
   Object {
+    "canEdit": true,
     "id": 1,
     "isCancellable": true,
     "isResumable": undefined,
     "name": "action1",
   },
   Object {
+    "canEdit": undefined,
     "id": 2,
     "isCancellable": undefined,
     "isResumable": true,

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -39,6 +39,7 @@ export const selectResults = createSelector(
         ...result.available_actions,
         stoppable: result.state !== 'stopped',
       },
+      canEdit: result.can_edit,
     }))
 );
 

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
@@ -18,6 +18,7 @@ jest.mock('foremanReact/redux/API');
 const task = {
   id: 'some-id',
   name: 'some-name',
+  canEdit: true,
 };
 
 const fixtures = {
@@ -140,6 +141,18 @@ const fixtures = {
       url: 'some-url',
       parentTaskID: 'parent',
     }),
+  'handles bulkCancelById requests with canEdit false': () => {
+    const selected = [{ ...task, isCancellable: true, canEdit: false }];
+    return bulkCancelById({ selected, url: 'some-url' });
+  },
+  'handles bulkResumeById requests with canEdit false': () => {
+    const selected = [{ ...task, isResumable: false, canEdit: false }];
+    return bulkResumeById({ selected, url: 'some-url' });
+  },
+  'handles bulkForceCancelById requests with canEdit false': () => {
+    const selected = [{ ...task, isResumable: false, canEdit: false }];
+    return bulkForceCancelById({ selected, url: 'some-url' });
+  },
 };
 
 describe('TasksTable bulk actions', () => {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTablePage.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTablePage.test.js
@@ -12,9 +12,10 @@ const history = {
 const fixtures = {
   'render with minimal props': { ...minProps, history },
 
-  'render with Breadcrubs': {
+  'render with Breadcrubs and edit permissions': {
     ...minProps,
     history,
+    results: [{ action: 'a', canEdit: true }],
     getBreadcrumbs: () => ({
       breadcrumbItems: [
         { caption: 'Tasks', url: `/foreman_tasks/tasks` },

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
@@ -48,6 +48,22 @@ Array [
 ]
 `;
 
+exports[`TasksTable bulk actions handles bulkCancelById requests with canEdit false 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Not all the selected tasks can be cancelled",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`TasksTable bulk actions handles bulkCancelBySearch requests 1`] = `
 Array [
   Array [
@@ -155,6 +171,22 @@ Array [
 ]
 `;
 
+exports[`TasksTable bulk actions handles bulkForceCancelById requests with canEdit false 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "User has no permission for 1 task(s)",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`TasksTable bulk actions handles bulkForceCancelBySearch requests 1`] = `
 Array [
   Array [
@@ -211,6 +243,22 @@ Array [
         "message": Object {
           "message": "Cannot resume tasks at the moment Error: Network Error",
           "type": "error",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable bulk actions handles bulkResumeById requests with canEdit false 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Not all the selected tasks can be resumed",
+          "type": "warning",
         },
       },
       "type": "TOASTS_ADD",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
+exports[`TasksTablePage rendering render with Breadcrubs and edit permissions 1`] = `
 <div
   className="tasks-table-wrapper"
 >
@@ -114,8 +114,10 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
       parentTaskID={null}
       results={
         Array [
-          "a",
-          "b",
+          Object {
+            "action": "a",
+            "canEdit": true,
+          },
         ]
       }
       selectPage={[MockFunction]}

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionCellFormatter.test.js.snap
@@ -7,6 +7,7 @@ exports[`actionCellFormatter render 1`] = `
       "cancellable": true,
     }
   }
+  canEdit={true}
   id="some-id"
   name="some-name"
   taskActions={Object {}}

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionCellFormatter.test.js.snap
@@ -3,8 +3,10 @@
 exports[`selectionCellFormatter render 1`] = `
 <TableSelectionCell
   checked={true}
+  disabled={true}
   id="selectsome-index"
   label="Select row"
   onChange={[Function]}
+  title="You do not have permission"
 />
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/actionCellFormatter.test.js
@@ -4,7 +4,7 @@ describe('actionCellFormatter', () => {
   it('render', () => {
     const data = [
       { cancellable: true },
-      { rowData: { action: 'some-name', id: 'some-id' } },
+      { rowData: { action: 'some-name', id: 'some-id', canEdit: true } },
     ];
     expect(actionCellFormatter({})(...data)).toMatchSnapshot();
   });

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionCellFormatter.test.js
@@ -5,7 +5,7 @@ describe('selectionCellFormatter', () => {
     expect(
       selectionCellFormatter(
         { isSelected: () => true },
-        { rowIndex: 'some-index' }
+        { rowIndex: 'some-index', rowData: {} }
       )
     ).toMatchSnapshot();
   });

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/actionCellFormatter.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/actionCellFormatter.js
@@ -4,13 +4,16 @@ import { ActionButton } from '../../common/ActionButtons/ActionButton';
 
 export const actionCellFormatter = taskActions => (
   value,
-  { rowData: { action, id } }
+  { rowData: { action, id, canEdit } }
 ) =>
   cellFormatter(
-    <ActionButton
-      id={id}
-      name={action}
-      taskActions={taskActions}
-      availableActions={value}
-    />
+    canEdit && (
+      <ActionButton
+        canEdit={canEdit}
+        id={id}
+        name={action}
+        taskActions={taskActions}
+        availableActions={value}
+      />
+    )
   );

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/selectionCellFormatter.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/selectionCellFormatter.js
@@ -1,9 +1,16 @@
 import React from 'react';
+import { translate as __ } from 'foremanReact/common/I18n';
 import TableSelectionCell from '../Components/TableSelectionCell';
 
 export default (selectionController, additionalData) => (
   <TableSelectionCell
     id={`select${additionalData.rowIndex}`}
+    disabled={!additionalData.rowData.canEdit}
+    title={
+      additionalData.rowData.canEdit
+        ? undefined
+        : __('You do not have permission')
+    }
     checked={selectionController.isSelected(additionalData)}
     onChange={() => selectionController.selectRow(additionalData)}
   />

--- a/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.js
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.js
@@ -4,45 +4,48 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { ActionButtons } from 'foremanReact/components/common/ActionButtons/ActionButtons';
 
 export const ActionButton = ({
+  canEdit,
   id,
   name,
   availableActions: { resumable, cancellable, stoppable },
   taskActions,
 }) => {
   const buttons = [];
-  const isTitle = !(resumable || cancellable || stoppable);
+  const isTitle = canEdit && !(resumable || cancellable || stoppable);
   const title = isTitle ? __('Task cannot be canceled') : undefined;
-  if (resumable) {
-    buttons.push({
-      title: __('Resume'),
-      action: {
-        disabled: !resumable,
-        onClick: () => taskActions.resumeTask(id, name),
-        id: `task-resume-button-${id}`,
-      },
-    });
-  }
-  if (cancellable || (!stoppable && !resumable)) {
-    // Cancel is the default button that should be shown if no task action can be done
-    buttons.push({
-      title: __('Cancel'),
-      action: {
-        disabled: !cancellable,
-        onClick: () => taskActions.cancelTask(id, name),
-        id: `task-cancel-button-${id}`,
-      },
-    });
-  }
+  if (canEdit) {
+    if (resumable) {
+      buttons.push({
+        title: __('Resume'),
+        action: {
+          disabled: !resumable,
+          onClick: () => taskActions.resumeTask(id, name),
+          id: `task-resume-button-${id}`,
+        },
+      });
+    }
+    if (cancellable || (!stoppable && !resumable)) {
+      // Cancel is the default button that should be shown if no task action can be done
+      buttons.push({
+        title: __('Cancel'),
+        action: {
+          disabled: !cancellable,
+          onClick: () => taskActions.cancelTask(id, name),
+          id: `task-cancel-button-${id}`,
+        },
+      });
+    }
 
-  if (stoppable) {
-    buttons.push({
-      title: __('Force Cancel'),
-      action: {
-        disabled: !stoppable,
-        onClick: () => taskActions.forceCancelTask(id, name),
-        id: `task-force-cancel-button-${id}`,
-      },
-    });
+    if (stoppable) {
+      buttons.push({
+        title: __('Force Cancel'),
+        action: {
+          disabled: !stoppable,
+          onClick: () => taskActions.forceCancelTask(id, name),
+          id: `task-force-cancel-button-${id}`,
+        },
+      });
+    }
   }
   return (
     <span title={title}>
@@ -52,6 +55,7 @@ export const ActionButton = ({
 };
 
 ActionButton.propTypes = {
+  canEdit: PropTypes.bool,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   availableActions: PropTypes.shape({
@@ -64,4 +68,8 @@ ActionButton.propTypes = {
     resumeTask: PropTypes.func,
     forceCancelTask: PropTypes.func,
   }).isRequired,
+};
+
+ActionButton.defaultProps = {
+  canEdit: false,
 };

--- a/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.test.js
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.test.js
@@ -7,6 +7,7 @@ const resumeTask = jest.fn();
 const cancelTask = jest.fn();
 const forceCancelTask = jest.fn();
 const taskActions = { resumeTask, cancelTask, forceCancelTask };
+const minProps = { canEdit: true, id: 'id', name: 'some-name' };
 const fixtures = {
   'render with cancellable true props': {
     availableActions: {
@@ -14,8 +15,7 @@ const fixtures = {
       resumable: false,
     },
     taskActions,
-    id: 'id',
-    name: 'some-name',
+    ...minProps,
   },
   'render with resumable true props': {
     availableActions: {
@@ -23,8 +23,7 @@ const fixtures = {
       resumable: true,
     },
     taskActions,
-    id: 'id',
-    name: 'some-name',
+    ...minProps,
   },
   'render with stoppable and cancellable true props': {
     availableActions: {
@@ -32,8 +31,7 @@ const fixtures = {
       stoppable: true,
     },
     taskActions,
-    id: 'id',
-    name: 'some-name',
+    ...minProps,
   },
   'render with cancellable false props': {
     availableActions: {
@@ -41,8 +39,16 @@ const fixtures = {
       resumable: false,
     },
     taskActions,
-    id: 'id',
-    name: 'some-name',
+    ...minProps,
+  },
+  'render with canEdit false': {
+    availableActions: {
+      cancellable: false,
+      resumable: false,
+    },
+    taskActions,
+    ...minProps,
+    canEdit: false,
   },
 };
 
@@ -57,6 +63,7 @@ describe('ActionButton', () => {
         <ActionButton
           id={id}
           name={name}
+          canEdit
           availableActions={{ cancellable: true }}
           taskActions={taskActions}
         />
@@ -69,6 +76,7 @@ describe('ActionButton', () => {
         <ActionButton
           id={id}
           name={name}
+          canEdit
           availableActions={{ resumable: true }}
           taskActions={taskActions}
         />
@@ -81,6 +89,7 @@ describe('ActionButton', () => {
         <ActionButton
           id={id}
           name={name}
+          canEdit
           availableActions={{ stoppable: true }}
           taskActions={taskActions}
         />

--- a/webpack/ForemanTasks/Components/common/ActionButtons/__snapshots__/ActionButton.test.js.snap
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/__snapshots__/ActionButton.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActionButton snapshot test render with canEdit false 1`] = `
+<span>
+  <ActionButtons
+    buttons={Array []}
+  />
+</span>
+`;
+
 exports[`ActionButton snapshot test render with cancellable false props 1`] = `
 <span
   title="Task cannot be canceled"


### PR DESCRIPTION
In tasks details and table user without can_edit permission still sees the cancel/resume buttons. if he clicks them there is a back end error as he has no permissions