### PR TITLE
Fixes #35950 - Make delivery of ProxyActionStopped events optional

### DIFF
--- a/app/lib/actions/middleware/watch_delegated_proxy_sub_tasks.rb
+++ b/app/lib/actions/middleware/watch_delegated_proxy_sub_tasks.rb
@@ -51,7 +51,7 @@ module Actions
 
       def notify(event, tasks)
         tasks.each do |task|
-          action.plan_event(event, execution_plan_id: task.execution_plan_id, step_id: task.step_id)
+          action.plan_event(event, execution_plan_id: task.execution_plan_id, step_id: task.step_id, optional: true)
         end
       end
 


### PR DESCRIPTION
They are meant to catch cases when the remote task stops or disappears. If this happens but the local task is already stopped, it is not an error state.