### PR TITLE
Fixes #36746 - Make email delivery skip on failures

### DIFF
--- a/app/lib/actions/check_long_running_tasks.rb
+++ b/app/lib/actions/check_long_running_tasks.rb
@@ -41,5 +41,9 @@ module Actions
     def humanized_name
       _('Check for long running tasks')
     end
+
+    def rescue_strategy_for_self
+      Dynflow::Action::Rescue::Skip
+    end
   end
 end

--- a/app/lib/actions/deliver_long_running_tasks_notification.rb
+++ b/app/lib/actions/deliver_long_running_tasks_notification.rb
@@ -18,5 +18,9 @@ module Actions
     def humanized_name
       _('Deliver notifications about long running tasks')
     end
+
+    def rescue_strategy_for_self
+      ::Dynflow::Action::Rescue::Skip
+    end
   end
 end


### PR DESCRIPTION
Without this change the execution plan would go into paused and then would be picked up by subsequent checks, which would then go into paused and so on and so on.