### PR TITLE
Fixes #20391 - Hide breadcrumb title from Tasks page

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -18,7 +18,7 @@ module ForemanTasks
 
     initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :"foreman-tasks" do
-        requires_foreman '>= 3.7.0'
+        requires_foreman '>= 3.9'
         divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
         menu :top_menu, :tasks,
              :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },

--- a/webpack/ForemanTasks/Components/TasksTable/TasksIndexPage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksIndexPage.js
@@ -1,10 +1,4 @@
 import React from 'react';
-import { translate as __ } from 'foremanReact/common/I18n';
 import TasksTablePage from './';
 
-export const TasksIndexPage = props => {
-  const getBreadcrumbs = () => ({
-    breadcrumbItems: [{ caption: __('Tasks'), url: `/foreman_tasks/tasks` }],
-  });
-  return <TasksTablePage getBreadcrumbs={getBreadcrumbs} {...props} />;
-};
+export const TasksIndexPage = props => <TasksTablePage {...props} />;

--- a/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTablePage.js
@@ -123,7 +123,7 @@ TasksTablePage.propTypes = {
   selectAllRows: PropTypes.func.isRequired,
   results: PropTypes.array.isRequired,
   getTableItems: PropTypes.func.isRequired,
-  getBreadcrumbs: PropTypes.func.isRequired,
+  getBreadcrumbs: PropTypes.func,
   actionName: PropTypes.string,
   status: PropTypes.oneOf(Object.keys(STATUS)),
   history: PropTypes.object.isRequired,
@@ -143,6 +143,7 @@ TasksTablePage.propTypes = {
 TasksTablePage.defaultProps = {
   perPage: 20,
   allRowsSelected: false,
+  getBreadcrumbs: () => null,
   actionName: '',
   status: STATUS.PENDING,
   selectedRows: [],


### PR DESCRIPTION
The Tasks page had multiple titles because of the usage of breadcrumb as a title in the PageLayout. It is dependent on https://github.com/theforeman/foreman/pull/9830.

![image](https://github.com/theforeman/foreman-tasks/assets/78563507/a63adbde-b1c2-4e79-a69a-2d5eea87621d)
