### PR TITLE
Mop up after split from locks to locks and links

### DIFF
--- a/app/models/foreman_tasks/lock.rb
+++ b/app/models/foreman_tasks/lock.rb
@@ -1,5 +1,7 @@
 module ForemanTasks
   class Lock < ApplicationRecord
+    OWNER_LOCK_NAME = :task_owner
+
     class LockConflict < StandardError
       attr_reader :required_lock, :conflicting_locks
       def initialize(required_lock, conflicting_locks)


### PR DESCRIPTION
looks like migration and API endpoint that rely on OWNER_LOCK_NAME are failing now,
reverting with a small fix