### PR TITLE
Fixes #36392 - Replace fugit.parse with fugit.do_parse

### DIFF
--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -96,7 +96,7 @@ module ForemanTasks
     end
 
     def next_occurrence_time(time = Time.zone.now)
-      @parser ||= Fugit.parse_cron(cron_line)
+      @parser ||= Fugit.do_parse_cron(cron_line)
       # @parser.next(start_time) is not inclusive of the start_time hence stepping back one run to include checking start_time for the first run.
       before_next = @parser.next_time(@parser.previous_time(time.iso8601))
       return before_next.utc.localtime if before_next >= time && tasks.count == 0

--- a/test/unit/recurring_logic_test.rb
+++ b/test/unit/recurring_logic_test.rb
@@ -54,6 +54,17 @@ class RecurringLogicsTest < ActiveSupport::TestCase
       _(ForemanTasks::RecurringLogic.cronline_hash(:monthly, time_hash, days, days_of_week)).must_equal expected_result_monthly
     end
 
+    it 'validates cronline correctly' do
+      recurring_logic = ::ForemanTasks::RecurringLogic.new_from_cronline('* * * * abc')
+      assert_not recurring_logic.valid_cronline?
+      recurring_logic = ::ForemanTasks::RecurringLogic.new_from_cronline(nil)
+      assert_not recurring_logic.valid_cronline?
+      recurring_logic = ::ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
+      assert recurring_logic.valid_cronline?
+      recurring_logic = ::ForemanTasks::RecurringLogic.new_from_cronline('0 22 * * mon-fri')
+      assert recurring_logic.valid_cronline?
+    end
+
     it 'can have limited number of repeats' do
       parser = ForemanTasks::RecurringLogic.new_from_cronline('* * * * *')
       parser.state = 'active'


### PR DESCRIPTION
Based on documentation, do_parse seems like a better fit for us.

https://github.com/floraison/fugit#fugitdo_parses