### PR TITLE
Fixes #35052 - Update js foreman packages to 10.1

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -25,7 +25,7 @@ module ForemanTasks
 
     initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :"foreman-tasks" do
-        requires_foreman '>= 3.2.0'
+        requires_foreman '>= 3.3.0'
         divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
         menu :top_menu, :tasks,
              :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "url": "http://projects.theforeman.org/projects/foreman-tasks/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^8.15.0"
+    "@theforeman/vendor": "^10.1.0"
   },
   "dependencies": {
     "c3": "^0.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^8.15.0",
-    "@theforeman/eslint-plugin-foreman": "^8.15.0",
-    "@theforeman/stories": "^8.15.0",
-    "@theforeman/test": "^8.15.0",
-    "@theforeman/vendor-dev": "^8.15.0",
+    "@theforeman/builder": "^10.1.0",
+    "@theforeman/eslint-plugin-foreman": "^10.1.0",
+    "@theforeman/stories": "^10.1.0",
+    "@theforeman/test": "^10.1.0",
+    "@theforeman/vendor-dev": "^10.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
     "jed": "^1.1.1",


### PR DESCRIPTION
This is the current version that core uses and it makes js tests green 