### PR TITLE
Fixes #30621 - add toast to recurring logic state change

### DIFF
--- a/app/controllers/foreman_tasks/recurring_logics_controller.rb
+++ b/app/controllers/foreman_tasks/recurring_logics_controller.rb
@@ -41,6 +41,11 @@ module ForemanTasks
     def change_enabled(value)
       begin
         @recurring_logic.update!(:enabled => value)
+        flash[:success] = if value
+                            _('The recurring logic was enabled.')
+                          else
+                            _('The recurring logic was disabled.')
+                          end
       rescue RecurringLogicCancelledException => e
         @errors = e.message
       end


### PR DESCRIPTION
When user enables/disables a recurring logic they will see a toast informing them of a successful action. 