### PR TITLE
Fixes #30797 - tasks not taxable in filters

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -198,6 +198,10 @@ module ForemanTasks
       'ForemanTasks::Task'
     end
 
+    def self.allows_taxonomy_filtering?(_taxonomy)
+      false
+    end
+
     def add_missing_task_groups(groups)
       groups = [groups] unless groups.is_a? Array
       (groups - task_groups).each { |group| task_groups << group }

--- a/db/migrate/20200908120905_remove_taxonomy_from_task_filters.rb
+++ b/db/migrate/20200908120905_remove_taxonomy_from_task_filters.rb
@@ -1,0 +1,8 @@
+class RemoveTaxonomyFromTaskFilters < ActiveRecord::Migration[6.0]
+  def up
+    Permission.where(name: %w[view_foreman_tasks edit_foreman_tasks]).each do |perm|
+      TaxableTaxonomy.where(taxable_type: 'Filter', taxable_id: perm.filter_ids).delete_all
+      perm.filters.update_all(taxonomy_search: nil)
+    end
+  end
+end


### PR DESCRIPTION
Tasks are falsely recognized as taxable by filters.