### PR TITLE
Get rid of a maruku warning

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -51,7 +51,7 @@ module ForemanTasks
           In case :type = 'resource', what resource id we're searching the tasks for
         DESC
         param :action_types, [String], :desc => <<-DESC
-          Return just tasks of given action type, e.g. ["Actions::Katello::Repository::Synchronize"]
+          Return just tasks of given action type, e.g. `["Actions::Katello::Repository::Synchronize"]`
         DESC
         param :active_only, :bool
         param :page, String


### PR DESCRIPTION
This gets rid of the following pesky warning on each request associated with tasks:

```
 ___________________________________________________________________________
| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "Actions::Katello::Repository::Synchronize" for md_link([
|       md_entity("ldquo"),
|       "Actions::Katello::Repository::Synchronize",
|       md_entity("rdquo")
| ], nil)
| Available refs are []
+---------------------------------------------------------------------------
!/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/maruku-0.7.3/lib/maruku/output/to_html.rb:656:in `to_html_link'
!/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/maruku-0.7.3/lib/maruku/output/to_html.rb:891:in `block in array_to_html'
!/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/maruku-0.7.3/lib/maruku/output/to_html.rb:879:in `each'
!/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/maruku-0.7.3/lib/maruku/output/to_html.rb:879:in `array_to_html'
\___________________________________________________________________________
```

Thanks to @tbrisker who located this place, @ofedoren to confirm.