### PR TITLE
Fixes #32024 - Drop fallback to non-batch triggering API

### DIFF
--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -192,7 +192,7 @@ module ForemanTasks
           _(task.state).must_equal 'running'
           _(task.result).must_equal 'pending'
 
-          callback = Support::DummyProxyAction.proxy.log[:trigger_task].first[1][:callback]
+          callback = Support::DummyProxyAction.proxy.log[:trigger_task].first[1][:action_input][:callback]
           post :callback, params: { 'callback' => callback, 'data' => { 'result' => 'success' } }
           triggered.finished.wait(5)
 

--- a/test/support/dummy_proxy_action.rb
+++ b/test/support/dummy_proxy_action.rb
@@ -36,6 +36,12 @@ module Support
       def statuses
         { version: DummyProxyVersion.new('1.21.0') }
       end
+
+      def launch_tasks(operation, args = {})
+        @log[:trigger_task] << [operation, args]
+        @task_triggered.fulfill(true)
+        { 'task_id' => @uuid, 'result' => 'success' }
+      end
     end
 
     class ProxySelector < ::ForemanTasks::ProxySelector

--- a/test/unit/remote_task_test.rb
+++ b/test/unit/remote_task_test.rb
@@ -28,14 +28,6 @@ module ForemanTasks
           _(remote_task.remote_task_id).must_equal((remote_task.id + 5).to_s)
         end
       end
-
-      it 'fallbacks to old way when batch trigger gets 404' do
-        fake_proxy = mock
-        fake_proxy.expects(:launch_tasks).raises(RestClient::NotFound.new)
-        remote_tasks.first.expects(:proxy).returns(fake_proxy)
-        remote_tasks.each { |task| task.expects(:trigger) }
-        RemoteTask.batch_trigger('a_operation', remote_tasks)
-      end
     end
   end
 end


### PR DESCRIPTION
The batch triggering API was introduced in 1.20, it should be available on all
releases which are not EOL.