### PR TITLE
Fixes #34741 - Supply time in right time zone

### DIFF
--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -90,7 +90,7 @@ module ForemanTasks
     def next_occurrence_time(time = Time.zone.now)
       @parser ||= CronParser.new(cron_line, Time.zone)
       # @parser.next(start_time) is not inclusive of the start_time hence stepping back one run to include checking start_time for the first run.
-      before_next = @parser.next(@parser.last(time))
+      before_next = @parser.next(@parser.last(time.in_time_zone))
       return before_next if before_next >= time && tasks.count == 0
       @parser.next(time)
     end


### PR DESCRIPTION
when calculating next occurence time. CronParser is picky about this.