### PR TITLE
Fixes #37608 - cleanup TaskDetailsActions.test.js api mock

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/TaskDetailsActions.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/TaskDetailsActions.test.js
@@ -1,14 +1,9 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import { API } from 'foremanReact/redux/API';
 import {
   taskReloadStop,
   taskReloadStart,
   cancelStep,
 } from '../TaskDetailsActions';
-
-jest.mock('foremanReact/redux/API');
-
-API.post.mockImplementation(async () => ({ data: 'some-data' }));
 
 const fixtures = {
   'should start reload': () => taskReloadStart(1),


### PR DESCRIPTION
its not needed as the mock is loaded from webpack/__mocks__/foremanReact/redux/API/index.js