### PR TITLE
Fixes #38625 - Use halting in api bulk_stop

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -160,7 +160,7 @@ module ForemanTasks
         to_stop_length = to_stop.count
         skipped_length = total_length - to_stop_length
 
-        to_stop.find_each { |task| task.update(state: :stopped) }
+        to_stop.find_each(&:halt)
 
         if params[:search]
           notification = UINotifications::Tasks::TaskBulkStop.new(filtered_scope.first, to_stop_length, skipped_length)


### PR DESCRIPTION
We started relying on the halting mechanism in Dynflow recently, but missed the bulk_stop api endpoint which should use it as well.