### PR TITLE
Fixes #29594 - Fix wrong bookmark controller

### DIFF
--- a/db/migrate/20200517215015_rename_bookmarks_controller.rb
+++ b/db/migrate/20200517215015_rename_bookmarks_controller.rb
@@ -1,0 +1,35 @@
+class RenameBookmarksController < ActiveRecord::Migration[5.2]
+  def up
+    original_controller = 'foreman_tasks_tasks'
+    original_bookmarks = Bookmark.where(controller: original_controller)
+    original_bookmarks_names = Hash[original_bookmarks.pluck(:name, :id)]
+    
+    new_controller = 'foreman_tasks/tasks'
+    new_bookmarks = Bookmark.where(controller: new_controller)
+    new_bookmarks.find_each do |new_bookmark|
+      name = new_bookmark.name
+      is_name_taken = original_bookmarks_names.key? name
+
+      if is_name_taken
+        original_bookmark = original_bookmarks.find(original_bookmarks_names[name])
+        is_duplicated = original_bookmark.query == new_bookmark.query &&
+                        original_bookmark.owner_id == new_bookmark.owner_id &&
+                        original_bookmark.owner_type == new_bookmark.owner_type &&
+                        original_bookmark.public == new_bookmark.public
+
+        if is_duplicated
+          original_bookmark.destroy     
+        else
+          modified_name = "#{name}_#{generate_token}"
+          original_bookmark.update(name: modified_name)
+        end
+      end
+      # Revert to the original controller name
+      new_bookmark.update(controller: original_controller)
+    end
+  end
+
+  def generate_token
+    SecureRandom.base64(5).gsub(/[^0-9a-z ]/i, '')
+  end
+end

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
@@ -19,5 +19,5 @@ export const UPDATE_CLICKED = 'UPDATE_CLICKED';
 
 export const TASKS_SEARCH_PROPS = {
   ...getControllerSearchProps('tasks'),
-  controller: 'foreman_tasks/tasks',
+  controller: 'foreman_tasks_tasks',
 };

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -85,7 +85,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
           "documentationUrl": "4.1.5Searching",
           "url": "/api/bookmarks",
         },
-        "controller": "foreman_tasks/tasks",
+        "controller": "foreman_tasks_tasks",
       }
     }
     searchQuery="a=b"
@@ -255,7 +255,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
           "documentationUrl": "4.1.5Searching",
           "url": "/api/bookmarks",
         },
-        "controller": "foreman_tasks/tasks",
+        "controller": "foreman_tasks_tasks",
       }
     }
     searchQuery="a=b"


### PR DESCRIPTION
The bookmarks controller was changed to `foreman_tasks/tasks`
it means that users that had saved bookmarks on the original controller (`foreman_tasks_tasks`)
can't see all of their original bookmarks..
This change in the UI and the DB migration, changes to the right bookmarks controller.

old bookmark with the same name as the new bookmark
will be renamed to `#{token}_#{name}`..