### PR TITLE
fixes #31457 - Adding method to Task jail

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -82,7 +82,7 @@ module ForemanTasks
       property :ended_at, ActiveSupport::TimeWithZone, desc: 'Returns date with time the task ended at'
     end
     class Jail < Safemode::Jail
-      allow :started_at, :ended_at, :result, :state, :label, :main_action
+      allow :started_at, :ended_at, :result, :state, :label, :main_action, :action_output
     end
 
     def input
@@ -240,6 +240,12 @@ module ForemanTasks
         end
       end.join('; ')
       parts.join(' ').strip
+    end
+
+    def action_output
+      return unless main_action.is_a?(Actions::Helpers::WithContinuousOutput)
+      main_action.continuous_output.sort!
+      main_action.continuous_output.raw_outputs
     end
 
     protected


### PR DESCRIPTION
This PR is consist of adding `action_output` to Task model and also is added to jail for usage in reports. This methods acts as proxy method for `to_json_output` in Continuous output class. These methods are requested by another PR in REX (https://github.com/theforeman/foreman_remote_execution/pull/453).