### PR TITLE
Fixes #32047 - Match proxy actions using task_id

### DIFF
--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -218,10 +218,8 @@ module Actions
     end
 
     def get_proxy_data(response)
-      proxy_data = response['actions'].detect do |action|
-        action['class'] == proxy_action_name || action.fetch('input', {})['proxy_operation_name'] == proxy_operation_name
-      end
-      proxy_data.fetch('output', {})
+      response['actions'].detect { |action| action.fetch('input', {})['task_id'] == task.id }
+                         .try(:fetch, 'output', {})
     end
 
     def proxy_version(proxy)


### PR DESCRIPTION
When we're retrieving outputs of proxy actions we get back a serialized
execution plan, walk its actions and look for an action with either expected
action_class or operation name. This is somewhat flaky.

With this change we only check one field in the actions' input and that is
task_id. First action found with matching value is considered the source of
output for the current task.