### PR TITLE
Fixes #34954 - Render issue after Rails 6.1.6 upgrade

### DIFF
--- a/app/views/foreman_tasks/layouts/react.html.erb
+++ b/app/views/foreman_tasks/layouts/react.html.erb
@@ -10,4 +10,4 @@
   <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
   <%= react_component('ForemanTasks') %>
 <% end %>
-<%= render file: "layouts/base" %>
+<%= render template: "layouts/base" %>


### PR DESCRIPTION
This fixes

```
 Showing /home/vagrant/foreman/.vendor/ruby/2.7.0/gems/foreman-tasks-6.0.2/app/views/foreman_tasks/layouts/react.html.erb where line #13 raised:

`render file:` should be given the absolute path to a file. 'layouts/base' was given instead
```