### PR TITLE
Fixes #29462 - bulk tasks api doesnt work with tasks ids

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -328,7 +328,7 @@ module ForemanTasks
         scope = resource_scope
         scope = scope.search_for(params[:search]) if params[:search]
         scope = scope.select('DISTINCT foreman_tasks_tasks.*')
-        scope.where(:id => params[:task_ids]) if params[:task_ids]
+        scope = scope.where(:id => params[:task_ids]) if params[:task_ids]
         scope
       end
     end


### PR DESCRIPTION

it doesn't filter out from the tasks list only the tasks with the relevant ids from params