### PR TITLE
Fixes #30009 - v1.2.0 should require foreman >= 2.1.0

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -34,7 +34,7 @@ module ForemanTasks
 
     initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :"foreman-tasks" do
-        requires_foreman '>= 2.0.0'
+        requires_foreman '>= 2.1.0'
         divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
         menu :top_menu, :tasks,
              :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },


### PR DESCRIPTION
With the addition of `ActionButtons` which depends on foreman > 2.1.0
while running webpack compile with a bit older foreman, I got the error:
```bash
ModuleNotFoundError: Module not found: Error: Can't resolve 'foremanReact/components/common/ActionButtons/ActionButtons' in '/home/travis/.rvm/gems/ruby-2.5.8/gems/foreman-tasks-1.2.0/webpack/ForemanTasks/Components/common/ActionButtons'
```

cc @adamruzicka @MariaAga @ShimShtein 
