### PR TITLE
 Fixes #38437 - Separate application code from plugin registration

### DIFF
--- a/lib/foreman_tasks/engine.rb
+++ b/lib/foreman_tasks/engine.rb
@@ -16,119 +16,120 @@ module ForemanTasks
       SETTINGS[:foreman_tasks] = { :assets => { :precompile => assets_to_precompile } }
     end
 
-    initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do |app|
-      app.reloader.to_prepare do
-        Foreman::Plugin.register :"foreman-tasks" do
-          requires_foreman '>= 3.15'
-          divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
-          menu :top_menu, :tasks,
-               :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },
-               :caption  => N_('Tasks'),
-               :parent   => :monitor_menu,
-               :last     => true
+    initializer 'foreman_tasks.register_plugin', :before => :finisher_hook do
+      Foreman::Plugin.register :"foreman-tasks" do
+        requires_foreman '>= 3.15'
+        divider :top_menu, :parent => :monitor_menu, :last => true, :caption => N_('Foreman Tasks')
+        menu :top_menu, :tasks,
+             :url_hash => { :controller => 'foreman_tasks/tasks', :action => :index },
+             :caption  => N_('Tasks'),
+             :parent   => :monitor_menu,
+             :last     => true
 
-          menu :top_menu, :recurring_logics,
-               :url_hash => { :controller => 'foreman_tasks/recurring_logics', :action => :index },
-               :caption  => N_('Recurring Logics'),
-               :parent   => :monitor_menu,
-               :last     => true
+        menu :top_menu, :recurring_logics,
+             :url_hash => { :controller => 'foreman_tasks/recurring_logics', :action => :index },
+             :caption  => N_('Recurring Logics'),
+             :parent   => :monitor_menu,
+             :last     => true
 
-          security_block :foreman_tasks do |_map|
-            permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :summary, :summary_sub_tasks, :show],
-                                              :'foreman_tasks/react' => [:index],
-                                              :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :summary_sub_tasks, :details, :sub_tasks] }, :resource_type => 'ForemanTasks::Task'
-            permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],
-                                              :'foreman_tasks/api/tasks' => [:bulk_resume, :bulk_cancel, :bulk_stop] }, :resource_type => 'ForemanTasks::Task'
+        security_block :foreman_tasks do |_map|
+          permission :view_foreman_tasks, { :'foreman_tasks/tasks' => [:auto_complete_search, :sub_tasks, :index, :summary, :summary_sub_tasks, :show],
+                                            :'foreman_tasks/react' => [:index],
+                                            :'foreman_tasks/api/tasks' => [:bulk_search, :show, :index, :summary, :summary_sub_tasks, :details, :sub_tasks] }, :resource_type => 'ForemanTasks::Task'
+          permission :edit_foreman_tasks, { :'foreman_tasks/tasks' => [:resume, :unlock, :force_unlock, :cancel_step, :cancel, :abort],
+                                            :'foreman_tasks/api/tasks' => [:bulk_resume, :bulk_cancel, :bulk_stop] }, :resource_type => 'ForemanTasks::Task'
 
-            permission :create_recurring_logics, {}, :resource_type => 'ForemanTasks::RecurringLogic'
+          permission :create_recurring_logics, {}, :resource_type => 'ForemanTasks::RecurringLogic'
 
-            permission :view_recurring_logics, { :'foreman_tasks/recurring_logics' => [:auto_complete_search, :index, :show],
-                                                 :'foreman_tasks/api/recurring_logics' => [:index, :show] }, :resource_type => 'ForemanTasks::RecurringLogic'
+          permission :view_recurring_logics, { :'foreman_tasks/recurring_logics' => [:auto_complete_search, :index, :show],
+                                               :'foreman_tasks/api/recurring_logics' => [:index, :show] }, :resource_type => 'ForemanTasks::RecurringLogic'
 
-            permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel, :enable, :disable, :clear_cancelled],
-                                                 :'foreman_tasks/api/recurring_logics' => [:cancel, :update, :bulk_destroy] }, :resource_type => 'ForemanTasks::RecurringLogic'
-          end
-
-          add_all_permissions_to_default_roles
-
-          settings do
-            category(:tasks, N_('Tasks')) do
-              setting('foreman_tasks_sync_task_timeout',
-                      type: :integer,
-                      description: N_('Number of seconds to wait for synchronous task to finish.'),
-                      default: 120,
-                      full_name: N_('Sync task timeout'))
-              setting('dynflow_enable_console',
-                      type: :boolean,
-                      description: N_('Enable the dynflow console (/foreman_tasks/dynflow) for debugging'),
-                      default: true,
-                      full_name: N_('Enable dynflow console'))
-              setting('dynflow_console_require_auth',
-                      type: :boolean,
-                      description: N_('Require user to be authenticated as user with admin rights when accessing dynflow console'),
-                      default: true,
-                      full_name: N_('Require auth for dynflow console'))
-              setting('foreman_tasks_proxy_action_retry_count',
-                      type: :integer,
-                      description: N_('Number of attempts to start a task on the smart proxy before failing'),
-                      default: 4,
-                      full_name: N_('Proxy action retry count'))
-              setting('foreman_tasks_proxy_action_retry_interval',
-                      type: :integer,
-                      description: N_('Time in seconds between retries'),
-                      default: 15,
-                      full_name: N_('Proxy action retry interval'))
-              setting('foreman_tasks_proxy_batch_trigger',
-                      type: :boolean,
-                      description: N_('Allow triggering tasks on the smart proxy in batches'),
-                      default: true,
-                      full_name: N_('Allow proxy batch tasks'))
-              setting('foreman_tasks_proxy_batch_size',
-                      type: :integer,
-                      description: N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'),
-                      default: 100,
-                      full_name: N_('Proxy tasks batch size'))
-              setting('foreman_tasks_troubleshooting_url',
-                      type: :string,
-                      description: N_('Url pointing to the task troubleshooting documentation. '\
-                                      'It should contain %{label} placeholder, that will be replaced with normalized task label '\
-                                      '(restricted to only alphanumeric characters)). %{version} placeholder is also available.'),
-                      default: nil,
-                      full_name: N_('Tasks troubleshooting URL'))
-              setting('foreman_tasks_polling_multiplier',
-                      type: :integer,
-                      description: N_('Polling multiplier which is used to multiply the default polling intervals. '\
-                           'This can be used to prevent polling too frequently for long running tasks.'),
-                      default: 1,
-                      full_name: N_("Polling intervals multiplier"),
-                      validate: { numericality: { greater_than: 0 } })
-            end
-          end
-
-          register_graphql_query_field :task, '::Types::Task', :record_field
-          register_graphql_query_field :tasks, '::Types::Task', :collection_field
-          register_graphql_query_field :recurring_logic, '::Types::RecurringLogic', :record_field
-          register_graphql_query_field :recurring_logics, '::Types::RecurringLogic', :collection_field
-
-          register_graphql_mutation_field :cancel_recurring_logic, '::Mutations::RecurringLogics::Cancel'
-
-          logger :dynflow, :enabled => true
-          logger :action, :enabled => true
-
-          role 'Tasks Manager', [:view_foreman_tasks, :edit_foreman_tasks],
-               'Role granting permissions to inspect, cancel, resume and unlock tasks'
-          role 'Tasks Reader', [:view_foreman_tasks],
-               'Role granting permissions to inspect tasks'
-
-          widget 'foreman_tasks/tasks/dashboard/tasks_status', :sizex => 6, :sizey => 1, :name => N_('Task Status')
-          widget 'foreman_tasks/tasks/dashboard/latest_tasks_in_error_warning', :sizex => 6, :sizey => 1, :name => N_('Latest Warning/Error Tasks')
-
-          register_gettext domain: "foreman_tasks"
-
-          ForemanTasks.dynflow.eager_load_actions!
-          extend_observable_events(::Dynflow::Action.descendants.select { |klass| klass <= ::Actions::ObservableAction }.map(&:namespaced_event_names))
+          permission :edit_recurring_logics, { :'foreman_tasks/recurring_logics' => [:cancel, :enable, :disable, :clear_cancelled],
+                                               :'foreman_tasks/api/recurring_logics' => [:cancel, :update, :bulk_destroy] }, :resource_type => 'ForemanTasks::RecurringLogic'
         end
+
+        add_all_permissions_to_default_roles
+
+        settings do
+          category(:tasks, N_('Tasks')) do
+            setting('foreman_tasks_sync_task_timeout',
+                    type: :integer,
+                    description: N_('Number of seconds to wait for synchronous task to finish.'),
+                    default: 120,
+                    full_name: N_('Sync task timeout'))
+            setting('dynflow_enable_console',
+                    type: :boolean,
+                    description: N_('Enable the dynflow console (/foreman_tasks/dynflow) for debugging'),
+                    default: true,
+                    full_name: N_('Enable dynflow console'))
+            setting('dynflow_console_require_auth',
+                    type: :boolean,
+                    description: N_('Require user to be authenticated as user with admin rights when accessing dynflow console'),
+                    default: true,
+                    full_name: N_('Require auth for dynflow console'))
+            setting('foreman_tasks_proxy_action_retry_count',
+                    type: :integer,
+                    description: N_('Number of attempts to start a task on the smart proxy before failing'),
+                    default: 4,
+                    full_name: N_('Proxy action retry count'))
+            setting('foreman_tasks_proxy_action_retry_interval',
+                    type: :integer,
+                    description: N_('Time in seconds between retries'),
+                    default: 15,
+                    full_name: N_('Proxy action retry interval'))
+            setting('foreman_tasks_proxy_batch_trigger',
+                    type: :boolean,
+                    description: N_('Allow triggering tasks on the smart proxy in batches'),
+                    default: true,
+                    full_name: N_('Allow proxy batch tasks'))
+            setting('foreman_tasks_proxy_batch_size',
+                    type: :integer,
+                    description: N_('Number of tasks which should be sent to the smart proxy in one request, if foreman_tasks_proxy_batch_trigger is enabled'),
+                    default: 100,
+                    full_name: N_('Proxy tasks batch size'))
+            setting('foreman_tasks_troubleshooting_url',
+                    type: :string,
+                    description: N_('Url pointing to the task troubleshooting documentation. '\
+                                    'It should contain %{label} placeholder, that will be replaced with normalized task label '\
+                                    '(restricted to only alphanumeric characters)). %{version} placeholder is also available.'),
+                    default: nil,
+                    full_name: N_('Tasks troubleshooting URL'))
+            setting('foreman_tasks_polling_multiplier',
+                    type: :integer,
+                    description: N_('Polling multiplier which is used to multiply the default polling intervals. '\
+                         'This can be used to prevent polling too frequently for long running tasks.'),
+                    default: 1,
+                    full_name: N_("Polling intervals multiplier"),
+                    validate: { numericality: { greater_than: 0 } })
+          end
+        end
+
+        register_graphql_query_field :task, '::Types::Task', :record_field
+        register_graphql_query_field :tasks, '::Types::Task', :collection_field
+        register_graphql_query_field :recurring_logic, '::Types::RecurringLogic', :record_field
+        register_graphql_query_field :recurring_logics, '::Types::RecurringLogic', :collection_field
+
+        register_graphql_mutation_field :cancel_recurring_logic, '::Mutations::RecurringLogics::Cancel'
+
+        logger :dynflow, :enabled => true
+        logger :action, :enabled => true
+
+        role 'Tasks Manager', [:view_foreman_tasks, :edit_foreman_tasks],
+             'Role granting permissions to inspect, cancel, resume and unlock tasks'
+        role 'Tasks Reader', [:view_foreman_tasks],
+             'Role granting permissions to inspect tasks'
+
+        widget 'foreman_tasks/tasks/dashboard/tasks_status', :sizex => 6, :sizey => 1, :name => N_('Task Status')
+        widget 'foreman_tasks/tasks/dashboard/latest_tasks_in_error_warning', :sizex => 6, :sizey => 1, :name => N_('Latest Warning/Error Tasks')
+
+        register_gettext domain: "foreman_tasks"
       end
+    end
+
+    config.after_initialize do
+      ForemanTasks.dynflow.eager_load_actions!
+      plugin = ::Foreman::Plugin.find("foreman-tasks")
+      plugin.extend_observable_events(::Dynflow::Action.descendants.select { |klass| klass <= ::Actions::ObservableAction }.map(&:namespaced_event_names))
     end
 
     initializer 'foreman_tasks.apipie' do


### PR DESCRIPTION
I'll file an issue later :)

Found that `reload!` via Rails console was broken in Katello. One reason came from this plugin:
```
Foreman::Exception: ERF42-8739 [Foreman::Exception]: Setting 'foreman_tasks_sync_task_timeout' is already defined, please avoid collisions
from /home/vagrant/foreman/app/registries/foreman/setting_manager.rb:124:in `setting'
```

This happens even in an environment where it's the only plugin: 

```
[1] pry(main)> Foreman::Plugin.registered_plugins.keys
=> [:"foreman-tasks"]
```

The design of the plugin registry is that it's built once at app load. The registry survives code reloading which is why the above error shows up. Seems like this broke in #752. 

The fix is to perform only the application-code dependent plugin work inside `reloader.to_prepare` and move the plugin registration back into an ordinary initializer.

❗ **HOWEVER** ❗ 
Katello, REX, and Foreman Tasks (maybe more) all have this line:

```
extend_observable_events(::Dynflow::Action.descendants.select { |klass| klass <= ::Actions::ObservableAction }.map(&:namespaced_event_names))
```

It brings into question the intent of the code because the result is that `::Dynflow::Action` descendants from one plugin could be referenced by any other plugin depending on when some plugin's actions were added to dynflow's eager loading

https://github.com/Dynflow/dynflow/blob/60db3a31ea05ee9f39071f0925ccc53d52af9866/lib/dynflow/rails.rb#L89-L99