### PR TITLE
Refs #31457 - add output messages method alias

### DIFF
--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -89,7 +89,7 @@ module ForemanTasks
       property :ended_at, ActiveSupport::TimeWithZone, desc: 'Returns date with time the task ended at'
     end
     class Jail < Safemode::Jail
-      allow :started_at, :ended_at, :result, :state, :label, :main_action, :action_continuous_output
+      allow :started_at, :ended_at, :result, :state, :label, :main_action, :action_continuous_output, :action_output
     end
 
     def input
@@ -254,6 +254,7 @@ module ForemanTasks
       main_action.continuous_output.sort!
       main_action.continuous_output.raw_outputs
     end
+    alias_method :action_output, :action_continuous_output
 
     protected
 


### PR DESCRIPTION
We already have shipped webhooks with action_output and it is unfortunate that its missing, let's keep the alias as undocumented so it still works.