### PR TITLE
Fixes #30011 - Remove internal use of deprecated JS API

### DIFF
--- a/webpack/ForemanTasks/Components/TaskActions/TaskAction.test.js
+++ b/webpack/ForemanTasks/Components/TaskActions/TaskAction.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   cancelTaskRequest,
   resumeTaskRequest,
@@ -11,7 +11,7 @@ jest.mock('foremanReact/components/common/table', () => ({
   getTableItemsAction: jest.fn(controller => controller),
 }));
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 
 const task = ['some-id', 'some-name'];
 

--- a/webpack/ForemanTasks/Components/TaskActions/index.js
+++ b/webpack/ForemanTasks/Components/TaskActions/index.js
@@ -1,5 +1,5 @@
 import { sprintf } from 'foremanReact/common/I18n';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import {
   TASKS_RESUME_REQUEST,

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   showLoading,
   hideLoading,

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/TaskDetailsActions.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/TaskDetailsActions.test.js
@@ -1,12 +1,12 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   taskReloadStop,
   taskReloadStart,
   fetchTaskDetails,
 } from '../TaskDetailsActions';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 
 API.get.mockImplementation(async () => ({ data: 'some-data' }));
 

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/integration.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/integration.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { IntegrationTestHelper } from '@theforeman/test';
 
 import TaskDetails, { reducers } from '../index';
 import { selectForemanTasks } from '../../../ForemanTasksSelectors';
 
 jest.mock('../../../ForemanTasksSelectors');
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 selectForemanTasks.mockImplementation(state => state);
 describe('TaskDetails integration test', () => {
   beforeEach(() => {

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardActions.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboardActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { timeToHoursNumber, resolveQuery } from './TasksDashboardHelper';
 import {
   FOREMAN_TASKS_DASHBOARD_INIT,

--- a/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksDashboard/__tests__/TasksDashboardActions.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { timeToHoursNumber } from '../TasksDashboardHelper';
 import {
   initializeDashboard,
@@ -14,7 +14,7 @@ import {
   apiGetMock,
 } from './TaskDashboard.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 jest.mock('../TasksDashboardHelper');
 
 timeToHoursNumber.mockImplementation(arg => arg);

--- a/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { translate as __, sprintf } from 'foremanReact/common/I18n';
 import {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksBulkActions.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   bulkCancelById,
   bulkCancelBySearch,
@@ -13,7 +13,7 @@ jest.mock('foremanReact/components/common/table', () => ({
   getTableItemsAction: jest.fn(controller => controller),
 }));
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 
 const task = {
   id: 'some-id',

--- a/webpack/__mocks__/foremanReact/redux/API.js
+++ b/webpack/__mocks__/foremanReact/redux/API.js
@@ -1,4 +1,4 @@
-export default {
+export const API = {
   get: jest.fn(),
   put: jest.fn(),
   post: jest.fn(),


### PR DESCRIPTION
The API object was moved from 'foremanReact/API' to 'foremanReact/redux/API'