### PR TITLE
Fixes #30407 - removes unmaintained react-html-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "c3": "^0.4.11",
     "humanize-duration": "^3.20.1",
-    "react-html-parser": "^2.0.2",
     "react-intl": "^2.8.0"
   },
   "devDependencies": {

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/TaskInfo.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/TaskInfo.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Grid, Row, Col, ProgressBar } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
-import ReactHtmlParser from 'react-html-parser';
 
 class TaskInfo extends Component {
   isDelayed = () => {
@@ -171,7 +170,7 @@ class TaskInfo extends Component {
                   <b>{__('Troubleshooting')}</b>
                 </span>
               </p>
-              <p>{ReactHtmlParser(help)}</p>
+              <p dangerouslySetInnerHTML={{ __html: help }} />
             </Col>
           </Row>
         )}

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/TaskInfo.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/TaskInfo.test.js.snap
@@ -290,10 +290,14 @@ exports[`TaskInfo rendering render with Props 1`] = `
           </b>
         </span>
       </p>
-      <p>
-        A paused task represents a process that has not finished properly. Any task in paused state can lead to potential inconsistency and needs to be resolved.
-The recommended approach is to investigate the error messages below and in 'errors' tab, address the primary cause of the issue and resume the task.
-      </p>
+      <p
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "A paused task represents a process that has not finished properly. Any task in paused state can lead to potential inconsistency and needs to be resolved.
+The recommended approach is to investigate the error messages below and in 'errors' tab, address the primary cause of the issue and resume the task.",
+          }
+        }
+      />
     </Col>
   </Row>
 </Grid>


### PR DESCRIPTION
'react-html-parser' was causing issues when opening task details, and as it's not maintained any more we can use `dangerouslySetInnerHTML` instead.
The html should be safe as it comes from the server