### PR TITLE
Fixes #31843 - Make sure logging context doesn't get wiped too early

### DIFF
--- a/app/lib/actions/middleware/keep_current_request_id.rb
+++ b/app/lib/actions/middleware/keep_current_request_id.rb
@@ -21,7 +21,10 @@ module Actions
 
       # Run all execution plan lifecycle hooks as the original request_id
       def hook(*args)
-        restore_current_request_id { pass(*args) }
+        store_current_request_id if !action.input.key?(:current_request_id) && ::Logging.mdc['request']
+        restore_current_request_id do
+          pass(*args)
+        end
       end
 
       private


### PR DESCRIPTION
The logging context storing middleware was being run after first round of execution plan hooks, which already wiped the logging context.