### PR TITLE
Fixes #36700 - Switch to v2 of sub plans

### DIFF
--- a/app/lib/actions/action_with_sub_plans.rb
+++ b/app/lib/actions/action_with_sub_plans.rb
@@ -1,6 +1,6 @@
 module Actions
   class Actions::ActionWithSubPlans < Actions::EntryAction
-    include Dynflow::Action::WithSubPlans
+    include Dynflow::Action::V2::WithSubPlans
 
     def plan(*_args)
       raise NotImplementedError
@@ -9,17 +9,9 @@ module Actions
     def humanized_output
       return unless counts_set?
       _('%{total} task(s), %{success} success, %{failed} fail') %
-        { total:   output[:total_count],
+        { total:   total_count,
           success: output[:success_count],
           failed:  output[:failed_count] }
-    end
-
-    def run_progress
-      if counts_set? && output[:total_count] > 0
-        (output[:success_count] + output[:failed_count]).to_f / output[:total_count]
-      else
-        0.1
-      end
     end
   end
 end

--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -1,7 +1,5 @@
 module Actions
   class BulkAction < Actions::ActionWithSubPlans
-    include Dynflow::Action::WithBulkSubPlans
-
     # == Parameters:
     # actions_class::
     #   Class of action to trigger on targets
@@ -9,12 +7,13 @@ module Actions
     #   Array of objects on which the action_class should be triggered
     # *args::
     #   Arguments that all the targets share
-    def plan(action_class, targets, *args)
+    def plan(action_class, targets, *args, concurrency_limit: nil, **kwargs)
       check_targets!(targets)
+      limit_concurrency_level!(concurrency_limit) if concurrency_limit
       plan_self(:action_class => action_class.to_s,
                 :target_ids => targets.map(&:id),
                 :target_class => targets.first.class.to_s,
-                :args => args)
+                :args => args + [kwargs])
     end
 
     def run(event = nil)

--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -13,7 +13,8 @@ module Actions
       plan_self(:action_class => action_class.to_s,
                 :target_ids => targets.map(&:id),
                 :target_class => targets.first.class.to_s,
-                :args => args + [kwargs])
+                :args => args,
+                :kwargs => kwargs)
     end
 
     def run(event = nil)
@@ -50,7 +51,7 @@ module Actions
       missing = Array.new((current_batch - targets.map(&:id)).count) { nil }
 
       (targets + missing).map do |target|
-        trigger(action_class, target, *input[:args])
+        trigger(action_class, target, *input[:args], **input[:kwargs])
       end
     end
 

--- a/foreman-tasks.gemspec
+++ b/foreman-tasks.gemspec
@@ -26,7 +26,7 @@ same resource. It also optionally provides Dynflow infrastructure for using it f
   s.test_files = `git ls-files test`.split("\n")
   s.extra_rdoc_files = Dir['README*', 'LICENSE']
 
-  s.add_dependency "dynflow", '>= 1.6.0'
+  s.add_dependency "dynflow", '>= 1.8.0'
   s.add_dependency 'fugit', '~> 1.8'
   s.add_dependency "get_process_mem" # for memory polling
   s.add_dependency "sinatra" # for Dynflow web console

--- a/test/unit/actions/action_with_sub_plans_test.rb
+++ b/test/unit/actions/action_with_sub_plans_test.rb
@@ -20,6 +20,10 @@ module ForemanTasks
         user = User.find(input[:user_id])
         trigger(ChildAction, user)
       end
+
+      def total_count
+        1
+      end
     end
 
     class ChildAction < Actions::EntryAction

--- a/test/unit/task_groups_test.rb
+++ b/test/unit/task_groups_test.rb
@@ -27,6 +27,10 @@ module ForemanTasks
       def create_sub_plans
         Array.new(input[:count]) { |i| trigger InheritingChildAction, i + 2 }
       end
+
+      def total_count
+        input[:count]
+      end
     end
 
     class ChildAction < Actions::EntryAction


### PR DESCRIPTION
In addition to migrating to a newer implementation, it also exposes concurrency limiting for sub-plans spawned by `::Actions::BulkAction`

Requires:
- https://github.com/Dynflow/dynflow/pull/428

TODO:
- [x] Bump dependency on dynflow