### PR TITLE
Fixes #29731 - Add bulk force unlock api for tasks

### DIFF
--- a/app/services/ui_notifications/tasks/task_bulk_stop.rb
+++ b/app/services/ui_notifications/tasks/task_bulk_stop.rb
@@ -1,0 +1,36 @@
+module UINotifications
+  module Tasks
+    class TaskBulkStop < ::UINotifications::Base
+      def initialize(task, stopped_length, skipped_length)
+        @subject = task
+        @stopped_length = stopped_length
+        @skipped_length = skipped_length
+      end
+
+      def create
+        Notification.create!(
+          initiator: initiator,
+          audience: audience,
+          subject: subject,
+          notification_blueprint: blueprint,
+          message: message,
+          notification_recipients: [NotificationRecipient.create(:user => User.current)]
+        )
+      end
+
+      def audience
+        Notification::AUDIENCE_GLOBAL
+      end
+
+      def message
+        ('%{stopped} Tasks were stopped. %{skipped} Tasks were already stopped. ' %
+          { stopped: @stopped_length,
+          skipped: @skipped_length })
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.find_by(name: 'tasks_bulk_stop')
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Foreman::Application.routes.draw do
           post :bulk_search
           post :bulk_resume
           post :bulk_cancel
+          post :bulk_stop
           get :summary
           get '/summary/:id/sub_tasks/', action: 'summary_sub_tasks'
           post :callback

--- a/db/seeds.d/30-notification_blueprints.rb
+++ b/db/seeds.d/30-notification_blueprints.rb
@@ -41,6 +41,13 @@ blueprints = [
     name: 'tasks_bulk_cancel',
     level: 'info',
     message: "DYNAMIC",
+  },
+
+  {
+    group: N_('Tasks'),
+    name: 'tasks_bulk_stop',
+    level: 'info',
+    message: "DYNAMIC",
   }
 ]
 

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -53,7 +53,7 @@ module ForemanTasks
                                             :'foreman_tasks/react' => [:index],
                                             :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :summary_sub_tasks, :details, :sub_tasks] }, :resource_type => ForemanTasks::Task.name
           permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],
-                                            :'foreman_tasks/api/tasks' => [:bulk_resume, :bulk_cancel] }, :resource_type => ForemanTasks::Task.name
+                                            :'foreman_tasks/api/tasks' => [:bulk_resume, :bulk_cancel, :bulk_stop] }, :resource_type => ForemanTasks::Task.name
 
           permission :create_recurring_logics, {}, :resource_type => ForemanTasks::RecurringLogic.name
 


### PR DESCRIPTION
Can bulk cancel tasks using search or tasks ids using the api `/bulk_stop/`
Response is the stopped tasks and the number of tasks in the request that were already stopped.
User also gets a notification when its done.