### PR TITLE
Fixes #31104 - TablePage wrong prop for toastNotifications

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -60,7 +60,6 @@ const TasksTablePage = ({
         onSearch={onSearch}
         header={createHeader(props.actionName)}
         breadcrumbOptions={getBreadcrumbs(props.actionName)}
-        toastNotifications="foreman-tasks-cancel"
         toolbarButtons={
           <React.Fragment>
             <Button onClick={() => props.reloadPage(url, props.parentTaskID)}>

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -66,7 +66,6 @@ exports[`TasksTablePage rendering render with Breadcrubs and edit permissions 1`
     }
     searchQuery="a=b"
     searchable={true}
-    toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
         <Button
@@ -202,7 +201,6 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
     }
     searchQuery="a=b"
     searchable={true}
-    toastNotifications="foreman-tasks-cancel"
     toolbarButtons={
       <React.Fragment>
         <Button


### PR DESCRIPTION
`toastNotifications` prop is not used at all in PageLayout and now breaks the page