### PR TITLE
Fixes #29671 - stop using strip_heredoc

### DIFF
--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -7,7 +7,7 @@
 require 'csv'
 
 namespace :foreman_tasks do
-  desc <<-DESC.strip_heredoc
+  desc <<~DESC
     Export dynflow tasks based on filter. ENV variables:
 
       * TASK_SEARCH     : scoped search filter (example: 'label = "Actions::Foreman::Host::ImportFacts"')


### PR DESCRIPTION
Replace `strip_heredoc` deprecated by Rails 6.