### PR TITLE
Store action names sorted

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -16,6 +16,7 @@ if gettext_find_task
                  .all_action_names
                  .uniq
                  .map { |n| %[_("#{n}")] }
+                 .sort
                  .join("\n")
     end
   end


### PR DESCRIPTION
This makes the output stable and avoids moving lines around. That only creates noise in the git log.