### PR TITLE
Fixes #38626 - Hide Sinatra error pages in production

### DIFF
--- a/lib/foreman_tasks/dynflow.rb
+++ b/lib/foreman_tasks/dynflow.rb
@@ -18,6 +18,11 @@ module ForemanTasks
           { _('Back to tasks') => "/#{ForemanTasks::TasksController.controller_path}" }
         end
         set(:world) { ::Rails.application.dynflow.world }
+        # Do not show Sinatra's pretty error pages in production
+        set(:show_exceptions) { ::Rails.env.development? }
+        # Let the errors propagate out from Sinatra to Rails.
+        # Without this, we'd only get a mostly blank 500 ISE page
+        set(:raise_errors) { !::Rails.env.development? }
       end
     end
   end


### PR DESCRIPTION
Before
<img width="1130" height="983" alt="image" src="https://github.com/user-attachments/assets/fc4ff208-52f3-407a-b9fb-e3d4469b855b" />


After
<img width="1130" height="983" alt="image" src="https://github.com/user-attachments/assets/c49f54d4-f6b4-4d80-b1ef-b0b6c04fceb6" />
