### PR TITLE
Fixes #35592 - Fix delegated proxy task watching

### DIFF
--- a/app/models/foreman_tasks/remote_task.rb
+++ b/app/models/foreman_tasks/remote_task.rb
@@ -7,7 +7,7 @@ module ForemanTasks
                       :foreign_key => :execution_plan_id,
                       :inverse_of  => :remote_tasks
 
-    scope :triggered, -> { where(:state => 'triggered') }
+    scope :triggered, -> { where(:state => ['triggered', 'parent-triggered']) }
     scope :pending,   -> { where(:state => 'new') }
     scope :external,  -> { where(:state => 'external') }
 


### PR DESCRIPTION
Consider tasks which were 'triggered' or 'parent-triggered' as running.

Steps to reproduce:
1) Start a rex job that runs for a while, `sleep 1000` works well
2) Wait for the job to get to the smart proxy
3) Kill smart proxy
4) Wait 10 minutes

Actual results: The job keeps pending, no checks to /dynflow/tasks/status going to the proxy

Expected results: One check to /dynflow/tasks/status on the proxy, the job then fails