### PR TITLE
Fixes #30018 - Add refresh button to tasks table

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
@@ -87,7 +87,7 @@ export const bulkResumeById = ({
           });
       });
       if (data.resumed) {
-        reloadPage(url, parentTaskID, dispatch);
+        reloadPage(url, parentTaskID)(dispatch);
       }
     } catch (error) {
       handleErrorResume(error, dispatch);
@@ -160,7 +160,7 @@ export const bulkCancelById = ({
           });
       });
       if (data.cancelled) {
-        reloadPage(url, parentTaskID, dispatch);
+        reloadPage(url, parentTaskID)(dispatch);
       }
     } catch (error) {
       handleErrorCancel(error, dispatch);
@@ -219,7 +219,7 @@ export const bulkForceCancelById = ({
           )
         );
       if (data.stopped_length > 0) {
-        reloadPage(url, parentTaskID, dispatch);
+        reloadPage(url, parentTaskID)(dispatch);
       }
     } catch (error) {
       handleErrorForceCancel(error, dispatch);

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableActions.js
@@ -22,7 +22,7 @@ import {
 export const getTableItems = url =>
   getTableItemsAction(TASKS_TABLE_ID, getURIQuery(url), getApiPathname(url));
 
-export const reloadPage = (url, parentTaskID, dispatch) => {
+export const reloadPage = (url, parentTaskID) => dispatch => {
   dispatch(getTableItems(url));
   dispatch(fetchTasksSummary(getURIQuery(url).time, parentTaskID));
 };
@@ -34,7 +34,7 @@ export const cancelTask = ({
   parentTaskID,
 }) => async dispatch => {
   await dispatch(cancelTaskRequest(taskId, taskName));
-  reloadPage(url, parentTaskID, dispatch);
+  reloadPage(url, parentTaskID)(dispatch);
 };
 
 export const resumeTask = ({
@@ -44,7 +44,7 @@ export const resumeTask = ({
   parentTaskID,
 }) => async dispatch => {
   await dispatch(resumeTaskRequest(taskId, taskName));
-  reloadPage(url, parentTaskID, dispatch);
+  reloadPage(url, parentTaskID)(dispatch);
 };
 
 export const forceCancelTask = ({

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getURIsearch } from 'foremanReact/common/urlHelpers';
-import { Spinner } from 'patternfly-react';
+import { Spinner, Button, Icon } from 'patternfly-react';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { getURIQuery } from 'foremanReact/common/helpers';
@@ -63,7 +63,10 @@ const TasksTablePage = ({
         toastNotifications="foreman-tasks-cancel"
         toolbarButtons={
           <React.Fragment>
-            {props.status === STATUS.PENDING && <Spinner size="lg" loading />}
+            <Button onClick={() => props.reloadPage(url, props.parentTaskID)}>
+              <Icon type="fa" name="refresh" /> {__('Refresh Data')}
+            </Button>
+            {props.status === STATUS.PENDING && <Spinner size="md" loading />}
             <ExportButton
               url={getCSVurl(url, uriQuery)}
               title={__('Export All')}
@@ -118,6 +121,7 @@ TasksTablePage.propTypes = {
   openModalAction: PropTypes.func.isRequired,
   showSelectAll: PropTypes.bool,
   unselectAllRows: PropTypes.func.isRequired,
+  reloadPage: PropTypes.func.isRequired,
 };
 
 TasksTablePage.defaultProps = {

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/TasksTable.fixtures.js
@@ -9,6 +9,7 @@ export const minProps = {
   unselectAllRows: jest.fn(),
   selectRow: jest.fn(),
   unselectRow: jest.fn(),
+  reloadPage: jest.fn(),
   selectedRows: [],
   pagination: {
     page: 1,

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/SubTasksPage.test.js.snap
@@ -30,6 +30,7 @@ exports[`SubTasksPage rendering render with minimal props 1`] = `
     }
   }
   parentTaskID="some-id"
+  reloadPage={[MockFunction]}
   results={
     Array [
       "a",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksIndexPage.test.js.snap
@@ -21,6 +21,7 @@ exports[`TasksIndexPage rendering render with minimal props 1`] = `
       "perPage": 10,
     }
   }
+  reloadPage={[MockFunction]}
   results={
     Array [
       "a",

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -69,12 +69,27 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
     toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
+        <Button
+          active={false}
+          block={false}
+          bsClass="btn"
+          bsStyle="default"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <Icon
+            name="refresh"
+            type="fa"
+          />
+           
+          Refresh Data
+        </Button>
         <Spinner
           className=""
           inline={false}
           inverse={false}
           loading={true}
-          size="lg"
+          size="md"
         />
         <ExportButton
           title="Export All"
@@ -112,6 +127,7 @@ exports[`TasksTablePage rendering render with Breadcrubs 1`] = `
         }
       }
       parentTaskID={null}
+      reloadPage={[MockFunction]}
       results={
         Array [
           "a",
@@ -187,12 +203,27 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
     toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
+        <Button
+          active={false}
+          block={false}
+          bsClass="btn"
+          bsStyle="default"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <Icon
+            name="refresh"
+            type="fa"
+          />
+           
+          Refresh Data
+        </Button>
         <Spinner
           className=""
           inline={false}
           inverse={false}
           loading={true}
-          size="lg"
+          size="md"
         />
         <ExportButton
           title="Export All"
@@ -230,6 +261,7 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
         }
       }
       parentTaskID={null}
+      reloadPage={[MockFunction]}
       results={
         Array [
           "a",


### PR DESCRIPTION
Adds ability to refresh the task states by clicking on a refresh button rather than refreshing the whole page\session.
Not sure where to place the button:
A: ![image](https://user-images.githubusercontent.com/30431079/83766692-64c95a00-a685-11ea-95be-d26d97a47959.png)
B: ![image](https://user-images.githubusercontent.com/30431079/83766699-672bb400-a685-11ea-837a-0147246d2a23.png)
