### PR TITLE
Fixes #27295 - Task widgets don't show time correctly

### DIFF
--- a/app/views/foreman_tasks/tasks/dashboard/_latest_tasks_in_error_warning.html.erb
+++ b/app/views/foreman_tasks/tasks/dashboard/_latest_tasks_in_error_warning.html.erb
@@ -11,7 +11,7 @@
       <td class="ellipsis"><%= link_to task.humanized[:action], defined?(main_app) ? main_app.foreman_tasks_task_path(task.id) : foreman_tasks_task_path(task.id) %></td>
       <td><%= task.state %></td>
       <td><%= task.result %></td>
-      <td><%= task.started_at ? (_(date_time_relative(task.started_at))) : _('N/A') %></td>
+      <td><%= task.started_at ? date_time_relative(task.started_at) : _('N/A') %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/foreman_tasks/tasks/dashboard/_tasks_status.html.erb
+++ b/app/views/foreman_tasks/tasks/dashboard/_tasks_status.html.erb
@@ -11,7 +11,7 @@
       <td><%= result.state %></td>
       <td><%= result.result %></td>
       <td><%= link_to result.count, main_app.foreman_tasks_tasks_path(:search => "state=#{result.state}&result=#{result.result}") %></td>
-      <td><%= result.started_at ? (_(date_time_relative(result.started_at))) : _('N/A') %></td>
+      <td><%= result.started_at ? date_time_relative(result.started_at) : _('N/A') %></td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
date_time_relative is a function that loads a react component so translating it causes showing the html instead of rendering the component 