### PR TITLE
Fixes #29623 - export tasks doesn't filter subtasks

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableHelpers.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableHelpers.js
@@ -22,9 +22,10 @@ export const resolveSearchQuery = (search, history) => {
   updateURlQuery(uriQuery, history);
 };
 
-export const addSearchToURL = (path, query) => {
-  const url = new URI(path);
-  url.addSearch({ ...query, include_permissions: true });
+export const getCSVurl = (path, query) => {
+  let url = new URI(path);
+  url = url.pathname(`${url.pathname()}.csv`);
+  url.addSearch(query);
   return url.toString();
 };
 

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -10,7 +10,7 @@ import { STATUS } from 'foremanReact/constants';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
 import TasksDashboard from '../TasksDashboard';
 import TasksTable from './TasksTable';
-import { resolveSearchQuery, addSearchToURL } from './TasksTableHelpers';
+import { resolveSearchQuery, getCSVurl } from './TasksTableHelpers';
 import { ConfirmationModals } from './Components/ConfirmationModals';
 import {
   TASKS_SEARCH_PROPS,
@@ -108,7 +108,7 @@ const TasksTablePage = ({
           <React.Fragment>
             {props.status === STATUS.PENDING && <Spinner size="lg" loading />}
             <ExportButton
-              url={addSearchToURL('/foreman_tasks/tasks.csv', uriQuery)}
+              url={getCSVurl(url, uriQuery)}
               title={__('Export All')}
             />
             <ActionSelectButton

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableHelpers.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableHelpers.test.js
@@ -1,4 +1,4 @@
-import { updateURlQuery, getDuration } from '../TasksTableHelpers';
+import { updateURlQuery, getDuration, getCSVurl } from '../TasksTableHelpers';
 
 describe('updateURlQuery', () => {
   it('should use url with new query', () => {
@@ -24,5 +24,21 @@ describe('updateURlQuery', () => {
     const duration = getDuration('', '1/1/2000 11:25');
     expect(duration.text).toEqual('N/A');
     expect(duration.tooltip).toEqual('Task was canceled');
+  });
+});
+
+describe('getCSVurl', () => {
+  it('should return currect url for tasks with search', () => {
+    const url = '/foreman_tasks/tasks';
+    const query = { state: 'stopped' };
+    expect(getCSVurl(url, query)).toEqual(
+      '/foreman_tasks/tasks.csv?state=stopped'
+    );
+  });
+  it('should return currect url for subtasks', () => {
+    const url = '/foreman_tasks/tasks/some-id/sub_tasks';
+    expect(getCSVurl(url, {})).toEqual(
+      '/foreman_tasks/tasks/some-id/sub_tasks.csv'
+    );
   });
 });

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTablePage.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTablePage.test.js
@@ -2,11 +2,19 @@ import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
 import TasksTablePage from '../TasksTablePage';
 import { minProps } from './TasksTable.fixtures';
 
+jest.mock('foremanReact/common/helpers', () => ({
+  getURIQuery: () => ({ state: 'stopped' }),
+}));
+
+const history = {
+  location: { pathname: '/foreman_tasks/tasks', search: '?action="some-name"' },
+};
 const fixtures = {
-  'render with minimal props': minProps,
+  'render with minimal props': { ...minProps, history },
 
   'render with Breadcrubs': {
     ...minProps,
+    history,
     getBreadcrumbs: () => ({
       breadcrumbItems: [
         { caption: 'Tasks', url: `/foreman_tasks/tasks` },

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -45,7 +45,8 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
         history={
           Object {
             "location": Object {
-              "search": "",
+              "pathname": "/foreman_tasks/tasks",
+              "search": "?action=\\"some-name\\"",
             },
           }
         }
@@ -94,7 +95,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
       <React.Fragment>
         <ExportButton
           title="Export All"
-          url="/foreman_tasks/tasks.csv?include_permissions=true"
+          url="/foreman_tasks/tasks.csv?action=%22some-name%22&state=stopped"
         />
         <ActionSelectButton
           disabled={true}
@@ -114,7 +115,8 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
       history={
         Object {
           "location": Object {
-            "search": "",
+            "pathname": "/foreman_tasks/tasks",
+            "search": "?action=\\"some-name\\"",
           },
         }
       }
@@ -220,7 +222,8 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
         history={
           Object {
             "location": Object {
-              "search": "",
+              "pathname": "/foreman_tasks/tasks",
+              "search": "?action=\\"some-name\\"",
             },
           }
         }
@@ -252,7 +255,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
       <React.Fragment>
         <ExportButton
           title="Export All"
-          url="/foreman_tasks/tasks.csv?include_permissions=true"
+          url="/foreman_tasks/tasks.csv?action=%22some-name%22&state=stopped"
         />
         <ActionSelectButton
           disabled={true}
@@ -272,7 +275,8 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
       history={
         Object {
           "location": Object {
-            "search": "",
+            "pathname": "/foreman_tasks/tasks",
+            "search": "?action=\\"some-name\\"",
           },
         }
       }


### PR DESCRIPTION
In tasks table when in subtasks mode the export button will export all tasks instead of only the subtasks