### PR TITLE
Fixes #36931 - Pass keywords around the old way

### DIFF
--- a/app/lib/actions/bulk_action.rb
+++ b/app/lib/actions/bulk_action.rb
@@ -50,8 +50,11 @@ module Actions
 
       missing = Array.new((current_batch - targets.map(&:id)).count) { nil }
 
+      args = input[:args]
+      args += [input[:kwargs]] unless input[:kwargs].empty?
+
       (targets + missing).map do |target|
-        trigger(action_class, target, *input[:args], **input[:kwargs])
+        trigger(action_class, target, *args)
       end
     end
 

--- a/test/unit/actions/bulk_action_test.rb
+++ b/test/unit/actions/bulk_action_test.rb
@@ -64,6 +64,15 @@ module ForemanTasks
         _(task.input[:kw_string]).must_equal 7
         _(task.input[:kw_symbol]).must_equal 7
       end
+
+      specify 'it allows setting concurrency limit' do
+        Target.expects(:unscoped).returns(Target)
+        Target.expects(:where).with(:id => targets.map(&:id)).returns(targets)
+
+        triggered = ForemanTasks.trigger(ParentAction, ChildAction, targets, concurrency_limit: 25)
+        task = ForemanTasks::Task.where(:external_id => triggered.id).first
+        _(task.execution_plan.entry_action.concurrency_limit).must_equal 25
+      end
     end
   end
 end


### PR DESCRIPTION
This is not ideal, but it should be in line with what we had before the move to v2 bulk actions.

To handle this properly, the changes will need to start in Dynflow and then in things that build on top of it. This is something we might ultimately have to do for Ruby 3.