### PR TITLE
Refs #37938 - Saner start_at handling

### DIFF
--- a/app/models/foreman_tasks/triggering.rb
+++ b/app/models/foreman_tasks/triggering.rb
@@ -38,7 +38,7 @@ module ForemanTasks
                                :if => proc { |t| t.recurring? && t.input_type == :monthly } }
     validate :can_start_recurring, :if => :recurring?
     validate :can_start_future, :if => :future?
-    validate :start_at_is_not_past
+    validate :start_at_is_not_past, :if => ->(triggering) { (triggering.future? || (triggering.recurring? && triggering.start_at_raw)) && triggering.start_at_changed? }
 
     def self.new_from_params(params = {})
       new(params.except(:mode, :start_at, :start_before)).tap do |triggering|

--- a/app/models/foreman_tasks/triggering.rb
+++ b/app/models/foreman_tasks/triggering.rb
@@ -36,7 +36,7 @@ module ForemanTasks
                                :if => proc { |t| t.recurring? && t.input_type == :monthly } }
     validate :can_start_recurring, :if => :recurring?
     validate :can_start_future, :if => :future?
-    validate :start_at_is_not_past, :if => ->(triggering) { (triggering.future? || (triggering.recurring? && (triggering.start_at || triggering.start_at_raw))) && triggering.start_at_changed? }
+    validate :start_at_is_not_past, :if => ->(triggering) { triggering.start_at_relevant? && triggering.start_at_changed? }
 
     def self.new_from_params(params = {})
       new(params.except(:mode, :start_at, :start_before)).tap do |triggering|
@@ -103,6 +103,11 @@ module ForemanTasks
 
     def parse_start_before!
       self.start_before ||= Time.zone.parse(start_before_raw) if start_before_raw.present?
+    end
+
+    # start_at is required for future execution and optional for recurring execution
+    def start_at_relevant?
+      future? || (recurring? && (start_at || start_at_raw))
     end
 
     private

--- a/app/models/foreman_tasks/triggering.rb
+++ b/app/models/foreman_tasks/triggering.rb
@@ -8,11 +8,9 @@ module ForemanTasks
     graphql_type '::Types::Triggering'
 
     before_save do
-      if future?
+      unless immediate?
         parse_start_at!
         parse_start_before!
-      else
-        self.start_at ||= Time.zone.now
       end
     end
 
@@ -31,21 +29,20 @@ module ForemanTasks
                            :inclusion => { :in => ALLOWED_INPUT_TYPES,
                                            :message => _('%{value} is not allowed input type') }
     validates :start_at_raw, format: { :with => TIME_REGEXP, :if => ->(triggering) { triggering.future? || (triggering.recurring? && triggering.start_at_raw) },
-                                       :message => _('%{value} is wrong format') }
+                                       :message => _('%{value} is wrong format'), :allow_blank => true }
     validates :start_before_raw, format: { :with => TIME_REGEXP, :if => :future?,
                                            :message => _('%{value} is wrong format'), :allow_blank => true }
     validates :days, format: { :with => DAYS_REGEXP,
                                :if => proc { |t| t.recurring? && t.input_type == :monthly } }
     validate :can_start_recurring, :if => :recurring?
     validate :can_start_future, :if => :future?
-    validate :start_at_is_not_past, :if => ->(triggering) { (triggering.future? || (triggering.recurring? && triggering.start_at_raw)) && triggering.start_at_changed? }
+    validate :start_at_is_not_past, :if => ->(triggering) { (triggering.future? || (triggering.recurring? && (triggering.start_at || triggering.start_at_raw))) && triggering.start_at_changed? }
 
     def self.new_from_params(params = {})
       new(params.except(:mode, :start_at, :start_before)).tap do |triggering|
         triggering.mode = params.fetch(:mode, :immediate).to_sym
         triggering.input_type = params.fetch(:input_type, :daily).to_sym
         triggering.end_time_limited = params[:end_time_limited] == 'true'
-        triggering.start_at_raw ||= Time.zone.now.strftime(TIME_FORMAT)
         triggering.recurring_logic = ::ForemanTasks::RecurringLogic.new_from_triggering(triggering) if triggering.recurring?
       end
     end
@@ -77,7 +74,7 @@ module ForemanTasks
 
     def delay_options
       {
-        :start_at => start_at.utc,
+        :start_at => start_at.try(:utc),
         :start_before => start_before.try(:utc),
       }
     end

--- a/test/unit/triggering_test.rb
+++ b/test/unit/triggering_test.rb
@@ -48,6 +48,22 @@ class TriggeringTest < ActiveSupport::TestCase
       triggering = FactoryBot.build(:triggering, :recurring_logic => logic, :mode => :recurring, :input_type => :cronline, :cronline => '* * * * *')
       assert_predicate(triggering, :valid?)
     end
+
+    it 'is valid by default' do
+      triggering = ForemanTasks::Triggering.new_from_params
+      assert triggering.save
+      # Save pre-fills start_at, which may eventually become in the past, but that should be irrelevant for type=immediate
+      assert triggering.valid?
+    end
+
+    it 'stays valid once created' do
+      triggering = ForemanTasks::Triggering.new_from_params({ :mode => "future" })
+      triggering.start_at = Time.zone.now + 1.second
+      triggering.save!
+      assert_predicate(triggering, :valid?)
+      Time.zone.expects(:now).never # No time comparisons should be done as nothing changed
+      assert_predicate(triggering, :valid?)
+    end
   end
 
   it 'cannot have mode set to arbitrary value' do

--- a/test/unit/triggering_test.rb
+++ b/test/unit/triggering_test.rb
@@ -52,8 +52,8 @@ class TriggeringTest < ActiveSupport::TestCase
     it 'is valid by default' do
       triggering = ForemanTasks::Triggering.new_from_params
       assert triggering.save
-      # Save pre-fills start_at, which may eventually become in the past, but that should be irrelevant for type=immediate
-      assert triggering.valid?
+      assert_predicate triggering.start_at, :blank?
+      assert_predicate triggering, :valid?
     end
 
     it 'stays valid once created' do


### PR DESCRIPTION
Validations are only run if the mode is future or recurring (ie. if start_at plays some roles) and only when the attribute actually changed.