### PR TITLE
Tweaks to task export

### DIFF
--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -239,6 +239,40 @@ namespace :foreman_tasks do
       end
     end
 
+    def csv_export(export_filename, tasks)
+      CSV.open(export_filename, 'wb') do |csv|
+        csv << %w[id state type label result parent_task_id started_at ended_at]
+        tasks.find_each do |task|
+          csv << [task.id, task.state, task.type, task.label, task.result,
+            task.parent_task_id, task.started_at, task.ended_at]
+        end
+      end
+    end
+
+    def html_export(export_filename, tasks)
+      Dir.mktmpdir('task-export') do |tmp_dir|
+        PageHelper.copy_assets(tmp_dir)
+
+        renderer = TaskRender.new
+        total = tasks.count
+        index = File.open(File.join(tmp_dir, 'index.html'), 'w')
+
+        File.open(File.join(tmp_dir, 'index.html'), 'w') do |index|
+          PageHelper.pagify(index) do |io|
+            PageHelper.generate_with_index(io) do |index|
+              tasks.find_each.each_with_index do |task, count|
+                File.open(File.join(tmp_dir, "#{task.id}.html"), 'w') { |file| PageHelper.pagify(file, renderer.render_task(task)) }
+                PageHelper.generate_index_entry(index, task)
+                puts "#{count + 1}/#{total}"
+              end
+            end
+          end
+        end
+
+        system("tar", "czf", export_filename, tmp_dir)
+      end
+    end
+
     filter = if ENV['TASK_SEARCH'].nil? && ENV['TASK_DAYS'].nil?
                "started_at > \"#{7.days.ago.to_s(:db)}\" || " \
                  "(result != success && started_at > \"#{60.days.ago.to_s(:db)})\""
@@ -258,35 +292,11 @@ namespace :foreman_tasks do
 
     puts _("Exporting all tasks matching filter #{filter}")
     puts _("Gathering #{tasks.count} tasks.")
-    if format == 'html'
-      Dir.mktmpdir('task-export') do |tmp_dir|
-        PageHelper.copy_assets(tmp_dir)
-
-        renderer = TaskRender.new
-        total = tasks.count
-        index = File.open(File.join(tmp_dir, 'index.html'), 'w')
-
-        PageHelper.pagify(index) do |io|
-          PageHelper.generate_with_index(io) do |index|
-            tasks.find_each.each_with_index do |task, count|
-              File.open(File.join(tmp_dir, "#{task.id}.html"), 'w') { |file| PageHelper.pagify(file, renderer.render_task(task)) }
-              PageHelper.generate_index_entry(index, task)
-              puts "#{count + 1}/#{total}"
-            end
-          end
-        end
-        index.close
-
-        system("tar", "czf", export_filename, tmp_dir)
-      end
-    elsif format == 'csv'
-      CSV.open(export_filename, 'wb') do |csv|
-        csv << %w[id state type label result parent_task_id started_at ended_at]
-        tasks.find_each do |task|
-          csv << [task.id, task.state, task.type, task.label, task.result,
-                  task.parent_task_id, task.started_at, task.ended_at]
-        end
-      end
+    case format
+    when 'html'
+      html_export(export_filename, tasks)
+    when 'csv'
+      csv_export(export_filename, tasks)
     end
 
     puts "Created #{export_filename}"

--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -228,14 +228,14 @@ namespace :foreman_tasks do
       end
 
       def self.generate_index_entry(io, task)
-        io << <<~EOF
+        io << <<~HTML
           <tr>
             <td><a href=\"#{task.id}.html\">#{task.label}</a></td>
             <td>#{task.started_at}</td>
             <td>#{task.state}</td>
             <td>#{task.result}</td>
           </tr>
-        EOF
+        HTML
       end
     end
 
@@ -244,7 +244,7 @@ namespace :foreman_tasks do
         csv << %w[id state type label result parent_task_id started_at ended_at]
         tasks.find_each do |task|
           csv << [task.id, task.state, task.type, task.label, task.result,
-            task.parent_task_id, task.started_at, task.ended_at]
+                  task.parent_task_id, task.started_at, task.ended_at]
         end
       end
     end


### PR DESCRIPTION
HTML export used to be a two pass process. First all the tasks would be exported one by one, then all the tasks would be ordered differently, loaded again and the index would be generated. With this change, the index is being generated as tasks are being exported, removing the need for a second pass.

Also introduces a `html-dir` export format, which is the same as `html`, but produces a directory instead of a `.tar.gz`. If `$TASK_FILE` is set, it is used as a directory for the export. Adding it as a separate output format is a bit unfortunate, but it felt like the most sensible way without introducing a breaking change.