### PR TITLE
Fixes #32771 - adds taxonomy scope to API results

### DIFF
--- a/app/controllers/concerns/foreman_tasks/find_tasks_common.rb
+++ b/app/controllers/concerns/foreman_tasks/find_tasks_common.rb
@@ -1,0 +1,14 @@
+module ForemanTasks
+  module FindTasksCommon
+    def search_query
+      [current_taxonomy_search, params[:search]].select(&:present?).join(' AND ')
+    end
+
+    def current_taxonomy_search
+      conditions = []
+      conditions << "organization_id = #{Organization.current.id}" if Organization.current
+      conditions << "location_id = #{Location.current.id}" if Location.current
+      conditions.empty? ? '' : "(#{conditions.join(' AND ')})"
+    end
+  end
+end

--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -1,6 +1,7 @@
 module ForemanTasks
   module Api
     class TasksController < ::Api::V2::BaseController
+      include ForemanTasks::FindTasksCommon
       include ::Foreman::Controller::SmartProxyAuth
       add_smart_proxy_filters :callback, :features => 'Dynflow'
 
@@ -195,7 +196,7 @@ module ForemanTasks
       end
 
       def search_options
-        [params[:search], {}]
+        [search_query, {}]
       end
 
       def_param_group :callback_target do

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -43,6 +43,21 @@ module ForemanTasks
           _(data.dig('sort', 'by')).must_equal 'duration'
           _(data['results'].count).must_equal 5
         end
+
+        context 'with current taxonomies' do
+          it 'includes untaxed tasks and taxed by current taxonomy' do
+            org1 = FactoryBot.create(:organization)
+            org2 = FactoryBot.create(:organization)
+            org1_task = FactoryBot.create(:task_with_links, resource_id: org1.id, resource_type: 'Organization')
+            org2_task = FactoryBot.create(:task_with_links, resource_id: org2.id, resource_type: 'Organization')
+            get :index, params: { organization_id: org1.id }
+            assert_response :success
+            results = JSON.parse(response.body)['results']
+            _(results.count).must_equal 6
+            _(results.map { |r| r['id'] }).must_include org1_task.id
+            _(results.map { |r| r['id'] }).wont_include org2_task.id
+          end
+        end
       end
 
       describe 'POST /api/tasks/bulk_search' do


### PR DESCRIPTION
Current taxonomies are not reflected within the API results, as the
search needs to be explicitly added for them, because of specifics of
Tasks taxonomy scoping - as it doesn't have direct association to
taxonomies.