### PR TITLE
Fixes #37908 - move css import from vendor to foreman

### DIFF
--- a/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksLabelsRow/TasksLabelsRow.scss
+++ b/webpack/ForemanTasks/Components/TasksDashboard/Components/TasksLabelsRow/TasksLabelsRow.scss
@@ -1,4 +1,4 @@
-@import '~@theforeman/vendor/scss/variables';
+@import 'foremanReact/common/variables';
 
 .tasks-labels-row {
   margin: 0;

--- a/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
+++ b/webpack/ForemanTasks/Components/TasksDashboard/TasksDashboard.scss
@@ -1,5 +1,5 @@
-@import '~@theforeman/vendor/scss/variables';
-@import '~@theforeman/vendor/scss/mixins';
+@import 'foremanReact/common/variables';
+@import 'foremanReact/common/scss/mixins';
 
 @mixin create-tasks-dashboard-column($columns: 12, $screen-min: 0, $gutter: $grid-gutter-width) {
   @media (min-width: $screen-min) {


### PR DESCRIPTION
css imports were moved in https://github.com/theforeman/foreman/pull/10345 already
and will break after https://github.com/theforeman/foreman/pull/10342 is merged.
This pr is only for the css import and can be merged now