### PR TITLE
fixes #31913 - Introducing find_job_invocation_by_id macro

### DIFF
--- a/app/services/renderer_methods.rb
+++ b/app/services/renderer_methods.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# macros to fetch information about invoked jobs
+module RendererMethods
+  extend ActiveSupport::Concern
+
+  def find_job_invocation_by_id(job_id, preload: nil)
+    JobInvocation.preload(preload).find_by(id: job_id)
+  rescue ActiveRecord::NotFound => _e
+    raise ::Foreman::Exception.new(N_("Can't find Job Invocation for an id %s"), job_id)
+  end
+end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -79,6 +79,8 @@ module ForemanTasks
 
         ForemanTasks.dynflow.eager_load_actions!
         extend_observable_events(::Dynflow::Action.descendants.select { |klass| klass <= ::Actions::ObservableAction }.map(&:namespaced_event_names))
+
+        extend_template_helpers ForemanTasks::RendererMethods
       end
     end
 


### PR DESCRIPTION
This PR is consist of adding `find_job_invocation_by_id` macro for get job invocation instance by id. This macro are requested by another PR in REX (https://github.com/theforeman/foreman_remote_execution/pull/453).