### PR TITLE
Fixes #31872 - Disable bulk actions when unauthorized

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
@@ -27,6 +27,7 @@ const TasksTable = ({
   openClickedModal,
   openModal,
   allRowsSelected,
+  permissions,
 }) => {
   const { search, pathname } = history.location;
   const url = pathname + search;
@@ -59,6 +60,7 @@ const TasksTable = ({
       },
       isSelected: ({ rowData }) =>
         allRowsSelected || selectedRows.includes(rowData.id),
+      permissions,
     };
   };
 
@@ -162,6 +164,9 @@ TasksTable.propTypes = {
   unselectRow: PropTypes.func.isRequired,
   openModal: PropTypes.func.isRequired,
   allRowsSelected: PropTypes.bool,
+  permissions: PropTypes.shape({
+    edit: PropTypes.bool,
+  }),
 };
 
 TasksTable.defaultProps = {
@@ -173,6 +178,9 @@ TasksTable.defaultProps = {
   },
   selectedRows: [],
   allRowsSelected: false,
+  permissions: {
+    edit: false,
+  },
 };
 
 export default TasksTable;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -81,7 +81,10 @@ const TasksTablePage = ({
               title={__('Export All')}
             />
             <ActionSelectButton
-              disabled={!(props.selectedRows.length || props.allRowsSelected)}
+              disabled={
+                !props.permissions.edit ||
+                !(props.selectedRows.length || props.allRowsSelected)
+              }
               onCancel={() => openModal(CANCEL_SELECTED_MODAL)}
               onResume={() => openModal(RESUME_SELECTED_MODAL)}
               onForceCancel={() => openModal(FORCE_UNLOCK_SELECTED_MODAL)}
@@ -94,15 +97,17 @@ const TasksTablePage = ({
         }
       >
         <React.Fragment>
-          {showSelectAll && props.itemCount >= props.pagination.perPage && (
-            <SelectAllAlert
-              itemCount={props.itemCount}
-              perPage={props.pagination.perPage}
-              selectAllRows={selectAllRows}
-              unselectAllRows={props.unselectAllRows}
-              allRowsSelected={props.allRowsSelected}
-            />
-          )}
+          {props.permissions.edit &&
+            showSelectAll &&
+            props.itemCount >= props.pagination.perPage && (
+              <SelectAllAlert
+                itemCount={props.itemCount}
+                perPage={props.pagination.perPage}
+                selectAllRows={selectAllRows}
+                unselectAllRows={props.unselectAllRows}
+                allRowsSelected={props.allRowsSelected}
+              />
+            )}
           <TasksTable history={history} {...props} openModal={openModal} />
         </React.Fragment>
       </PageLayout>
@@ -131,6 +136,9 @@ TasksTablePage.propTypes = {
   showSelectAll: PropTypes.bool,
   unselectAllRows: PropTypes.func.isRequired,
   reloadPage: PropTypes.func.isRequired,
+  permissions: PropTypes.shape({
+    edit: PropTypes.bool,
+  }),
 };
 
 TasksTablePage.defaultProps = {
@@ -146,6 +154,9 @@ TasksTablePage.defaultProps = {
   createHeader: () => __('Tasks'),
   showSelectAll: false,
   modalID: '',
+  permissions: {
+    edit: false,
+  },
 };
 
 export default TasksTablePage;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableReducer.js
@@ -19,8 +19,13 @@ const initialState = Immutable({
 
 export const TasksTableQueryReducer = (state = initialState, action) => {
   const { type, payload, response } = action;
-  const { subtotal, page, per_page: perPageString, action_name: actionName } =
-    response || {};
+  const {
+    subtotal,
+    page,
+    per_page: perPageString,
+    action_name: actionName,
+    can_edit: canEdit,
+  } = response || {};
   const ACTION_TYPES = createTableActionTypes(TASKS_TABLE_ID);
   switch (type) {
     case SELECT_ALL_ROWS:
@@ -34,6 +39,9 @@ export const TasksTableQueryReducer = (state = initialState, action) => {
           perPage: Number(perPageString),
         },
         selectedRows: [],
+        permissions: {
+          edit: canEdit,
+        },
       });
     case SELECT_ROWS:
       return state.set('selectedRows', union(payload, state.selectedRows));

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableSelectors.js
@@ -24,6 +24,9 @@ export const selectActionName = state =>
 export const selectSelectedRows = state =>
   selectTasksTableQuery(state).selectedRows || [];
 
+export const selectPermissions = state =>
+  selectTasksTableQuery(state).permissions || { edit: false };
+
 export const selectResults = createSelector(
   selectTasksTableContent,
   ({ results }) =>

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTablePage.test.js.snap
@@ -126,6 +126,11 @@ exports[`TasksTablePage rendering render with Breadcrubs and edit permissions 1`
         }
       }
       parentTaskID={null}
+      permissions={
+        Object {
+          "edit": false,
+        }
+      }
       reloadPage={[MockFunction]}
       results={
         Array [
@@ -261,6 +266,11 @@ exports[`TasksTablePage rendering render with minimal props 1`] = `
         }
       }
       parentTaskID={null}
+      permissions={
+        Object {
+          "edit": false,
+        }
+      }
       reloadPage={[MockFunction]}
       results={
         Array [

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableReducer.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTableReducer.test.js.snap
@@ -59,6 +59,9 @@ Object {
       "page": 3,
       "perPage": 12,
     },
+    "permissions": Object {
+      "edit": undefined,
+    },
     "selectedRows": Array [],
   },
 }

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionHeaderCellFormatter.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/__snapshots__/selectionHeaderCellFormatter.test.js.snap
@@ -3,6 +3,7 @@
 exports[`selectionHeaderCellFormatter render 1`] = `
 <TableSelectionHeaderCell
   checked={true}
+  disabled={false}
   id="selectAll"
   label="some-label"
   onChange={[Function]}

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionHeaderCellFormatter.test.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/__test__/selectionHeaderCellFormatter.test.js
@@ -4,7 +4,7 @@ describe('selectionHeaderCellFormatter', () => {
   it('render', () => {
     expect(
       selectionHeaderCellFormatter(
-        { allPageSelected: () => true },
+        { allPageSelected: () => true, permissions: { edit: true } },
         'some-label'
       )
     ).toMatchSnapshot();

--- a/webpack/ForemanTasks/Components/TasksTable/formatters/selectionHeaderCellFormatter.js
+++ b/webpack/ForemanTasks/Components/TasksTable/formatters/selectionHeaderCellFormatter.js
@@ -5,6 +5,7 @@ export default (selectionController, label) => (
   <TableSelectionHeaderCell
     label={label}
     checked={selectionController.allPageSelected()}
+    disabled={!selectionController.permissions.edit}
     onChange={selectionController.selectPage}
   />
 );

--- a/webpack/ForemanTasks/Components/TasksTable/index.js
+++ b/webpack/ForemanTasks/Components/TasksTable/index.js
@@ -16,6 +16,7 @@ import {
   selectAllRowsSelected,
   selectShowSelectAll,
   selectModalID,
+  selectPermissions,
 } from './TasksTableSelectors';
 
 const mapStateToProps = state => ({
@@ -30,6 +31,7 @@ const mapStateToProps = state => ({
   allRowsSelected: selectAllRowsSelected(state),
   showSelectAll: selectShowSelectAll(state),
   modalID: selectModalID(state),
+  permissions: selectPermissions(state),
 });
 
 const mapDispatchToProps = dispatch =>


### PR DESCRIPTION
disables action dropdown and select all in tasks table for users without
`edit_foreman_tasks` permission.

This was already merged once as https://github.com/theforeman/foreman-tasks/pull/607, but then got reverted for some reason. IIRC the patch in core got reverted. However, the needed changes in core are present in both develop and 2.5-stable so this should be good to go once again.