### PR TITLE
Fixes #35860 - Fix untranslatable strings

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/Components/TaskButtons.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/TaskButtons.js
@@ -48,7 +48,7 @@ export const TaskButtons = ({
         <span
           className={`glyphicon glyphicon-refresh ${taskReload ? 'spin' : ''}`}
         />
-        {__(`${taskReload ? 'Stop' : 'Start'}  auto-reloading`)}
+        {taskReload ? __('Stop auto-reloading') : __('Start auto-reloading')}
       </Button>
       <Button
         className="dynflow-button"

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/TaskButtons.test.js.snap
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/__tests__/__snapshots__/TaskButtons.test.js.snap
@@ -19,7 +19,7 @@ exports[`Task rendering render with minimal Props 1`] = `
     <span
       className="glyphicon glyphicon-refresh "
     />
-    Start  auto-reloading
+    Start auto-reloading
   </Button>
   <Button
     active={false}
@@ -118,7 +118,7 @@ exports[`Task rendering render with some Props 1`] = `
     <span
       className="glyphicon glyphicon-refresh spin"
     />
-    Stop  auto-reloading
+    Stop auto-reloading
   </Button>
   <Button
     active={false}

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'patternfly-react';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import MessageBox from 'foremanReact/components/common/MessageBox';
 import Task from './Components/Task';
@@ -49,7 +49,7 @@ const TaskDetails = ({
       <MessageBox
         key="task-details-error"
         icontype="error-circle-o"
-        msg={__(`Could not receive data: ${APIerror && APIerror.message}`)}
+        msg={sprintf(__('Could not receive data: %s'), APIerror?.message)}
       />
     );
   }

--- a/webpack/ForemanTasks/Components/TasksTable/Components/SelectAllAlert.js
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/SelectAllAlert.js
@@ -1,3 +1,4 @@
+import { FormattedMessage } from 'react-intl';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button } from 'patternfly-react';
@@ -17,14 +18,19 @@ export const SelectAllAlert = ({
         Math.min(itemCount, perPage)
       )}
       <Button bsStyle="link" onClick={selectAllRows}>
-        {__('Select All')}
-        <b> {itemCount} </b> {__('tasks.')}
+        <FormattedMessage
+          id="select-all-tasks"
+          values={{
+            count: <b>{itemCount}</b>,
+          }}
+          defaultMessage={__('Select all {count} tasks')}
+        />
       </Button>
     </React.Fragment>
   );
   const undoSelectText = (
     <React.Fragment>
-      {sprintf(__(`All %s tasks are selected. `), itemCount)}
+      {sprintf(__('All %s tasks are selected.'), itemCount)}
       <Button bsStyle="link" onClick={unselectAllRows}>
         {__('Undo selection')}
       </Button>

--- a/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/SelectAllAlert.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/Components/__test__/__snapshots__/SelectAllAlert.test.js.snap
@@ -6,7 +6,7 @@ exports[`SelectAllAlert renders SelectAllAlert with all rows selected 1`] = `
   onDismiss={null}
   type="info"
 >
-  All 7 tasks are selected. 
+  All 7 tasks are selected.
   <Button
     active={false}
     block={false}
@@ -35,14 +35,17 @@ exports[`SelectAllAlert renders SelectAllAlert with perPage > itemCout 1`] = `
     disabled={false}
     onClick={[MockFunction]}
   >
-    Select All
-    <b>
-       
-      7
-       
-    </b>
-     
-    tasks.
+    <FormattedMessage
+      defaultMessage="Select all {count} tasks"
+      id="select-all-tasks"
+      values={
+        Object {
+          "count": <b>
+            7
+          </b>,
+        }
+      }
+    />
   </Button>
 </Alert>
 `;
@@ -62,14 +65,17 @@ exports[`SelectAllAlert renders SelectAllAlert without all rows selected 1`] = `
     disabled={false}
     onClick={[MockFunction]}
   >
-    Select All
-    <b>
-       
-      7
-       
-    </b>
-     
-    tasks.
+    <FormattedMessage
+      defaultMessage="Select all {count} tasks"
+      id="select-all-tasks"
+      values={
+        Object {
+          "count": <b>
+            7
+          </b>,
+        }
+      }
+    />
   </Button>
 </Alert>
 `;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksBulkActions.js
@@ -53,7 +53,7 @@ const handleErrorResume = (error, dispatch) => {
   dispatch({ type: TASKS_RESUME_FAILURE, error });
   dispatch(
     addToast(
-      errorToastData(`${__(`Cannot resume tasks at the moment`)} ${error}`)
+      errorToastData(`${__('Cannot resume tasks at the moment')} ${error}`)
     )
   );
 };
@@ -112,7 +112,7 @@ const handleErrorCancel = (error, dispatch) => {
   dispatch({ type: TASKS_CANCEL_FAILURE, error });
   dispatch(
     addToast(
-      errorToastData(`${__(`Cannot cancel tasks at the moment`)} ${error}`)
+      errorToastData(`${__('Cannot cancel tasks at the moment')} ${error}`)
     )
   );
 };
@@ -175,7 +175,7 @@ const handleErrorForceCancel = (error, dispatch) => {
   dispatch(
     addToast(
       errorToastData(
-        `${__(`Cannot force cancel tasks at the moment`)} ${error}`
+        `${__('Cannot force cancel tasks at the moment')} ${error}`
       )
     )
   );

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Table } from 'foremanReact/components/common/table';
 import { STATUS } from 'foremanReact/constants';
 import MessageBox from 'foremanReact/components/common/MessageBox';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
 import Pagination from 'foremanReact/components/Pagination';
 import { getURIQuery } from 'foremanReact/common/helpers';
 import createTasksTableSchema from './TasksTableSchema';
@@ -68,7 +68,7 @@ const TasksTable = ({
       <MessageBox
         key="tasks-table-error"
         icontype="error-circle-o"
-        msg={__(`Could not receive data: ${error && error.message}`)}
+        msg={sprintf(__('Could not receive data: %s'), error?.message)}
       />
     );
   }

--- a/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTable.test.js.snap
+++ b/webpack/ForemanTasks/Components/TasksTable/__tests__/__snapshots__/TasksTable.test.js.snap
@@ -4,7 +4,7 @@ exports[`TasksTable rendering render with error Props 1`] = `
 <MessageBox
   icontype="error-circle-o"
   key="tasks-table-error"
-  msg="Could not receive data: null"
+  msg="Could not receive data: "
 />
 `;
 


### PR DESCRIPTION
It is never valid to use ```__(``)``` since string extraction relies on static strings. String interpolation breaks this, so it's best to avoid it even if the string contained is static.

This also fixes a string where interpolation should happen. This allows translations to move around the word order. Ideally they would actually properly use pluralization so that it would be "select 1 task" instead of "select 1 tasks". That would also allow other languages to properly use plurals, but that's left as a future improvement.