### PR TITLE
Fixes #31298 - Table pagination in react has extra space

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.scss
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.scss
@@ -1,6 +1,3 @@
-.tasks-pagination {
-  margin-top: -6px;
-}
 .tasks-table {
   margin-bottom: 70px;
 }


### PR DESCRIPTION
6px margin for pagination was removed from the table in: https://github.com/theforeman/foreman/pull/8133