### PR TITLE
Fixes #29729 - add force unlock to tasks table rows

### DIFF
--- a/webpack/ForemanTasks/Components/TaskActions/TaskActionHelpers.js
+++ b/webpack/ForemanTasks/Components/TaskActions/TaskActionHelpers.js
@@ -45,20 +45,15 @@ export const cancelToastInfo = {
 };
 
 export const forceCancelToastInfo = {
-  forceCancelled: successToastData(
-    __('Task resources were unlocked with force.')
-  ),
-  failed: warningToastData(
-    __('Task cannot be cancelled with force at the moment.')
-  ),
+  forceCancelled: successToastData(__('resources were unlocked with force.')),
+  failed: warningToastData(__('cannot be cancelled with force at the moment.')),
 };
 
 export const unlockToastInfo = {
-  unlocked: successToastData(__('Task resources were unlocked ')),
-  failed: warningToastData(
-    __('Task resources cannot be unlocked at the moment.')
-  ),
+  unlocked: successToastData(__('resources were unlocked ')),
+  failed: warningToastData(__('resources cannot be unlocked at the moment.')),
 };
+
 export const toastDispatch = ({ type, name, toastInfo, dispatch }) => {
   dispatch(
     addToast({

--- a/webpack/ForemanTasks/Components/TaskActions/UnlockModals.js
+++ b/webpack/ForemanTasks/Components/TaskActions/UnlockModals.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
 import { ClickConfirmation } from '../common/ClickConfirmation';
 import { UNLOCK_MODAL, FORCE_UNLOCK_MODAL } from './TaskActionsConstants';
 
@@ -22,12 +22,15 @@ export const UnlockModal = ({ onClick, id }) => (
   />
 );
 
-export const ForceUnlockModal = ({ onClick, id }) => (
+export const ForceUnlockModal = ({ onClick, id, selectedRowsLen }) => (
   <ClickConfirmation
     id={id}
     title={__('Force Unlock')}
-    body={__(
-      'Resources will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck'
+    body={sprintf(
+      __(
+        `Resources for %s task(s) will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck.`
+      ),
+      selectedRowsLen
     )}
     confirmationMessage={confirmationMessage}
     confirmAction={__('Force Unlock')}
@@ -44,6 +47,7 @@ UnlockModal.propTypes = {
 ForceUnlockModal.propTypes = {
   onClick: PropTypes.func.isRequired,
   id: PropTypes.string,
+  selectedRowsLen: PropTypes.number,
 };
 
 UnlockModal.defaultProps = {
@@ -52,4 +56,5 @@ UnlockModal.defaultProps = {
 
 ForceUnlockModal.defaultProps = {
   id: FORCE_UNLOCK_MODAL,
+  selectedRowsLen: 1,
 };

--- a/webpack/ForemanTasks/Components/TaskActions/__snapshots__/TaskAction.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskActions/__snapshots__/TaskAction.test.js.snap
@@ -91,7 +91,7 @@ Array [
     Object {
       "payload": Object {
         "message": Object {
-          "message": "some-name Task execution Task cannot be cancelled with force at the moment.",
+          "message": "some-name Task execution cannot be cancelled with force at the moment.",
           "type": "warning",
         },
       },
@@ -117,7 +117,7 @@ Array [
     Object {
       "payload": Object {
         "message": Object {
-          "message": "some-name Task execution Task resources were unlocked with force.",
+          "message": "some-name Task execution resources were unlocked with force.",
           "type": "success",
         },
       },
@@ -196,7 +196,7 @@ Array [
     Object {
       "payload": Object {
         "message": Object {
-          "message": "some-name Task execution Task cannot be cancelled with force at the moment.",
+          "message": "some-name Task execution cannot be cancelled with force at the moment.",
           "type": "warning",
         },
       },
@@ -222,7 +222,7 @@ Array [
     Object {
       "payload": Object {
         "message": Object {
-          "message": "some-name Task execution Task resources were unlocked ",
+          "message": "some-name Task execution resources were unlocked ",
           "type": "success",
         },
       },

--- a/webpack/ForemanTasks/Components/TaskActions/__snapshots__/UnlockModals.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskActions/__snapshots__/UnlockModals.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ForceUnlockModal render 1`] = `
 <ClickConfirmation
-  body="Resources will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck"
+  body="Resources for 1 task(s) will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck."
   confirmAction="Force Unlock"
   confirmType="danger"
   confirmationMessage="I understand that this may cause harm and have working database backups of all backend services."

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
@@ -9,6 +9,7 @@ exports[`Task rendering render with some Props 1`] = `
   <ForceUnlockModal
     id="forceUnlockModal"
     onClick={[Function]}
+    selectedRowsLen={1}
   />
   <Grid
     bsClass="container"
@@ -169,6 +170,7 @@ exports[`Task rendering render without Props 1`] = `
   <ForceUnlockModal
     id="forceUnlockModal"
     onClick={[Function]}
+    selectedRowsLen={1}
   />
   <Grid
     bsClass="container"

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModal.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModal.js
@@ -4,6 +4,8 @@ import { startCase } from 'lodash';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { Button } from 'patternfly-react';
 import ForemanModal from 'foremanReact/components/ForemanModal';
+import { FORCE_UNLOCK_MODAL } from '../../../TaskActions/TaskActionsConstants';
+import { ForceUnlockModal } from '../../../TaskActions/UnlockModals';
 
 export const ConfirmModal = ({
   actionText,
@@ -16,32 +18,46 @@ export const ConfirmModal = ({
   uriQuery: query,
   setModalClosed,
   ...props
-}) => (
-  <ForemanModal
-    title={sprintf(__('%s Selected Tasks'), startCase(actionText))}
-    id={id}
-  >
-    {sprintf(
-      __(
-        `This will %(action)s %(number)s task(s), putting them in the %(state)s state. Are you sure?`
-      ),
-      { action: actionText, number: selectedRowsLen, state: actionState }
-    )}
-    <ForemanModal.Footer>
-      <Button onClick={setModalClosed}>{__('No')}</Button>
-      <Button
-        className="confirm-button"
-        bsStyle="primary"
+}) => {
+  if (actionType === FORCE_UNLOCK_MODAL) {
+    return (
+      <ForceUnlockModal
         onClick={() => {
           props[actionType]({ url, query, parentTaskID });
           setModalClosed();
         }}
-      >
-        {__('Yes')}
-      </Button>
-    </ForemanModal.Footer>
-  </ForemanModal>
-);
+        id={id}
+        selectedRowsLen={selectedRowsLen}
+      />
+    );
+  }
+  return (
+    <ForemanModal
+      title={sprintf(__('%s Selected Tasks'), startCase(actionText))}
+      id={id}
+    >
+      {sprintf(
+        __(
+          `This will %(action)s %(number)s task(s), putting them in the %(state)s state. Are you sure?`
+        ),
+        { action: actionText, number: selectedRowsLen, state: actionState }
+      )}
+      <ForemanModal.Footer>
+        <Button onClick={setModalClosed}>{__('No')}</Button>
+        <Button
+          className="confirm-button"
+          bsStyle="primary"
+          onClick={() => {
+            props[actionType]({ url, query, parentTaskID });
+            setModalClosed();
+          }}
+        >
+          {__('Yes')}
+        </Button>
+      </ForemanModal.Footer>
+    </ForemanModal>
+  );
+};
 
 ConfirmModal.propTypes = {
   actionText: PropTypes.string,

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalActions.js
@@ -1,4 +1,8 @@
-import { resumeTask, cancelTask } from '../../TasksTableActions';
+import {
+  resumeTask,
+  cancelTask,
+  forceCancelTask,
+} from '../../TasksTableActions';
 import {
   bulkCancelBySearch,
   bulkCancelById,
@@ -13,6 +17,7 @@ import {
   CANCEL_SELECTED_MODAL,
   RESUME_SELECTED_MODAL,
 } from '../../TasksTableConstants';
+import { FORCE_UNLOCK_MODAL } from '../../../TaskActions/TaskActionsConstants';
 
 export default {
   [CANCEL_SELECTED_MODAL]: ({ url, query, parentTaskID }) => (
@@ -61,6 +66,18 @@ export default {
     const { taskId, taskName } = selectClicked(getState());
     return dispatch(
       resumeTask({
+        taskId,
+        taskName,
+        url,
+        parentTaskID,
+      })
+    );
+  },
+
+  [FORCE_UNLOCK_MODAL]: ({ url, parentTaskID }) => (dispatch, getState) => {
+    const { taskId, taskName } = selectClicked(getState());
+    return dispatch(
+      forceCancelTask({
         taskId,
         taskName,
         url,

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalReducer.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalReducer.js
@@ -29,7 +29,7 @@ export const ConfirmModalReducer = (state = initialState, action) => {
             actionType: payload.modalID,
           });
         default:
-          return state;
+          return state.set('actionType', payload.modalID);
       }
     default:
       return state;

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalSelectors.js
@@ -7,6 +7,7 @@ import {
   selectAllRowsSelected,
 } from '../../TasksTableSelectors';
 import { RESUME_MODAL, CANCEL_MODAL } from '../../TasksTableConstants';
+import { FORCE_UNLOCK_MODAL } from '../../../TaskActions/TaskActionsConstants';
 
 export const selectCofirmModal = state =>
   selectForemanTasks(state).confirmModal || {};
@@ -30,7 +31,11 @@ export const selectSelectedTasks = state => {
 };
 
 export const selectSelectedRowsLen = state => {
-  if ([CANCEL_MODAL, RESUME_MODAL].includes(selectActionType(state))) {
+  if (
+    [CANCEL_MODAL, RESUME_MODAL, FORCE_UNLOCK_MODAL].includes(
+      selectActionType(state)
+    )
+  ) {
     return 1;
   }
   if (selectAllRowsSelected(state)) {

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModal.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModal.test.js
@@ -1,10 +1,24 @@
 import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
 import { ConfirmModal } from '../ConfirmModal';
 import { RESUME_SELECTED_MODAL } from '../../../TasksTableConstants';
+import { FORCE_UNLOCK_MODAL } from '../../../../TaskActions/TaskActionsConstants';
 
 const fixtures = {
   'renders ConfirmModal': {
     actionType: RESUME_SELECTED_MODAL,
+    actionText: 'some text',
+    actionState: 'some state',
+    selectedRowsLen: 1,
+    id: 'modalID',
+    parentTaskID: 'parent-id',
+    allRowsSelected: true,
+    url: 'some-url',
+    uriQuery: { state: 'stopped' },
+    setModalClosed: jest.fn(),
+  },
+
+  'renders ConfirmModal for unlock ': {
+    actionType: FORCE_UNLOCK_MODAL,
     actionText: 'some text',
     actionState: 'some state',
     selectedRowsLen: 1,

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalActions.test.js
@@ -6,12 +6,15 @@ import {
   RESUME_SELECTED_MODAL,
 } from '../../../TasksTableConstants';
 
+import { FORCE_UNLOCK_MODAL } from '../../../../TaskActions/TaskActionsConstants';
+
 import { resumeTask, cancelTask } from '../../../TasksTableActions';
 import {
   bulkCancelBySearch,
   bulkCancelById,
   bulkResumeBySearch,
   bulkResumeById,
+  forceCancelTask,
 } from '../../../TasksBulkActions';
 
 jest.mock('../../../TasksBulkActions');
@@ -100,6 +103,13 @@ describe('ConfirmModalActions', () => {
       parentTaskID,
     });
     expect(dispatch).toBeCalledWith(resumeTaskMock);
+  });
+  it('run FORCE_UNLOCK_MODAL', () => {
+    runWithGetState(clickedState, taskActions[FORCE_UNLOCK_MODAL], dispatch, {
+      url,
+      parentTaskID,
+    });
+    expect(dispatch).toBeCalledWith(forceCancelTask);
   });
   it('run CANCEL_SELECTED_MODAL by id', () => {
     runWithGetState(

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/__snapshots__/ConfirmModal.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/__snapshots__/ConfirmModal.test.js.snap
@@ -31,3 +31,11 @@ exports[`ConfirmModal renders ConfirmModal 1`] = `
   </Component>
 </ForemanModal>
 `;
+
+exports[`ConfirmModal renders ConfirmModal for unlock  1`] = `
+<ForceUnlockModal
+  id="modalID"
+  onClick={[Function]}
+  selectedRowsLen={1}
+/>
+`;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
@@ -9,6 +9,7 @@ import { getURIQuery } from 'foremanReact/common/helpers';
 import createTasksTableSchema from './TasksTableSchema';
 import { updateURlQuery } from './TasksTableHelpers';
 import { RESUME_MODAL, CANCEL_MODAL } from './TasksTableConstants';
+import { FORCE_UNLOCK_MODAL } from '../TaskActions/TaskActionsConstants';
 
 const TasksTable = ({
   getTableItems,
@@ -106,6 +107,13 @@ const TasksTable = ({
         taskId,
         taskName,
         setModalOpen: () => openModal(RESUME_MODAL),
+      });
+    },
+    forceCancelTask: (taskId, taskName) => {
+      openClickedModal({
+        taskId,
+        taskName,
+        setModalOpen: () => openModal(FORCE_UNLOCK_MODAL),
       });
     },
   };

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
@@ -13,7 +13,11 @@ import {
 } from './TasksTableConstants';
 import { getApiPathname } from './TasksTableHelpers';
 import { fetchTasksSummary } from '../TasksDashboard/TasksDashboardActions';
-import { cancelTaskRequest, resumeTaskRequest } from '../TaskActions';
+import {
+  cancelTaskRequest,
+  resumeTaskRequest,
+  forceCancelTaskRequest,
+} from '../TaskActions';
 
 export const getTableItems = url =>
   getTableItemsAction(TASKS_TABLE_ID, getURIQuery(url), getApiPathname(url));
@@ -41,6 +45,17 @@ export const resumeTask = ({
 }) => async dispatch => {
   await dispatch(resumeTaskRequest(taskId, taskName));
   reloadPage(url, parentTaskID, dispatch);
+};
+
+export const forceCancelTask = ({
+  taskId,
+  taskName,
+  url,
+  parentTaskID,
+}) => async dispatch => {
+  await dispatch(forceCancelTaskRequest(taskId, taskName));
+  dispatch(getTableItems(url));
+  dispatch(fetchTasksSummary(getURIQuery(url).time, parentTaskID));
 };
 
 export const selectPage = results => dispatch => {

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSchema.js
@@ -67,7 +67,7 @@ const createTasksTableSchema = (
     sortableColumn('started_at', __('Started at'), 3, sortController, [
       dateCellFormmatter,
     ]),
-    sortableColumn('duration', __('Duration'), 3, sortController, [
+    sortableColumn('duration', __('Duration'), 2, sortController, [
       durationCellFormmatter,
     ]),
     column(
@@ -76,7 +76,7 @@ const createTasksTableSchema = (
       headFormat,
       [actionCellFormatter(taskActions)],
       {
-        className: 'col-md-1',
+        className: 'col-md-2',
       }
     ),
   ];

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -35,7 +35,10 @@ export const selectResults = createSelector(
       username: result.username || '',
       state: result.state + (result.frozen ? ` ${__('Disabled')}` : ''),
       duration: getDuration(result.started_at, result.ended_at),
-      availableActions: result.available_actions,
+      availableActions: {
+        ...result.available_actions,
+        stoppable: result.state !== 'stopped',
+      },
     }))
 );
 

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTableActions.test.js
@@ -7,6 +7,7 @@ import {
   getTableItems,
   cancelTask,
   resumeTask,
+  forceCancelTask,
   selectPage,
   openClickedModal,
   openModalAction,
@@ -41,6 +42,12 @@ describe('TasksTable actions', () => {
   it('should cancelTask', async () => {
     const dispatch = jest.fn();
     cancelTask({ ...taskInfo, url: 'some-url' })(dispatch);
+    await IntegrationTestHelper.flushAllPromises();
+    expect(dispatch.mock.calls).toHaveLength(3);
+  });
+  it('should forceCancelTask', async () => {
+    const dispatch = jest.fn();
+    forceCancelTask({ ...taskInfo, url: 'some-url' })(dispatch);
     await IntegrationTestHelper.flushAllPromises();
     expect(dispatch.mock.calls).toHaveLength(3);
   });

--- a/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.js
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.js
@@ -6,27 +6,41 @@ import { ActionButtons } from 'foremanReact/components/common/ActionButtons/Acti
 export const ActionButton = ({
   id,
   name,
-  availableActions: { resumable, cancellable },
+  availableActions: { resumable, cancellable, stoppable },
   taskActions,
 }) => {
   const buttons = [];
-  const title =
-    !resumable && !cancellable ? __('Task cannot be canceled') : undefined;
+  const isTitle = !(resumable || cancellable || stoppable);
+  const title = isTitle ? __('Task cannot be canceled') : undefined;
   if (resumable) {
     buttons.push({
       title: __('Resume'),
       action: {
         disabled: !resumable,
         onClick: () => taskActions.resumeTask(id, name),
+        id: `task-resume-button-${id}`,
       },
     });
   }
-  if (cancellable || !resumable) {
+  if (cancellable || (!stoppable && !resumable)) {
+    // Cancel is the default button that should be shown if no task action can be done
     buttons.push({
       title: __('Cancel'),
       action: {
         disabled: !cancellable,
         onClick: () => taskActions.cancelTask(id, name),
+        id: `task-cancel-button-${id}`,
+      },
+    });
+  }
+
+  if (stoppable) {
+    buttons.push({
+      title: __('Force Cancel'),
+      action: {
+        disabled: !stoppable,
+        onClick: () => taskActions.forceCancelTask(id, name),
+        id: `task-force-cancel-button-${id}`,
       },
     });
   }
@@ -43,9 +57,11 @@ ActionButton.propTypes = {
   availableActions: PropTypes.shape({
     cancellable: PropTypes.bool,
     resumable: PropTypes.bool,
+    stoppable: PropTypes.bool,
   }).isRequired,
   taskActions: PropTypes.shape({
     cancelTask: PropTypes.func,
     resumeTask: PropTypes.func,
+    forceCancelTask: PropTypes.func,
   }).isRequired,
 };

--- a/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.test.js
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/ActionButton.test.js
@@ -3,16 +3,17 @@ import { testComponentSnapshotsWithFixtures, shallow } from '@theforeman/test';
 
 import { ActionButton } from './ActionButton';
 
+const resumeTask = jest.fn();
+const cancelTask = jest.fn();
+const forceCancelTask = jest.fn();
+const taskActions = { resumeTask, cancelTask, forceCancelTask };
 const fixtures = {
   'render with cancellable true props': {
     availableActions: {
       cancellable: true,
       resumable: false,
     },
-    taskActions: {
-      cancelTask: jest.fn(),
-      resumeTask: jest.fn(),
-    },
+    taskActions,
     id: 'id',
     name: 'some-name',
   },
@@ -21,10 +22,16 @@ const fixtures = {
       cancellable: false,
       resumable: true,
     },
-    taskActions: {
-      cancelTask: jest.fn(),
-      resumeTask: jest.fn(),
+    taskActions,
+    id: 'id',
+    name: 'some-name',
+  },
+  'render with stoppable and cancellable true props': {
+    availableActions: {
+      cancellable: true,
+      stoppable: true,
     },
+    taskActions,
     id: 'id',
     name: 'some-name',
   },
@@ -33,10 +40,7 @@ const fixtures = {
       cancellable: false,
       resumable: false,
     },
-    taskActions: {
-      cancelTask: jest.fn(),
-      resumeTask: jest.fn(),
-    },
+    taskActions,
     id: 'id',
     name: 'some-name',
   },
@@ -46,11 +50,8 @@ describe('ActionButton', () => {
   describe('snapshot test', () =>
     testComponentSnapshotsWithFixtures(ActionButton, fixtures));
   describe('click test', () => {
-    const resumeTask = jest.fn();
-    const cancelTask = jest.fn();
     const id = 'some-id';
     const name = 'some-name';
-    const taskActions = { resumeTask, cancelTask };
     it('cancel', () => {
       const component = shallow(
         <ActionButton
@@ -72,9 +73,20 @@ describe('ActionButton', () => {
           taskActions={taskActions}
         />
       ).children();
-
       component.props().buttons[0].action.onClick();
       expect(resumeTask).toHaveBeenCalledWith(id, name);
+    });
+    it('force cancel', () => {
+      const component = shallow(
+        <ActionButton
+          id={id}
+          name={name}
+          availableActions={{ stoppable: true }}
+          taskActions={taskActions}
+        />
+      ).children();
+      component.props().buttons[0].action.onClick();
+      expect(cancelTask).toHaveBeenCalledWith(id, name);
     });
   });
 });

--- a/webpack/ForemanTasks/Components/common/ActionButtons/__snapshots__/ActionButton.test.js.snap
+++ b/webpack/ForemanTasks/Components/common/ActionButtons/__snapshots__/ActionButton.test.js.snap
@@ -10,6 +10,7 @@ exports[`ActionButton snapshot test render with cancellable false props 1`] = `
         Object {
           "action": Object {
             "disabled": true,
+            "id": "task-cancel-button-id",
             "onClick": [Function],
           },
           "title": "Cancel",
@@ -28,6 +29,7 @@ exports[`ActionButton snapshot test render with cancellable true props 1`] = `
         Object {
           "action": Object {
             "disabled": false,
+            "id": "task-cancel-button-id",
             "onClick": [Function],
           },
           "title": "Cancel",
@@ -46,9 +48,37 @@ exports[`ActionButton snapshot test render with resumable true props 1`] = `
         Object {
           "action": Object {
             "disabled": false,
+            "id": "task-resume-button-id",
             "onClick": [Function],
           },
           "title": "Resume",
+        },
+      ]
+    }
+  />
+</span>
+`;
+
+exports[`ActionButton snapshot test render with stoppable and cancellable true props 1`] = `
+<span>
+  <ActionButtons
+    buttons={
+      Array [
+        Object {
+          "action": Object {
+            "disabled": false,
+            "id": "task-cancel-button-id",
+            "onClick": [Function],
+          },
+          "title": "Cancel",
+        },
+        Object {
+          "action": Object {
+            "disabled": false,
+            "id": "task-force-cancel-button-id",
+            "onClick": [Function],
+          },
+          "title": "Force Cancel",
         },
       ]
     }


### PR DESCRIPTION
Each task - row should have a force cancel button (if the task is not already stopped)
Does not include unlock for multiple tasks
depends on https://github.com/theforeman/foreman-tasks/pull/539