### PR TITLE
Fixes #30289 - disable travis npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+cache:
+  npm: false
 node_js:
   - '10'
   - '12'


### PR DESCRIPTION
the npm cache prevent using updated versions of libraries such as `@theforeman` packages.

