### PR TITLE
Fixes #30016 - task Open Dynflow console in a new tab

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Task.js
@@ -86,6 +86,8 @@ const Task = props => {
               bsSize="small"
               href={`/foreman_tasks/dynflow/${externalId}`}
               disabled={!dynflowEnableConsole}
+              rel="noopener noreferrer"
+              target="_blank"
             >
               {__('Dynflow console')}
             </Button>

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/Task.test.js.snap
@@ -49,6 +49,8 @@ exports[`Task rendering render with some Props 1`] = `
           className="dynflow-button"
           disabled={false}
           href="/foreman_tasks/dynflow/"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           Dynflow console
         </Button>
@@ -208,6 +210,8 @@ exports[`Task rendering render without Props 1`] = `
           className="dynflow-button"
           disabled={true}
           href="/foreman_tasks/dynflow/"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           Dynflow console
         </Button>


### PR DESCRIPTION
In task details, the dynflow button should open the console in a new tab