### PR TITLE
Fixes #36351 - Send out email notification when tasks linger in running or paused for longer than two days

### DIFF
--- a/app/lib/actions/check_long_running_tasks.rb
+++ b/app/lib/actions/check_long_running_tasks.rb
@@ -1,5 +1,7 @@
 module Actions
   class CheckLongRunningTasks < ::Actions::EntryAction
+    include Actions::RecurringAction
+
     INTERVAL = 2.days
     STATES = ['running', 'paused'].freeze
 

--- a/app/lib/actions/check_long_running_tasks.rb
+++ b/app/lib/actions/check_long_running_tasks.rb
@@ -1,0 +1,39 @@
+module Actions
+  class CheckLongRunningTasks < ::Actions::EntryAction
+    INTERVAL = 2.days
+    STATES = ['running', 'paused'].freeze
+
+    def plan
+      time = Time.now.utc
+      cutoff = time - INTERVAL
+      notification = ::ForemanTasks::TasksMailNotification.find_by(name: "long_running_tasks")
+      users = User.where(id: UserMailNotification.where(mail_notification_id: notification.id))
+
+      query = "state ^ (#{STATES.join(', ')}) AND state_updated_at <= \"#{cutoff}\""
+      users.each do |user|
+        User.as(user) do
+          tasks = ForemanTasks::Task.authorized
+                                    .search_for(query)
+                                    .select(:id)
+                                    .pluck(:id)
+          plan_action(DeliverLongRunningTasksNotification,
+                      OpenStruct.new(
+                        user_id: User.current.id,
+                        time: time,
+                        interval: INTERVAL,
+                        states: STATES,
+                        task_uuids: tasks,
+                        query: query,
+                        # Non serializable fields
+                        user: nil,
+                        tasks: nil
+                      ))
+        end
+      end
+    end
+
+    def humanized_name
+      _('Check for long running tasks')
+    end
+  end
+end

--- a/app/lib/actions/deliver_long_running_tasks_notification.rb
+++ b/app/lib/actions/deliver_long_running_tasks_notification.rb
@@ -11,6 +11,7 @@ module Actions
       tasks = ForemanTasks::Task.where(id: report.task_uuids)
       report.user = User.current
       report.tasks = tasks
+      ::UINotifications::Tasks::TasksRunningLong.new.deliver!
       TasksMailer.long_tasks(report).deliver_now
     end
 

--- a/app/lib/actions/deliver_long_running_tasks_notification.rb
+++ b/app/lib/actions/deliver_long_running_tasks_notification.rb
@@ -1,0 +1,21 @@
+module Actions
+  class DeliverLongRunningTasksNotification < EntryAction
+    def plan(report)
+      return if report.task_uuids.empty?
+
+      plan_self report: report
+    end
+
+    def run
+      report = OpenStruct.new(input[:report])
+      tasks = ForemanTasks::Task.where(id: report.task_uuids)
+      report.user = User.current
+      report.tasks = tasks
+      TasksMailer.long_tasks(report).deliver_now
+    end
+
+    def humanized_name
+      _('Deliver notifications about long running tasks')
+    end
+  end
+end

--- a/app/mailers/tasks_mailer.rb
+++ b/app/mailers/tasks_mailer.rb
@@ -1,0 +1,12 @@
+class TasksMailer < ApplicationMailer
+  helper ApplicationHelper
+
+  def long_tasks(report, opts = {})
+    return if report.tasks.empty?
+
+    @report = report
+    @subject = opts[:subject]
+    @subject ||= _('Tasks pending since %s') % (@report.time - @report.interval)
+    mail(to: report.user.mail, subject: @subject)
+  end
+end

--- a/app/models/foreman_tasks/tasks_mail_notification.rb
+++ b/app/models/foreman_tasks/tasks_mail_notification.rb
@@ -1,0 +1,9 @@
+module ForemanTasks
+  class TasksMailNotification < MailNotification
+    ALL = N_("Subscribe")
+
+    def subscription_options
+      [ALL]
+    end
+  end
+end

--- a/app/services/ui_notifications/tasks/tasks_running_long.rb
+++ b/app/services/ui_notifications/tasks/tasks_running_long.rb
@@ -1,0 +1,33 @@
+module UINotifications
+  module Tasks
+    class TasksRunningLong < Tasks::Base
+      include Rails.application.routes.url_helpers
+
+      def deliver!
+        notification = ::Notification.new(
+          :audience => Notification::AUDIENCE_GLOBAL,
+          :notification_blueprint => blueprint,
+          :initiator => initiator,
+          :message => message,
+          :subject => nil,
+          :notification_recipients => [NotificationRecipient.create(:user => User.current)]
+        )
+        notification.actions['links'] ||= []
+        notification.actions['links'] << {
+          href: foreman_tasks_tasks_path(search: subject.query),
+          title: N_('Long running tasks'),
+        }
+        notification.save!
+        notification
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => 'tasks_running_long')
+      end
+
+      def message
+        _("%{count} tasks are in running or paused state for more than a day") % { count: subject.task_uuids.count }
+      end
+    end
+  end
+end

--- a/app/views/tasks_mailer/long_tasks.html.erb
+++ b/app/views/tasks_mailer/long_tasks.html.erb
@@ -1,0 +1,29 @@
+<p>
+<%= _("Tasks lingering in states %{states} since %{time}") % {
+  time: @report.time - @report.interval,
+  states: @report.states.join(', ')
+} %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <tr>
+      <th>_("ID")</th>
+      <th>_("Action")</th>
+      <th>_("Label")</th>
+      <th>_("State")</th>
+      <th>_("State updated at")</th>
+    </tr>
+    <% @report.tasks.each do |task| %>
+      <tr>
+        <td><%= link_to task.id, foreman_tasks_task_url(task) %></td>
+        <td><%= task.action %></td>
+        <td><%= task.label %></td>
+        <td><%= task.state %></td>
+        <td><%= task.state_updated_at %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>
+
+<%= link_to 'More details', foreman_tasks_tasks_url(search: @report.query) %>

--- a/app/views/tasks_mailer/long_tasks.text.erb
+++ b/app/views/tasks_mailer/long_tasks.text.erb
@@ -1,0 +1,16 @@
+<%= _("Tasks lingering in states %{states} since %{time}") % {
+  time: @report.time - @report.interval,
+  states: @report.states.join(', ')
+} %>
+
+More details: <%= foreman_tasks_tasks_url(search: @report.query) %>
+
+<% @report.tasks.each do |task| %>
+ID: <%= task.id %>
+Action: <%= task.action %>
+Label: <%= task.label %>
+State: <%= task.state %>
+State updated at: <%= task.state_updated_at %>
+Details: <%= foreman_tasks_task_url(task) %>
+
+<% end %>

--- a/db/seeds.d/30-notification_blueprints.rb
+++ b/db/seeds.d/30-notification_blueprints.rb
@@ -49,6 +49,13 @@ blueprints = [
     level: 'info',
     message: "DYNAMIC",
   },
+
+  {
+    group: N_('Tasks'),
+    name: 'tasks_running_long',
+    message: 'DYNAMIC',
+    level: 'warning',
+  },
 ]
 
 blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/db/seeds.d/95-mail_notifications.rb
+++ b/db/seeds.d/95-mail_notifications.rb
@@ -1,0 +1,24 @@
+N_('Long running tasks')
+
+notifications = [
+  {
+    :name               => 'long_running_tasks',
+    :description        => N_('A notification when tasks run for suspiciously long time'),
+    :mailer             => 'TasksMailer',
+    :method             => 'long_tasks',
+    :subscription_type  => 'alert',
+  },
+]
+
+notifications.each do |notification|
+  if (mail = ForemanTasks::TasksMailNotification.find_by(name: notification[:name]))
+    mail.attributes = notification
+    mail.save! if mail.changed?
+  else
+    created_notification = ForemanTasks::TasksMailNotification.create(notification)
+    if created_notification.nil? || created_notification.errors.any?
+      raise ::Foreman::Exception.new(N_("Unable to create mail notification: %s"),
+                                     format_errors(created_notification))
+    end
+  end
+end

--- a/db/seeds.d/95-mail_notifications.rb
+++ b/db/seeds.d/95-mail_notifications.rb
@@ -18,7 +18,7 @@ notifications.each do |notification|
     created_notification = ForemanTasks::TasksMailNotification.create(notification)
     if created_notification.nil? || created_notification.errors.any?
       raise ::Foreman::Exception.new(N_("Unable to create mail notification: %s"),
-                                     format_errors(created_notification))
+                                     SeedHelper.format_errors(created_notification))
     end
   end
 end

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -61,4 +61,19 @@ module ForemanTasks
     result = dynflow.world.delay action, delay_options, *args
     ForemanTasks::Task::DynflowTask.where(:external_id => result.id).first!
   end
+
+  def self.register_scheduled_task(task_class, cronline)
+    ForemanTasks::RecurringLogic.transaction(isolation: :serializable) do
+      return if ForemanTasks::RecurringLogic.joins(:tasks)
+                                            .merge(ForemanTasks::Task.where(label: task_class.name))
+                                            .exists?
+
+      User.as_anonymous_admin do
+        recurring_logic = ForemanTasks::RecurringLogic.new_from_cronline(cronline)
+        recurring_logic.save!
+        recurring_logic.start(task_class)
+      end
+    end
+  rescue ActiveRecord::TransactionIsolationError # rubocop:disable Lint/SuppressedException
+  end
 end

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -65,6 +65,7 @@ module ForemanTasks
   def self.register_scheduled_task(task_class, cronline)
     ForemanTasks::RecurringLogic.transaction(isolation: :serializable) do
       return if ForemanTasks::RecurringLogic.joins(:tasks)
+                                            .where(state: 'active')
                                             .merge(ForemanTasks::Task.where(label: task_class.name))
                                             .exists?
 

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -162,6 +162,7 @@ module ForemanTasks
         world.middleware.use Actions::Middleware::KeepCurrentTimezone
         world.middleware.use Actions::Middleware::KeepCurrentRequestID
         world.middleware.use ::Actions::Middleware::LoadSettingValues
+        ForemanTasks.register_scheduled_task(Actions::CheckLongRunningTasks, ENV['FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE'] || '0 0 * * *')
       end
       ::ForemanTasks.dynflow.config.on_init(true) do
         ::ForemanTasks::Task::DynflowTask.consistency_check

--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -187,7 +187,7 @@ module ForemanTasks
     end
 
     rake_tasks do
-      %w[dynflow.rake test.rake export_tasks.rake cleanup.rake generate_task_actions.rake].each do |rake_file|
+      %w[dynflow.rake test.rake export_tasks.rake cleanup.rake generate_task_actions.rake reschedule_long_running_tasks_checker.rake].each do |rake_file|
         full_path = File.expand_path("../tasks/#{rake_file}", __FILE__)
         load full_path if File.exist?(full_path)
       end

--- a/lib/foreman_tasks/tasks/reschedule_long_running_tasks_checker.rake
+++ b/lib/foreman_tasks/tasks/reschedule_long_running_tasks_checker.rake
@@ -1,0 +1,21 @@
+namespace :foreman_tasks do
+  desc <<~DESC
+    Reschedules the long running task checker recurring logic to run at a different schedule. ENV variables:
+
+      * FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE : A cron line describing the schedule, defaults to 0 0 * * *
+  DESC
+  task :reschedule_long_running_tasks_checker => ['environment', 'dynflow:client'] do
+    User.as_anonymous_admin do
+      task_class = Actions::CheckLongRunningTasks
+      cronline = ENV['FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE'] || '0 0 * * *'
+      rl = ForemanTasks::RecurringLogic.joins(:tasks)
+                                       .where(state: 'active')
+                                       .merge(ForemanTasks::Task.where(label: task_class.name))
+                                       .first
+      if rl&.cron_line != cronline
+        rl.cancel
+        ForemanTasks.register_scheduled_task(task_class, cronline)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] users should be able to opt-out/in
  - users are able to opt-in/opt-out in email preferences
  - toast notification is now tied to the email notification which isn't exactly great, but we don't really have any other means of configuring it
- [x] always enabled ~~by default~~ for admin
  - ~~this is tricky. I thought I'd add a migration, but the migration needs to run after data (the template) is seeded. Currently the migration creates the template and then the seeds override it. I'm not particularly fond of this, but I don't really see another way~~
- [x] honor taxonomy boundaries
- [x] time should be configurable
  - done, sort of. We don't really have the means for doing this nicely as recurring logics cannot be edited
  - by default set to midnight
  - However, as a workaround the RL can be cancelled, env variable `FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE` can be set to a new cronline and then on service restart the RL should get re-created with the new schedule
  - Alternatively `rake foreman_tasks:reschedule_long_running_tasks_checker FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE=$cron` can be used
- [x] have a recurring task monitor the rest of tasks