### PR TITLE
update github actions node version to 12,14

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 12]
+        node-version:
+          - 12
+          - 14
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node


### PR DESCRIPTION
Foreman tests are only run on node versions 12,14. 
node 10 is eol for around 2 years now