### PR TITLE
Fixes #29966 - test fails in eslint for routes test

### DIFF
--- a/webpack/ForemanTasks/Routes/ForemanTasksRoutes.test.js
+++ b/webpack/ForemanTasks/Routes/ForemanTasksRoutes.test.js
@@ -6,7 +6,8 @@ import ForemanTasksRoutes from './ForemanTasksRoutes';
 describe('ForemanTasksRoutes', () => {
   it('should create routes', () => {
     Object.entries(ForemanTasksRoutes).forEach(([key, Route]) => {
-      const component = shallow(<Route.render history={{}} some="props" />);
+      const RouteRender = Route.render;
+      const component = shallow(<RouteRender history={{}} some="props" />);
       Route.renderResult = component;
     });
 


### PR DESCRIPTION
`/home/travis/build/theforeman/foreman-tasks/webpack/ForemanTasks/Routes/ForemanTasksRoutes.test.js`

`9:33 error Imported JSX component render must be in PascalCase or SCREAMING_SNAKE_CASE react/jsx-pascal-case`