### PR TITLE
Fixes #30622 - Add ID to recurring logics table

### DIFF
--- a/app/views/foreman_tasks/recurring_logics/index.html.erb
+++ b/app/views/foreman_tasks/recurring_logics/index.html.erb
@@ -37,6 +37,7 @@
 
 <table class="<%= table_css_classes('table-condensed table-fixed') %>">
   <thead>
+    <th class="col-md-1"><%= N_("ID") %></th>
     <th><%= N_("Cron line") %></th>
     <th><%= N_("Task count") %></th>
     <th><%= N_("Action") %></th>
@@ -50,7 +51,8 @@
   </thead>
   <% @recurring_logics.each do |recurring_logic| %>
     <tr>
-      <td><%= link_to(recurring_logic.cron_line, foreman_tasks_recurring_logic_path(recurring_logic)) %></td>
+      <td><%= link_to(recurring_logic.id, foreman_tasks_recurring_logic_path(recurring_logic)) %></td>
+      <td><%= recurring_logic.cron_line %></td>
       <td><%= link_to(recurring_logic.tasks.count, foreman_tasks_tasks_url(:search => "task_group.id = #{recurring_logic.task_group.id}")) %></td>
       <td><%= format_task_input(recurring_logic.tasks.first) %></td>
       <td><%= recurring_logic.tasks.order(:started_at).where('started_at IS NOT NULL').last.try(:started_at) || "-" %></td>


### PR DESCRIPTION
Makes the ID clickable to the logic instead on the cron line
![Screenshot from 2020-08-10 17-36-13](https://user-images.githubusercontent.com/30431079/89794645-02328580-db30-11ea-875c-4f2ad4b6720f.png)
