### PR TITLE
Fixes #36002 - Migration error 'column settings.category does not exist'

### DIFF
--- a/db/migrate/20211123170430_tasks_settings_to_dsl_category.rb
+++ b/db/migrate/20211123170430_tasks_settings_to_dsl_category.rb
@@ -1,5 +1,5 @@
 class TasksSettingsToDslCategory < ActiveRecord::Migration[6.0]
   def up
-    Setting.where(category: 'Setting::ForemanTasks').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::ForemanTasks').update_all(category: 'Setting') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
See:
* https://github.com/theforeman/foreman/pull/9524
* https://github.com/theforeman/foreman/pull/9524#issuecomment-1404661119