### PR TITLE
Hack around source location lookup failure

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -14,6 +14,8 @@ if gettext_find_task
                 .select do |action|
         src, = Object.const_source_location(action.to_s)
         src.start_with? @engine.root.to_s
+      rescue
+        warn "Unable to find plugin for action '#{action}'"
       end
 
       if klasses.any?


### PR DESCRIPTION
While extracting plugins I found this started to fail. With the patch
applied I get this output:

```console
$ bundle exec rake 'gettext:find[foreman-tasks]'
2024-09-19T12:16:13 [I|app|] Rails cache backend: File
2024-09-19T12:16:13 [W|app|] You are trying to replace import_subnets from . Adding allowed actions from plugin permissions to the existing one.
2024-09-19T12:16:13 [D|app|] Registering 15 assets for plugin foreman-tasks precompilation
Unable to find plugin for action 'Actions::CheckLongRunningTasks'
Unable to find plugin for action 'Actions::ActionWithSubPlans'
Unable to find plugin for action 'Actions::Foreman::Puppetclass::Import'
Unable to find plugin for action 'Actions::Foreman::Host::ImportFacts'
Unable to find plugin for action 'Actions::DeliverLongRunningTasksNotification'
```

That is all of the actions. When I used pry I could see that sometimes
`@engine` was `nil`. Other times lookup actually failed:

```
[1] pry(main)> action
=> Actions::Foreman::Puppetclass::Import
[4] pry(main)> Object.const_source_location(action.to_s)
=> [false, 0]
```

Looking at the [documentation](https://www.rubydoc.info/stdlib/core/Module:const_source_location) Ruby is never supposed to return `false`.

I suspect this is because of Zeitwerk changes, but I have no idea why.