### PR TITLE
Fixes #35328 - Propagate errors when remote parent task fails

### DIFF
--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -102,6 +102,8 @@ module Actions
       else
         suspend
       end
+    rescue RestClient::NotFound
+      on_proxy_action_missing
     end
 
     def cancel_proxy_task

--- a/app/lib/actions/trigger_proxy_batch.rb
+++ b/app/lib/actions/trigger_proxy_batch.rb
@@ -42,6 +42,9 @@ module Actions
     rescue => e
       action_logger.warn "Could not trigger task on the smart proxy"
       action_logger.warn e
+      # The response contains non-serializable objects
+      # TypeError: no _dump_data is defined for class Monitor
+      e.response = nil
       batch.each { |remote_task| remote_task.update_from_batch_trigger({ 'exception' => e }) }
       output[:failed_count] += batch.size
     end

--- a/app/lib/actions/trigger_proxy_batch.rb
+++ b/app/lib/actions/trigger_proxy_batch.rb
@@ -42,7 +42,7 @@ module Actions
     rescue => e
       action_logger.warn "Could not trigger task on the smart proxy"
       action_logger.warn e
-      batch.each { |remote_task| remote_task.update_from_batch_trigger({}) }
+      batch.each { |remote_task| remote_task.update_from_batch_trigger({ 'exception' => e }) }
       output[:failed_count] += batch.size
     end
 

--- a/app/models/foreman_tasks/remote_task.rb
+++ b/app/models/foreman_tasks/remote_task.rb
@@ -49,10 +49,11 @@ module ForemanTasks
         self.parent_task_id = parent['task_id']
         self.state = 'parent-triggered'
       else
+        exception = data['exception']
         # Tell the action the task on the smart proxy stopped
         ForemanTasks.dynflow.world.event execution_plan_id,
                                          step_id,
-                                         ::Actions::ProxyAction::ProxyActionStopped.new,
+                                         ::Actions::ProxyAction::ProxyActionStoppedEvent[exception],
                                          optional: true
       end
       save!


### PR DESCRIPTION
Before we notified the local child actions that their remote counterpart
has failed, but we didn't include any details. This made the local
actions ask the smart proxy for status, get back a 404, which the local
actions did not expect.

If we know that the remote parent failed during triggering, it is clear
there will not be any remote tasks to ask about, so we can fail straight
away, without having to ask for status.