### PR TITLE
Fixes #34343 - Unlock tasks on {force_,}unlock

### DIFF
--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -72,17 +72,15 @@ module ForemanTasks
     def unlock
       task = find_dynflow_task
       if task.paused?
-        task.state = :stopped
-        task.save!
-        render json: { statusText: 'OK' }
+        force_unlock(task)
       else
         render json: {}, status: :bad_request
       end
     end
 
-    def force_unlock
-      task       = find_dynflow_task
+    def force_unlock(task = find_dynflow_task)
       task.state = :stopped
+      task.locks.destroy_all
       task.save!
       render json: { statusText: 'OK' }
     end


### PR DESCRIPTION
After f505bb3 it is not enough for a task to be in stopped state, its locks have
to be really destroyed to count the task as unlocked.