### PR TITLE
Fixes #29736 - Add bulk force unlock button in tasks table

### DIFF
--- a/webpack/ForemanTasks/Components/TaskActions/TaskActionHelpers.js
+++ b/webpack/ForemanTasks/Components/TaskActions/TaskActionHelpers.js
@@ -60,7 +60,7 @@ export const toastDispatch = ({ type, name, toastInfo, dispatch }) => {
       type: toastInfo[type].type,
       message: sprintf('%(name)s Task execution %(type)s', {
         name,
-        type: toastInfo[type].text,
+        type: toastInfo[type].message,
       }),
     })
   );

--- a/webpack/ForemanTasks/Components/TaskActions/UnlockModals.js
+++ b/webpack/ForemanTasks/Components/TaskActions/UnlockModals.js
@@ -28,7 +28,7 @@ export const ForceUnlockModal = ({ onClick, id, selectedRowsLen }) => (
     title={__('Force Unlock')}
     body={sprintf(
       __(
-        `Resources for %s task(s) will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck.`
+        `Resources for %s task(s) will be unlocked and will not prevent other tasks from being run. As the task(s) might be still running, it should be avoided to use this unless you are really sure the task(s) got stuck.`
       ),
       selectedRowsLen
     )}

--- a/webpack/ForemanTasks/Components/TaskActions/__snapshots__/UnlockModals.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskActions/__snapshots__/UnlockModals.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ForceUnlockModal render 1`] = `
 <ClickConfirmation
-  body="Resources for 1 task(s) will be unlocked and will not prevent other tasks from being run. As the task might be still running, it should be avoided to use this unless you are really sure the task got stuck."
+  body="Resources for 1 task(s) will be unlocked and will not prevent other tasks from being run. As the task(s) might be still running, it should be avoided to use this unless you are really sure the task(s) got stuck."
   confirmAction="Force Unlock"
   confirmType="danger"
   confirmationMessage="I understand that this may cause harm and have working database backups of all backend services."

--- a/webpack/ForemanTasks/Components/TaskActions/index.js
+++ b/webpack/ForemanTasks/Components/TaskActions/index.js
@@ -15,7 +15,7 @@ import {
   TASKS_UNLOCK_SUCCESS,
   TASKS_UNLOCK_FAILURE,
 } from './TaskActionsConstants';
-import { TOAST_TYPES } from '../common/ToastsHelpers/ToastTypesConstants';
+import { infoToastData } from '../common/ToastsHelpers/';
 import {
   resumeToastInfo,
   cancelToastInfo,
@@ -25,12 +25,7 @@ import {
 } from './TaskActionHelpers';
 
 export const cancelTaskRequest = (id, name) => async dispatch => {
-  dispatch(
-    addToast({
-      type: TOAST_TYPES.INFO,
-      message: sprintf('Trying to cancel %s task', name),
-    })
-  );
+  dispatch(addToast(infoToastData(sprintf('Trying to cancel %s task', name))));
   dispatch({ type: TASKS_CANCEL_REQUEST });
   try {
     await API.post(`/foreman_tasks/tasks/${id}/cancel`);

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ActionSelectButton.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ActionSelectButton.js
@@ -3,7 +3,12 @@ import { DropdownButton, MenuItem } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-export const ActionSelectButton = ({ onCancel, onResume, disabled }) => (
+export const ActionSelectButton = ({
+  onCancel,
+  onResume,
+  onForceCancel,
+  disabled,
+}) => (
   <DropdownButton
     title={__('Select Action')}
     disabled={disabled}
@@ -23,6 +28,13 @@ export const ActionSelectButton = ({ onCancel, onResume, disabled }) => (
     >
       {__('Resume Selected')}
     </MenuItem>
+    <MenuItem
+      title={__('Force Cancel selected tasks')}
+      onClick={onForceCancel}
+      eventKey="3"
+    >
+      {__('Force Cancel Selected')}
+    </MenuItem>
   </DropdownButton>
 );
 
@@ -30,6 +42,7 @@ ActionSelectButton.propTypes = {
   disabled: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onResume: PropTypes.func.isRequired,
+  onForceCancel: PropTypes.func.isRequired,
 };
 
 ActionSelectButton.defaultProps = {

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModal.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModal.js
@@ -5,6 +5,7 @@ import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { Button } from 'patternfly-react';
 import ForemanModal from 'foremanReact/components/ForemanModal';
 import { FORCE_UNLOCK_MODAL } from '../../../TaskActions/TaskActionsConstants';
+import { FORCE_UNLOCK_SELECTED_MODAL } from '../../TasksTableConstants';
 import { ForceUnlockModal } from '../../../TaskActions/UnlockModals';
 
 export const ConfirmModal = ({
@@ -19,7 +20,7 @@ export const ConfirmModal = ({
   setModalClosed,
   ...props
 }) => {
-  if (actionType === FORCE_UNLOCK_MODAL) {
+  if ([FORCE_UNLOCK_MODAL, FORCE_UNLOCK_SELECTED_MODAL].includes(actionType)) {
     return (
       <ForceUnlockModal
         onClick={() => {

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/ConfirmModalActions.js
@@ -8,6 +8,8 @@ import {
   bulkCancelById,
   bulkResumeBySearch,
   bulkResumeById,
+  bulkForceCancelBySearch,
+  bulkForceCancelById,
 } from '../../TasksBulkActions';
 import { selectClicked, selectSelectedTasks } from './ConfirmModalSelectors';
 import { selectAllRowsSelected } from '../../TasksTableSelectors';
@@ -16,6 +18,7 @@ import {
   RESUME_MODAL,
   CANCEL_SELECTED_MODAL,
   RESUME_SELECTED_MODAL,
+  FORCE_UNLOCK_SELECTED_MODAL,
 } from '../../TasksTableConstants';
 import { FORCE_UNLOCK_MODAL } from '../../../TaskActions/TaskActionsConstants';
 
@@ -80,6 +83,21 @@ export default {
       forceCancelTask({
         taskId,
         taskName,
+        url,
+        parentTaskID,
+      })
+    );
+  },
+  [FORCE_UNLOCK_SELECTED_MODAL]: ({ url, query, parentTaskID }) => (
+    dispatch,
+    getState
+  ) => {
+    if (selectAllRowsSelected(getState())) {
+      return dispatch(bulkForceCancelBySearch({ query, parentTaskID }));
+    }
+    return dispatch(
+      bulkForceCancelById({
+        selected: selectSelectedTasks(getState()),
         url,
         parentTaskID,
       })

--- a/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/ConfirmModal/__test__/ConfirmModalActions.test.js
@@ -4,17 +4,23 @@ import {
   RESUME_MODAL,
   CANCEL_SELECTED_MODAL,
   RESUME_SELECTED_MODAL,
+  FORCE_UNLOCK_SELECTED_MODAL,
 } from '../../../TasksTableConstants';
 
 import { FORCE_UNLOCK_MODAL } from '../../../../TaskActions/TaskActionsConstants';
 
-import { resumeTask, cancelTask } from '../../../TasksTableActions';
+import {
+  resumeTask,
+  cancelTask,
+  forceCancelTask,
+} from '../../../TasksTableActions';
 import {
   bulkCancelBySearch,
   bulkCancelById,
   bulkResumeBySearch,
   bulkResumeById,
-  forceCancelTask,
+  bulkForceCancelBySearch,
+  bulkForceCancelById,
 } from '../../../TasksBulkActions';
 
 jest.mock('../../../TasksBulkActions');
@@ -24,15 +30,21 @@ const bulkCancelBySearchMock = 'bulkCancelBySearchMock';
 const bulkCancelByIdMock = 'bulkCancelByIdMock';
 const bulkResumeBySearchMock = 'bulkResumeBySearchMock';
 const bulkResumeByIdMock = 'bulkResumeByIdMock';
+const bulkForceCancelBySearchMock = 'bulkForceCancelBySearchMock';
+const bulkForceCancelByIdMock = 'bulkForceCancelByIdMock';
 const resumeTaskMock = 'resumeTaskMock';
 const cancelTaskMock = 'cancelTaskMock';
+const forceCancelTaskMock = 'forceCancelTaskMock';
 
 bulkCancelBySearch.mockImplementation(() => bulkCancelBySearchMock);
 bulkCancelById.mockImplementation(() => bulkCancelByIdMock);
 bulkResumeBySearch.mockImplementation(() => bulkResumeBySearchMock);
 bulkResumeById.mockImplementation(() => bulkResumeByIdMock);
+bulkForceCancelBySearch.mockImplementation(() => bulkForceCancelBySearchMock);
+bulkForceCancelById.mockImplementation(() => bulkForceCancelByIdMock);
 resumeTask.mockImplementation(() => resumeTaskMock);
 cancelTask.mockImplementation(() => cancelTaskMock);
+forceCancelTask.mockImplementation(() => forceCancelTaskMock);
 
 const url = 'some-url';
 const query = 'some-query';
@@ -109,7 +121,7 @@ describe('ConfirmModalActions', () => {
       url,
       parentTaskID,
     });
-    expect(dispatch).toBeCalledWith(forceCancelTask);
+    expect(dispatch).toBeCalledWith(forceCancelTaskMock);
   });
   it('run CANCEL_SELECTED_MODAL by id', () => {
     runWithGetState(
@@ -163,5 +175,31 @@ describe('ConfirmModalActions', () => {
       }
     );
     expect(dispatch).toBeCalledWith(bulkResumeBySearchMock);
+  });
+  it('run FORCE_UNLOCK_SELECTED_MODAL by id', () => {
+    runWithGetState(
+      selectedState,
+      taskActions[FORCE_UNLOCK_SELECTED_MODAL],
+      dispatch,
+      {
+        url,
+        query,
+        parentTaskID,
+      }
+    );
+    expect(dispatch).toBeCalledWith(bulkForceCancelByIdMock);
+  });
+  it('run FORCE_UNLOCK_SELECTED_MODAL by search', () => {
+    runWithGetState(
+      allRowsState,
+      taskActions[FORCE_UNLOCK_SELECTED_MODAL],
+      dispatch,
+      {
+        url,
+        query,
+        parentTaskID,
+      }
+    );
+    expect(dispatch).toBeCalledWith(bulkForceCancelBySearchMock);
   });
 });

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/ActionSelectButton.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/ActionSelectButton.test.js
@@ -6,6 +6,7 @@ const fixtures = {
   'renders with minimal props': {
     onCancel: jest.fn(),
     onResume: jest.fn(),
+    onForceCancel: jest.fn(),
   },
 };
 

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/ActionSelectButton.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/ActionSelectButton.test.js.snap
@@ -28,5 +28,16 @@ exports[`ActionSelectButton renders with minimal props 1`] = `
   >
     Resume Selected
   </MenuItem>
+  <MenuItem
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    eventKey="3"
+    header={false}
+    onClick={[MockFunction]}
+    title="Force Cancel selected tasks"
+  >
+    Force Cancel Selected
+  </MenuItem>
 </DropdownButton>
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
@@ -24,7 +24,6 @@ import {
   resumeToastInfo,
   cancelToastInfo,
   toastDispatch,
-  forceCancelToastInfo,
 } from '../TaskActions/TaskActionHelpers';
 
 export const bulkByIdRequest = (resumeTasks, path) => {
@@ -196,31 +195,33 @@ export const bulkForceCancelById = ({
         ),
       })
     );
-  if (stopTasks.length) {
+  if (stopTasks.length > 0) {
     dispatch({ type: TASKS_FORCE_CANCEL_REQUEST });
     try {
       const { data } = await bulkByIdRequest(stopTasks, BULK_FORCE_CANCEL_PATH);
       dispatch({ type: TASKS_FORCE_CANCEL_SUCCESS });
-      if (data.stopped) {
-        data.stopped.forEach(task => {
-          toastDispatch({
-            type: 'forceCancelled',
-            name: task.action,
-            toastInfo: forceCancelToastInfo,
-            dispatch,
-          });
-        });
+      if (data.stopped_length) {
+        dispatch(
+          addToast({
+            type: TOAST_TYPES.SUCCESS,
+            message: sprintf(
+              '%s task(s) cancelled with force',
+              data.stopped_length
+            ),
+          })
+        );
       }
-      dispatch(
-        addToast({
-          type: TOAST_TYPES.WARNING,
-          message: sprintf(
-            '%s task(s) are already stopped',
-            data.skipped_length
-          ),
-        })
-      );
-      if (data.stopped) {
+      if (data.skipped_length > 0)
+        dispatch(
+          addToast({
+            type: TOAST_TYPES.WARNING,
+            message: sprintf(
+              '%s task(s) are already stopped',
+              data.skipped_length
+            ),
+          })
+        );
+      if (data.stopped_length > 0) {
         reloadPage(url, parentTaskID, dispatch);
       }
     } catch (error) {

--- a/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
@@ -1,7 +1,6 @@
 import API from 'foremanReact/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { translate as __, sprintf } from 'foremanReact/common/I18n';
-import { TOAST_TYPES } from '../common/ToastsHelpers/ToastTypesConstants';
 import {
   BULK_CANCEL_PATH,
   BULK_RESUME_PATH,
@@ -25,6 +24,12 @@ import {
   cancelToastInfo,
   toastDispatch,
 } from '../TaskActions/TaskActionHelpers';
+import {
+  successToastData,
+  errorToastData,
+  warningToastData,
+  infoToastData,
+} from '../common/ToastsHelpers';
 
 export const bulkByIdRequest = (resumeTasks, path) => {
   const ids = resumeTasks.map(task => task.id);
@@ -47,10 +52,9 @@ export const bulkBySearchRequest = ({ query, parentTaskID, path }) => {
 const handleErrorResume = (error, dispatch) => {
   dispatch({ type: TASKS_RESUME_FAILURE, error });
   dispatch(
-    addToast({
-      type: TOAST_TYPES.ERROR,
-      message: `${__(`Cannot resume tasks at the moment`)} ${error}`,
-    })
+    addToast(
+      errorToastData(`${__(`Cannot resume tasks at the moment`)} ${error}`)
+    )
   );
 };
 
@@ -62,10 +66,9 @@ export const bulkResumeById = ({
   const resumeTasks = selected.filter(task => task.isResumable);
   if (resumeTasks.length < selected.length)
     dispatch(
-      addToast({
-        type: TOAST_TYPES.WARNING,
-        message: __('Not all the selected tasks can be resumed'),
-      })
+      addToast(
+        warningToastData(__('Not all the selected tasks can be resumed'))
+      )
     );
   if (resumeTasks.length) {
     dispatch({ type: TASKS_RESUME_REQUEST });
@@ -98,10 +101,9 @@ export const bulkResumeBySearch = ({
 }) => async dispatch => {
   dispatch({ type: TASKS_RESUME_REQUEST });
   dispatch(
-    addToast({
-      type: 'info',
-      message: __('Resuming selected tasks, this might take a while'),
-    })
+    addToast(
+      infoToastData(__('Resuming selected tasks, this might take a while'))
+    )
   );
   await bulkBySearchRequest({ query, path: BULK_RESUME_PATH, parentTaskID });
 };
@@ -109,10 +111,9 @@ export const bulkResumeBySearch = ({
 const handleErrorCancel = (error, dispatch) => {
   dispatch({ type: TASKS_CANCEL_FAILURE, error });
   dispatch(
-    addToast({
-      type: TOAST_TYPES.ERROR,
-      message: `${__(`Cannot cancel tasks at the moment`)} ${error}`,
-    })
+    addToast(
+      errorToastData(`${__(`Cannot cancel tasks at the moment`)} ${error}`)
+    )
   );
 };
 
@@ -122,10 +123,9 @@ export const bulkCancelBySearch = ({
 }) => async dispatch => {
   dispatch({ type: TASKS_CANCEL_REQUEST });
   dispatch(
-    addToast({
-      type: 'info',
-      message: __('Canceling selected tasks, this might take a while'),
-    })
+    addToast(
+      infoToastData(__('Canceling selected tasks, this might take a while'))
+    )
   );
   await bulkBySearchRequest({ query, path: BULK_CANCEL_PATH, parentTaskID });
 };
@@ -138,10 +138,9 @@ export const bulkCancelById = ({
   const cancelTasks = selected.filter(task => task.isCancellable);
   if (cancelTasks.length < selected.length)
     dispatch(
-      addToast({
-        type: TOAST_TYPES.WARNING,
-        message: __('Not all the selected tasks can be cancelled'),
-      })
+      addToast(
+        warningToastData(__('Not all the selected tasks can be cancelled'))
+      )
     );
   if (cancelTasks.length) {
     dispatch({ type: TASKS_CANCEL_REQUEST });
@@ -172,10 +171,11 @@ export const bulkCancelById = ({
 const handleErrorForceCancel = (error, dispatch) => {
   dispatch({ type: TASKS_FORCE_CANCEL_FAILURE, error });
   dispatch(
-    addToast({
-      type: TOAST_TYPES.ERROR,
-      message: `${__(`Cannot force cancel tasks at the moment`)} ${error}`,
-    })
+    addToast(
+      errorToastData(
+        `${__(`Cannot force cancel tasks at the moment`)} ${error}`
+      )
+    )
   );
 };
 
@@ -187,13 +187,14 @@ export const bulkForceCancelById = ({
   const stopTasks = selected.filter(task => task.state !== 'stopped');
   if (stopTasks.length < selected.length)
     dispatch(
-      addToast({
-        type: TOAST_TYPES.WARNING,
-        message: sprintf(
-          '%s task(s) are already stopped',
-          selected.length - stopTasks.length
-        ),
-      })
+      addToast(
+        warningToastData(
+          sprintf(
+            '%s task(s) are already stopped',
+            selected.length - stopTasks.length
+          )
+        )
+      )
     );
   if (stopTasks.length > 0) {
     dispatch({ type: TASKS_FORCE_CANCEL_REQUEST });
@@ -202,24 +203,20 @@ export const bulkForceCancelById = ({
       dispatch({ type: TASKS_FORCE_CANCEL_SUCCESS });
       if (data.stopped_length) {
         dispatch(
-          addToast({
-            type: TOAST_TYPES.SUCCESS,
-            message: sprintf(
-              '%s task(s) cancelled with force',
-              data.stopped_length
-            ),
-          })
+          addToast(
+            successToastData(
+              sprintf('%s task(s) cancelled with force', data.stopped_length)
+            )
+          )
         );
       }
       if (data.skipped_length > 0)
         dispatch(
-          addToast({
-            type: TOAST_TYPES.WARNING,
-            message: sprintf(
-              '%s task(s) are already stopped',
-              data.skipped_length
-            ),
-          })
+          addToast(
+            warningToastData(
+              sprintf('%s task(s) are already stopped', data.skipped_length)
+            )
+          )
         );
       if (data.stopped_length > 0) {
         reloadPage(url, parentTaskID, dispatch);
@@ -236,12 +233,11 @@ export const bulkForceCancelBySearch = ({
 }) => async dispatch => {
   dispatch({ type: TASKS_FORCE_CANCEL_REQUEST });
   dispatch(
-    addToast({
-      type: 'info',
-      message: __(
-        'Canceling with force selected tasks, this might take a while'
-      ),
-    })
+    addToast(
+      infoToastData(
+        __('Canceling with force selected tasks, this might take a while')
+      )
+    )
   );
   await bulkBySearchRequest({
     query,

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
@@ -10,12 +10,14 @@ export const OPEN_SELECT_ALL = 'OPEN_SELECT_ALL';
 
 export const BULK_CANCEL_PATH = 'bulk_cancel';
 export const BULK_RESUME_PATH = 'bulk_resume';
+export const BULK_FORCE_CANCEL_PATH = 'bulk_stop';
 
 export const CANCEL_MODAL = 'cancelConfirmModal';
 export const RESUME_MODAL = 'resumeConfirmModal';
 export const CANCEL_SELECTED_MODAL = 'cancelSelectedConfirmModal';
 export const RESUME_SELECTED_MODAL = 'resumeSelectedConfirmModal';
 export const CONFIRM_MODAL = 'ConfirmModal';
+export const FORCE_UNLOCK_SELECTED_MODAL = 'forceUnlockSelectedConfirmModal';
 
 export const UPDATE_CLICKED = 'UPDATE_CLICKED';
 export const UPDATE_MODAL = 'UPDATE_MODAL';

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -16,6 +16,7 @@ import {
   TASKS_SEARCH_PROPS,
   CANCEL_SELECTED_MODAL,
   RESUME_SELECTED_MODAL,
+  FORCE_UNLOCK_SELECTED_MODAL,
   CONFIRM_MODAL,
 } from './TasksTableConstants';
 import { ActionSelectButton } from './Components/ActionSelectButton';
@@ -71,6 +72,7 @@ const TasksTablePage = ({
               disabled={!(props.selectedRows.length || props.allRowsSelected)}
               onCancel={() => openModal(CANCEL_SELECTED_MODAL)}
               onResume={() => openModal(RESUME_SELECTED_MODAL)}
+              onForceCancel={() => openModal(FORCE_UNLOCK_SELECTED_MODAL)}
             />
           </React.Fragment>
         }

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
@@ -5,6 +5,8 @@ import {
   bulkCancelBySearch,
   bulkResumeById,
   bulkResumeBySearch,
+  bulkForceCancelById,
+  bulkForceCancelBySearch,
 } from '../TasksBulkActions';
 
 jest.mock('foremanReact/components/common/table', () => ({
@@ -68,6 +70,19 @@ const fixtures = {
     }));
     return bulkCancelById({ selected, url: 'some-url' });
   },
+
+  'handles bulkForceCancelById requests': () => {
+    const selected = [{ ...task, isCancellable: true }];
+
+    API.post.mockImplementation(() => ({
+      data: {
+        stopped: [{ action: 'I am cancelled' }],
+        skipped_length: 4,
+      },
+    }));
+    return bulkForceCancelById({ selected, url: 'some-url' });
+  },
+
   'handles bulkCancelById requests that are not cancellable': () => {
     const selected = [{ ...task, isCancellable: false }];
     return bulkCancelById({ selected, url: 'some-url' });
@@ -75,6 +90,11 @@ const fixtures = {
   'handles bulkResumeById requests that are not resumable': () => {
     const selected = [{ ...task, isResumable: false, isCancellable: false }];
     return bulkResumeById({ selected, url: 'some-url' });
+  },
+
+  'handles bulkForceCancelById requests that are stopped': () => {
+    const selected = [{ ...task, isResumable: false, state: 'stopped' }];
+    return bulkForceCancelById({ selected, url: 'some-url' });
   },
 
   'handles bulkCancelBySearch requests': () => {
@@ -100,6 +120,19 @@ const fixtures = {
       },
     }));
     return bulkResumeBySearch({
+      query: { search: {} },
+      url: 'some-url',
+      parentTaskID: 'parent',
+    });
+  },
+  'handles bulkForceCancelBySearch requests': () => {
+    API.post.mockImplementation(() => ({
+      data: {
+        stopped: [{ action: 'I am cancelled' }],
+        skipped_length: 7,
+      },
+    }));
+    return bulkForceCancelBySearch({
       query: { search: {} },
       url: 'some-url',
       parentTaskID: 'parent',

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
@@ -76,7 +76,7 @@ const fixtures = {
 
     API.post.mockImplementation(() => ({
       data: {
-        stopped: [{ action: 'I am cancelled' }],
+        stopped_length: 2,
         skipped_length: 4,
       },
     }));
@@ -125,19 +125,12 @@ const fixtures = {
       parentTaskID: 'parent',
     });
   },
-  'handles bulkForceCancelBySearch requests': () => {
-    API.post.mockImplementation(() => ({
-      data: {
-        stopped: [{ action: 'I am cancelled' }],
-        skipped_length: 7,
-      },
-    }));
-    return bulkForceCancelBySearch({
+  'handles bulkForceCancelBySearch requests': () =>
+    bulkForceCancelBySearch({
       query: { search: {} },
       url: 'some-url',
       parentTaskID: 'parent',
-    });
-  },
+    }),
 };
 
 describe('TasksTable bulk actions', () => {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
@@ -83,6 +83,15 @@ const fixtures = {
     return bulkForceCancelById({ selected, url: 'some-url' });
   },
 
+  'handles bulkForceCancelById requests that fail': () => {
+    const selected = [{ ...task, isResumable: true }];
+
+    API.post.mockImplementation(() =>
+      Promise.reject(new Error('Network Error'))
+    );
+    return bulkForceCancelById({ selected, url: 'some-url' });
+  },
+
   'handles bulkCancelById requests that are not cancellable': () => {
     const selected = [{ ...task, isCancellable: false }];
     return bulkCancelById({ selected, url: 'some-url' });

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
@@ -128,6 +128,33 @@ Array [
 ]
 `;
 
+exports[`TasksTable bulk actions handles bulkForceCancelById requests that fail 1`] = `
+Array [
+  Array [
+    Object {
+      "type": "TASKS_FORCE_CANCEL_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "error": [Error: Network Error],
+      "type": "TASKS_FORCE_CANCEL_FAILURE",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Cannot force cancel tasks at the moment Error: Network Error",
+          "type": "error",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`TasksTable bulk actions handles bulkForceCancelBySearch requests 1`] = `
 Array [
   Array [

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
@@ -85,7 +85,7 @@ Array [
     Object {
       "payload": Object {
         "message": Object {
-          "message": "I am cancelled Task execution resources were unlocked with force.",
+          "message": "2 task(s) cancelled with force",
           "type": "success",
         },
       },

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksBulkActions.test.js.snap
@@ -69,6 +69,86 @@ Array [
 ]
 `;
 
+exports[`TasksTable bulk actions handles bulkForceCancelById requests 1`] = `
+Array [
+  Array [
+    Object {
+      "type": "TASKS_FORCE_CANCEL_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "type": "TASKS_FORCE_CANCEL_SUCCESS",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "I am cancelled Task execution resources were unlocked with force.",
+          "type": "success",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "4 task(s) are already stopped",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+  Array [
+    "TASKS_TABLE",
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`TasksTable bulk actions handles bulkForceCancelById requests that are stopped 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "1 task(s) are already stopped",
+          "type": "warning",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`TasksTable bulk actions handles bulkForceCancelBySearch requests 1`] = `
+Array [
+  Array [
+    Object {
+      "type": "TASKS_FORCE_CANCEL_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "Canceling with force selected tasks, this might take a while",
+          "type": "info",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`TasksTable bulk actions handles bulkResumeById requests that are not resumable 1`] = `
 Array [
   Array [

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -83,6 +83,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
         <ActionSelectButton
           disabled={true}
           onCancel={[Function]}
+          onForceCancel={[Function]}
           onResume={[Function]}
         />
       </React.Fragment>
@@ -200,6 +201,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
         <ActionSelectButton
           disabled={true}
           onCancel={[Function]}
+          onForceCancel={[Function]}
           onResume={[Function]}
         />
       </React.Fragment>

--- a/webpack/ForemanTasks/Components/common/ClickConfirmation/ClickConfirmation.scss
+++ b/webpack/ForemanTasks/Components/common/ClickConfirmation/ClickConfirmation.scss
@@ -1,0 +1,9 @@
+.confirmation-check {
+  margin-top: 1em;
+  input {
+    vertical-align: text-top;
+  }
+  span {
+    vertical-align: middle;
+  }
+}

--- a/webpack/ForemanTasks/Components/common/ClickConfirmation/__snapshots__/ClickConfirmation.test.js.snap
+++ b/webpack/ForemanTasks/Components/common/ClickConfirmation/__snapshots__/ClickConfirmation.test.js.snap
@@ -10,14 +10,20 @@ exports[`ClickConfirmation render 1`] = `
     />
      some-title
   </Component>
-  some-body
-  <div>
+  <span>
+    some-body
+  </span>
+  <div
+    className="confirmation-check"
+  >
     <input
       checked={false}
       onChange={[Function]}
       type="checkbox"
     />
-     some-message
+    <span>
+       some-message
+    </span>
   </div>
   <Component>
     <Button

--- a/webpack/ForemanTasks/Components/common/ClickConfirmation/index.js
+++ b/webpack/ForemanTasks/Components/common/ClickConfirmation/index.js
@@ -4,6 +4,7 @@ import { Button } from 'patternfly-react';
 import ForemanModal from 'foremanReact/components/ForemanModal';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
+import './ClickConfirmation.scss';
 
 export const ClickConfirmation = ({
   title,
@@ -29,8 +30,8 @@ export const ClickConfirmation = ({
         <span className={`glyphicon glyphicon-${icon}-sign`} />
         {` ${title}`}
       </ForemanModal.Header>
-      {body}
-      <div>
+      <span>{body}</span>
+      <div className="confirmation-check">
         <input
           onChange={e => {
             setConfirm(e.target.checked);
@@ -38,7 +39,7 @@ export const ClickConfirmation = ({
           checked={isConfirmed}
           type="checkbox"
         />
-        {` ${confirmationMessage}`}
+        <span>{` ${confirmationMessage}`}</span>
       </div>
       <ForemanModal.Footer>
         <Button

--- a/webpack/ForemanTasks/Components/common/ToastsHelpers/index.js
+++ b/webpack/ForemanTasks/Components/common/ToastsHelpers/index.js
@@ -1,5 +1,15 @@
 import { TOAST_TYPES } from './ToastTypesConstants';
 
-export const successToastData = text => ({ type: TOAST_TYPES.SUCCESS, text });
-export const errorToastData = text => ({ type: TOAST_TYPES.ERROR, text });
-export const warningToastData = text => ({ type: TOAST_TYPES.WARNING, text });
+export const successToastData = message => ({
+  type: TOAST_TYPES.SUCCESS,
+  message,
+});
+export const errorToastData = message => ({ type: TOAST_TYPES.ERROR, message });
+export const warningToastData = message => ({
+  type: TOAST_TYPES.WARNING,
+  message,
+});
+export const infoToastData = message => ({
+  type: TOAST_TYPES.INFO,
+  message,
+});


### PR DESCRIPTION
Adds a button to bulk stop selected tasks in the tasks table.
ignores "allow dangerous actions" setting
Depends on: https://github.com/theforeman/foreman-tasks/pull/543, https://github.com/theforeman/foreman-tasks/pull/541