### PR TITLE
Refs #31773 - Fix pg syntax errors when searching by taxonomy

### DIFF
--- a/app/models/foreman_tasks/task/search.rb
+++ b/app/models/foreman_tasks/task/search.rb
@@ -21,6 +21,7 @@ module ForemanTasks
         SQL
         # Select only those tasks which either have the correct taxonomy or are not related to any
         sql = "foreman_tasks_links_taxonomy#{uniq_suffix}.resource_id #{operator} (?) OR foreman_tasks_links_taxonomy#{uniq_suffix}.resource_id IS NULL"
+        value = value.split(',') if operator.index(/IN/i)
         { :conditions => sanitize_sql_for_conditions([sql, value]), :joins => joins }
       end
 

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -134,6 +134,8 @@ class TasksTest < ActiveSupport::TestCase
       test 'can search by taxonomies using IN' do
         assert_nothing_raised(PG::SyntaxError) { ForemanTasks::Task.search_for('location_id ^ (1)').first }
         assert_nothing_raised(PG::SyntaxError) { ForemanTasks::Task.search_for('organization_id ^ (1)').first }
+        assert_nothing_raised(PG::SyntaxError) { ForemanTasks::Task.search_for('location_id ^ (1,2)').first }
+        assert_nothing_raised(PG::SyntaxError) { ForemanTasks::Task.search_for('organization_id ^ (1,2)').first }
         assert_nothing_raised(PG::SyntaxError) { ForemanTasks::Task.search_for('organization_id = 1').first }
       end
     end


### PR DESCRIPTION
Previous fix allowed searching using IN, but only if there was a single value.
The value was treated as a string of comma-delimited numbers instead of an array
of numbers.