### PR TITLE
Fixes #30210 - Fix task progress dp discrepancy

### DIFF
--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -46,7 +46,8 @@ module ForemanTasks
     end
 
     def progress
-      execution_plan.try(:progress) || 0
+      progress_raw = execution_plan.try(:progress) || 0
+      progress_raw.round(2)
     end
 
     def execution_plan(silence_exception = true)

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetailsSelectors.js
@@ -30,7 +30,7 @@ export const selectErrors = state => {
 
 export const selectProgress = state =>
   selectTaskDetails(state).progress
-    ? parseFloat((selectTaskDetails(state).progress * 100).toFixed(2))
+    ? Math.trunc(selectTaskDetails(state).progress * 100)
     : 0;
 
 export const selectUsername = state =>


### PR DESCRIPTION
There is a task progress decimal precision discrepancy between the UI, Hammer, and the API.  Hammer shows no decimals, the API shows many, and the UI shows at most 2.  This PR updates the UI to have the progress be an integer (no more decimals) and updates the API progress fraction to have the same precision as the UI's value.  E.g., if the task value in the UI and CLI is 83%, the progress from the API will be 0.83.