### PR TITLE
[1.1.x] Fixes #30103 - Add index to tasks_locks table

### DIFF
--- a/db/migrate/20200611090846_add_task_lock_index_on_resource_type_and_task_id.rb
+++ b/db/migrate/20200611090846_add_task_lock_index_on_resource_type_and_task_id.rb
@@ -1,0 +1,9 @@
+class AddTaskLockIndexOnResourceTypeAndTaskId < ActiveRecord::Migration[6.0]
+  def change
+    add_index :foreman_tasks_locks, [:task_id, :resource_type, :resource_id], name: 'index_tasks_locks_on_task_id_resource_type_and_resource_id'
+    # These indexes are not needed as they can be gained from partial index lookups
+    remove_index :foreman_tasks_locks, :task_id
+    remove_index :foreman_tasks_locks, :name
+    remove_index :foreman_tasks_locks, :resource_type
+  end
+end


### PR DESCRIPTION
This index leads to significant improvement in speed of certain queries
looking for locks related to a specific task and resource type.
Also removes several indexes that are already covered by other
multi-column indexes.

(cherry picked from commit fb70a5537743f04ee0732b3de5eea99465d586bf)