### PR TITLE
Fixes #31501 - Word Wrap for Long names in tasks table

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionNameCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/actionNameCellFormatter.test.js.snap
@@ -4,6 +4,8 @@ exports[`actionNameCellFormatter render 1`] = `
 <a
   href="/some-url/some-id"
 >
-  action-name
+  <EllipisWithTooltip>
+    action-name
+  </EllipisWithTooltip>
 </a>
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/actionNameCellFormatter.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/actionNameCellFormatter.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import { cellFormatter } from 'foremanReact/components/common/table';
+import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 
 export const actionNameCellFormatter = url => (value, { rowData: { id } }) =>
-  cellFormatter(<a href={`/${url}/${id}`}>{value}</a>);
+  cellFormatter(
+    <a href={`/${url}/${id}`}>
+      <EllipsisWithTooltip>{value}</EllipsisWithTooltip>
+    </a>
+  );


### PR DESCRIPTION
In the tasks table long action names overflow their cell

