### PR TITLE
[CP] Fixes #33338 - bulk search API refers to Locks instead of Links (#648)

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -260,7 +260,7 @@ module ForemanTasks
             raise BadRequest,
                   _('Resource search_params requires resource_type and resource_id to be specified')
           end
-          scope.joins(:locks).where(foreman_tasks_locks:
+          scope.joins(:links).where(foreman_tasks_links:
                                         { resource_type: search_params[:resource_type],
                                           resource_id:   search_params[:resource_id] })
         when 'task'

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -68,6 +68,17 @@ module ForemanTasks
           data = JSON.parse(response.body)
           _(data[0]['results'][0]['id']).must_equal task.id
         end
+
+        it 'can search for a specific resource' do
+          org = FactoryBot.create(:organization)
+          task = FactoryBot.create(:task_with_links, resource_id: org.id, resource_type: 'Organization')
+
+          post :bulk_search, params: { :searches => [{ :type => 'resource', :resource_id => org.id, :resource_type => 'Organization' }] }
+
+          assert_response :success
+          data = JSON.parse(response.body)
+          _(data[0]['results'][0]['id']).must_equal task.id
+        end
       end
 
       describe 'GET /api/tasks/show' do


### PR DESCRIPTION
(cherry picked from commit 37aee1b69eced429ed4c9d4a5de40df33e03bd44)