### PR TITLE
Fixes #32729 - reload setting prior run

### DIFF
--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -1,6 +1,7 @@
 module Actions
   class Base < Dynflow::Action
     middleware.use ::Actions::Middleware::RailsExecutorWrap
+    middleware.use ::Actions::Middleware::LoadSettingValues
     include Actions::Helpers::LifecycleLogging
 
     execution_plan_hooks.use :notify_paused, :on => [:paused]

--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -1,7 +1,6 @@
 module Actions
   class Base < Dynflow::Action
     middleware.use ::Actions::Middleware::RailsExecutorWrap
-    middleware.use ::Actions::Middleware::LoadSettingValues
     include Actions::Helpers::LifecycleLogging
 
     execution_plan_hooks.use :notify_paused, :on => [:paused]

--- a/app/lib/actions/middleware/load_setting_values.rb
+++ b/app/lib/actions/middleware/load_setting_values.rb
@@ -1,0 +1,36 @@
+module Actions
+  module Middleware
+    class LoadSettingValues < ::Dynflow::Middleware
+      # ::Actions::Middleware::LoadSettingValues
+      #
+      # A middleware to ensure we load current setting values
+
+      def delay(*args)
+        reload_setting_values
+        pass(*args)
+      end
+
+      def plan(*args)
+        reload_setting_values
+        pass(*args)
+      end
+
+      def run(*args)
+        reload_setting_values
+        pass(*args)
+      end
+
+      def finalize(*args)
+        reload_setting_values
+        pass(*args)
+      end
+
+      private
+
+      def reload_setting_values
+        return unless Gem::Version.new(::SETTINGS[:version]) >= Gem::Version.new('2.5')
+        ::Foreman.settings.load_values
+      end
+    end
+  end
+end

--- a/app/lib/actions/middleware/load_setting_values.rb
+++ b/app/lib/actions/middleware/load_setting_values.rb
@@ -28,7 +28,6 @@ module Actions
       private
 
       def reload_setting_values
-        return unless Gem::Version.new(::SETTINGS[:version]) >= Gem::Version.new('2.5')
         ::Foreman.settings.load_values
       end
     end

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -113,6 +113,7 @@ module ForemanTasks
         world.middleware.use Actions::Middleware::KeepCurrentUser, :before => ::Dynflow::Middleware::Common::Transaction
         world.middleware.use Actions::Middleware::KeepCurrentTimezone
         world.middleware.use Actions::Middleware::KeepCurrentRequestID
+        world.middleware.use ::Actions::Middleware::LoadSettingValues if Gem::Version.new(::SETTINGS[:version]) >= Gem::Version.new('2.5')
       end
     end
 


### PR DESCRIPTION
In Foreman we've switched to in-memory setting cache, that needs to be
reloaded on demand, Rails is doing that on every request, for dynflow
actions we need to do it on every phase.