### PR TITLE
Implement YAML export

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -16,7 +16,7 @@ module ForemanTasks
       class BadRequest < Apipie::ParamError
       end
 
-      before_action :find_task, :only => [:show, :details]
+      before_action :find_task, :only => [:show, :details, :plan]
 
       api :GET, '/tasks/summary', 'Show task summary'
       def summary
@@ -30,6 +30,13 @@ module ForemanTasks
       api :GET, '/tasks/:id/details', 'Show task extended details'
       param :id, :identifier, desc: 'UUID of the task'
       def details; end
+
+      api :GET, "/tasks/:id/plan", "Show task plan including sub-tasks"
+      param :id, :identifier, desc: "UUID of the task"
+      def plan
+        exporter = ForemanTasks::Export.new(ForemanTasks.dynflow.world)
+        render json: exporter.prepare_task(@task)
+      end
 
       api :POST, '/tasks/bulk_search', 'List dynflow tasks for uuids'
       param :searches, Array, :desc => 'List of uuids to fetch info about' do
@@ -327,7 +334,7 @@ module ForemanTasks
 
       def action_permission
         case params[:action]
-        when 'bulk_search', 'summary', 'details', 'sub_tasks'
+        when 'bulk_search', 'summary', 'details', 'sub_tasks', 'plan'
           :view
         when 'bulk_resume', 'bulk_cancel', 'bulk_stop'
           :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Foreman::Application.routes.draw do
       resources :tasks, :only => [:show, :index] do
         member do
           get :details
+          get :plan
         end
         collection do
           post :bulk_search

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -6,6 +6,7 @@ require 'foreman_tasks/dynflow/configuration'
 require 'foreman_tasks/triggers'
 require 'foreman_tasks/authorizer_ext'
 require 'foreman_tasks/cleaner'
+require 'foreman_tasks/export'
 
 module ForemanTasks
   extend Algebrick::TypeCheck

--- a/lib/foreman_tasks/export.rb
+++ b/lib/foreman_tasks/export.rb
@@ -1,0 +1,37 @@
+require 'dynflow/export'
+
+module ForemanTasks
+  class Export < ::Dynflow::Export
+    def prepare_task(task)
+      base = {
+        id:               task.id,
+        label:            task.label,
+        started_at:       format_time(task.started_at),
+        ended_at:         format_time(task.ended_at),
+        state:            task.state,
+        result:           task.result,
+        external_id:      task.external_id,
+        parent_task_id:   task.parent_task_id,
+        action:           task.action,
+        state_updated_at: format_time(task.state_updated_at),
+        user_id:          task.user_id,
+        sub_task_ids:     task.sub_tasks.pluck(:id),
+        locks:            prepare_locks(task.locks)
+      }
+      base[:execution_plan] = task.execution_plan && prepare_execution_plan(task.execution_plan)
+      base
+    end
+
+    def prepare_locks(locks)
+      locks.map do |lock|
+        {
+          id: lock.id,
+          name: lock.name,
+          exclusive: lock.exclusive,
+          resource_type: lock.resource_type,
+          resource_id: lock.resource_id
+        }
+      end
+    end
+  end
+end

--- a/lib/foreman_tasks/export.rb
+++ b/lib/foreman_tasks/export.rb
@@ -16,7 +16,7 @@ module ForemanTasks
         state_updated_at: format_time(task.state_updated_at),
         user_id:          task.user_id,
         sub_task_ids:     task.sub_tasks.pluck(:id),
-        locks:            prepare_locks(task.locks)
+        locks:            prepare_locks(task.locks),
       }
       base[:execution_plan] = task.execution_plan && prepare_execution_plan(task.execution_plan)
       base
@@ -29,7 +29,7 @@ module ForemanTasks
           name: lock.name,
           exclusive: lock.exclusive,
           resource_type: lock.resource_type,
-          resource_id: lock.resource_id
+          resource_id: lock.resource_id,
         }
       end
     end

--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -247,7 +247,7 @@ namespace :foreman_tasks do
     puts _("Gathering #{tasks.count} tasks.")
     case format
     when 'html'
-      after = ->(tmp_dir) do
+      after = lambda do |tmp_dir|
         File.open(File.join(tmp_dir, 'index.html'), 'w') { |file| file.write(PageHelper.pagify(PageHelper.generate_index(tasks))) }
       end
       renderer = TaskRender.new
@@ -261,7 +261,7 @@ namespace :foreman_tasks do
         csv << %w[id state type label result parent_task_id started_at ended_at]
         tasks.each do |task|
           csv << [task.id, task.state, task.type, task.label, task.result,
-            task.parent_task_id, task.started_at, task.ended_at]
+                  task.parent_task_id, task.started_at, task.ended_at]
         end
       end
     when 'yaml', 'yml'

--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -265,7 +265,6 @@ namespace :foreman_tasks do
         end
       end
     when 'yaml', 'yml'
-      require 'foreman_tasks/export'
       exporter = ForemanTasks::Export.new(ForemanTasks.dynflow.world)
       generate_archive(export_filename, format, tasks) do |task|
         YAML.dump(exporter.prepare_task(task))


### PR DESCRIPTION
requires:
- [ ] https://github.com/Dynflow/dynflow/pull/365

### Example output
```
---
:id: ad1b1218-2124-4e5b-87a9-afe5a6397fb2
:label: Actions::BulkAction
:started_at: '2020-09-02T10:43:36Z'
:ended_at: '2020-09-02T12:57:18Z'
:state: stopped
:result: success
:external_id: f19595b4-49e9-4463-8c8f-14d15ded882e
:parent_task_id:
:action: Synchronize synchronize; repository 'Red Hat Enterprise Linux 8 for x86_64
  - BaseOS RPMs 8'; product 'Red Hat Enterprise Linux for x86_64'; organization 'Default
  Organization'; ...
:state_updated_at: '2020-09-02T12:57:18Z'
:user_id: 4
:sub_task_ids:
- b6fb355f-3640-419c-aec1-0c2360689e8a
- 84f1e916-fc45-40cb-88a6-206cc8fcc8e3
- d81b93b4-a070-4b57-8df4-de574c678386
- 915de100-da18-4d19-ba4a-7edf21720b6a
- 9eb328bc-cb20-4e78-b144-aa389470ee1e
- df3a038a-1d92-4281-88b4-25c93372b868
:locks: []
:execution_plan:
  :uuid: f19595b4-49e9-4463-8c8f-14d15ded882e
  :label: Actions::BulkAction
  :state: :stopped
  :result: :success
  :started_at: '2020-09-02T10:43:36Z'
  :ended_at: '2020-09-02T12:57:18Z'
  :execution_time: 8.351045544
  :real_time: 8022.411133018
  :execution_history:
  - :event: start execution
    :time: '2020-09-02T10:43:36Z'
    :world:
      :uuid: 70a8e68d-35d2-459c-bc64-fd6974a26ef6
      :meta:
        hostname: host.something.somewhere.com
        pid: 25087
        queues:
          default:
            pool_size: 5
          remote_execution:
            pool_size: 5
          hosts_queue:
            pool_size: 5
        last_seen: '2020-09-03 04:54:10.324'
        delayed_executor: true
  - :event: finish execution
    :time: '2020-09-02T12:57:18Z'
    :world:
      :uuid: 70a8e68d-35d2-459c-bc64-fd6974a26ef6
      :meta:
        hostname: host.something.somewhere.com
        pid: 25087
        queues:
          default:
            pool_size: 5
          remote_execution:
            pool_size: 5
          hosts_queue:
            pool_size: 5
        last_seen: '2020-09-03 04:54:10.324'
        delayed_executor: true
  :plan_phase:
    :id: 1
    :state: :success
    :queue:
    :started_at: '2020-09-02T10:43:36Z'
    :ended_at: '2020-09-02T10:43:36Z'
    :real_time: 0.017205235
    :execution_time: 0.017205235
    :label: Actions::BulkAction
    :input:
      action_class: Actions::Katello::Repository::Sync
      target_ids:
      - 1
      - 2
      - 3
      - 4
      - 5
      - 6
      target_class: Katello::Repository
      args:
      -
      - skip_metadata_check: false
        validate_contents: false
      current_request_id:
      current_timezone: Europe/Prague
      current_user_id: 4
      current_organization_id: 1
      current_location_id: 2
    :output:
      planned_count: 6
      cancelled_count: 0
      total_count: 6
      failed_count: 0
      pending_count: 0
      success_count: 6
    :children: []
  :run_phase:
    :id: 2
    :state: :success
    :queue: :default
    :started_at: '2020-09-02T10:43:36Z'
    :ended_at: '2020-09-02T12:57:18Z'
    :real_time: 8022.692698655
    :execution_time: 8.333840309
    :label: Actions::BulkAction
    :input:
      action_class: Actions::Katello::Repository::Sync
      target_ids:
      - 1
      - 2
      - 3
      - 4
      - 5
      - 6
      target_class: Katello::Repository
      args:
      -
      - skip_metadata_check: false
        validate_contents: false
      current_request_id:
      current_timezone: Europe/Prague
      current_user_id: 4
      current_organization_id: 1
      current_location_id: 2
    :output:
      planned_count: 6
      cancelled_count: 0
      total_count: 6
      failed_count: 0
      pending_count: 0
      success_count: 6
  :finalize_phase:
    :type: sequence
    :children: []
  :delay_record:

```