### PR TITLE
Refs #30397 - Apipie DSL compatibility fix for Foreman 2.1-stable

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -4,6 +4,7 @@ module ForemanTasks
   class Task < ApplicationRecord
     include Authorizable
     extend Search
+    extend ApipieDSL::Class
 
     def check_permissions_after_save
       # there's no create_tasks permission, tasks are created as a result of internal actions, in such case we

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -86,6 +86,9 @@ module ForemanTasks
         Apipie.configuration.api_controllers_matcher << "#{ForemanTasks::Engine.root}/app/controllers/foreman_tasks/api/*.rb"
         Apipie.configuration.checksum_path += ['/foreman_tasks/api/']
       end
+      ApipieDSL.configuration.dsl_classes_matchers += [
+        "#{ForemanTasks::Engine.root}/app/models/**/*.rb"
+      ]
     end
 
     initializer 'foreman_tasks.register_paths' do |_app|


### PR DESCRIPTION
When running latest master against foreman 2.1-stable I'm getting the following stacktrace.

```
31: from /home/aruzicka/projects/foreman/foreman-tasks/lib/foreman_tasks/engine.rb:36:in `block in <class:Engine>'
30: from /home/aruzicka/projects/foreman/foreman/app/registries/foreman/plugin.rb:78:in `register'
29: from /home/aruzicka/projects/foreman/foreman/app/registries/foreman/plugin.rb:78:in `instance_eval'
28: from /home/aruzicka/projects/foreman/foreman-tasks/lib/foreman_tasks/engine.rb:51:in `block (2 levels) in <class:Engine>'
27: from /home/aruzicka/projects/foreman/foreman/app/registries/foreman/plugin.rb:276:in `security_block'
26: from /home/aruzicka/projects/foreman/foreman/app/registries/foreman/plugin.rb:276:in `instance_eval'
25: from /home/aruzicka/projects/foreman/foreman-tasks/lib/foreman_tasks/engine.rb:54:in `block (3 levels) in <class:Engine>'
24: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:214:in `const_missing' 
23: from /home/aruzicka/projects/foreman/foreman_hooks/lib/foreman_hooks/as_dependencies_hook.rb:4:in `load_missing_constant'
22: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:60:in `load_missing_constant'
21: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:17:in `allow_bootsnap_retry'
20: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant'
19: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:544:in `load_missing_constant'
18: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:48:in `require_or_load'
17: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:17:in `allow_bootsnap_retry'
16: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:49:in `block in require_or_load'
15: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:389:in `require_or_load'
14: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:40:in `load_interlock' 
13: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies/interlock.rb:13:in `loading'
12: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
11: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
10: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:40:in `block in load_interlock'
 9: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:406:in `block in require_or_load'
 8: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:509:in `load_file'
 7: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:701:in `new_constants_in'
 6: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:510:in `block in load_file'
 5: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
 4: from /home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
 3: from /home/aruzicka/projects/foreman/foreman-tasks/app/models/foreman_tasks/task.rb:3:in `<main>'
 2: from /home/aruzicka/projects/foreman/foreman-tasks/app/models/foreman_tasks/task.rb:4:in `<module:ForemanTasks>'
 1: from /home/aruzicka/projects/foreman/foreman-tasks/app/models/foreman_tasks/task.rb:73:in `<class:Task>'
/home/aruzicka/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/activerecord-6.0.3.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `apipie' for #<Class:0x00005578aadd0220> (NoMethodError)
```