### PR TITLE
Fixes #35880 - Do not configure sidekiq sessions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,6 @@ Foreman::Application.routes.draw do
         require 'sidekiq/web'
         redis_url = ENV['DYNFLOW_REDIS_URL'] || SETTINGS.dig(:dynflow, :redis_url)
         Sidekiq.redis = { url: redis_url }
-        Sidekiq::Web.set :sessions, false
         mount Sidekiq::Web => '/sidekiq', :constraints => ForemanTasks::Dynflow::SidekiqConsoleConstraint.new
       end
     end


### PR DESCRIPTION
Sidekiq >= 6.2.0 has reworked session handling, we shouldn't need to set anything and everything should just work out of the box.