### PR TITLE
Fixes #38628 - Drop deprecated params for index tasks endpoint

### DIFF
--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -179,24 +179,12 @@ module ForemanTasks
       param :parent_task_id, :identifier, desc: 'UUID of the task'
       param_group :search_and_pagination, ::Api::V2::BaseController
       def index
-        if params[:sort_by] || params[:sort_order]
-          Foreman::Deprecation.api_deprecation_warning(
-            "The sort params sort_by and sort_order are deprecated.
-            Please use the order param instead as one string 'order=started_at desc'"
-          )
-
-          ordering_params = {
-            sort_by: params[:sort_by] || 'started_at',
-            sort_order: params[:sort_order] || 'DESC',
-          }
-          params[:order] = "#{ordering_params[:sort_by]} #{ordering_params[:sort_order]}"
-        end
         params[:order] ||= 'started_at DESC'
-        @tasks = resource_scope_for_index.order(params[:order].to_s)
+        @tasks = resource_scope_for_index
       end
 
       def search_options
-        [search_query, {}]
+        [search_query, { :order => params[:order] }]
       end
 
       def_param_group :callback_target do

--- a/app/controllers/foreman_tasks/api/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/api/tasks_controller.rb
@@ -308,17 +308,14 @@ module ForemanTasks
       end
 
       def find_task
-        @task = resource_scope.with_duration.find(params[:id])
+        @task = resource_scope.select_duration.find(params[:id])
       end
 
       def resource_scope(_options = {})
         scope = ForemanTasks::Task.authorized("#{action_permission}_foreman_tasks")
         scope = scope.where(:parent_task_id => params[:parent_task_id]) if params[:parent_task_id]
+        scope = scope.select_duration if params[:action] == 'index'
         scope
-      end
-
-      def resource_scope_for_index(*args)
-        super.with_duration.distinct
       end
 
       def controller_permission

--- a/app/controllers/foreman_tasks/tasks_controller.rb
+++ b/app/controllers/foreman_tasks/tasks_controller.rb
@@ -97,7 +97,7 @@ module ForemanTasks
     private
 
     def respond_with_tasks(scope)
-      @tasks = filter(scope, paginate: false).with_duration
+      @tasks = filter(scope, paginate: false).select_duration
       csv_response(@tasks, [:id, :action, :state, :result, 'started_at.in_time_zone', 'ended_at.in_time_zone', :duration, :username], ['Id', 'Action', 'State', 'Result', 'Started At', 'Ended At', 'Duration', 'User'])
     end
 

--- a/app/models/foreman_tasks/task.rb
+++ b/app/models/foreman_tasks/task.rb
@@ -78,7 +78,7 @@ module ForemanTasks
                                  :"foreman_tasks_links.resource_type" => resource.class.name)
            end)
     scope :for_action_types, (->(action_types) { where('foreman_tasks_tasks.label IN (?)', Array(action_types)) })
-    scope :with_duration, -> { select("foreman_tasks_tasks.*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration") }
+    virtual_column_scope :select_duration, -> { select("foreman_tasks_tasks.*, coalesce(ended_at, current_timestamp) - coalesce(coalesce(started_at, ended_at), current_timestamp) as duration") }
 
     apipie :class, "A class representing #{model_name.human} object" do
       name 'Task'

--- a/lib/foreman_tasks/tasks/export_tasks.rake
+++ b/lib/foreman_tasks/tasks/export_tasks.rake
@@ -324,7 +324,7 @@ namespace :foreman_tasks do
     format = ENV['TASK_FORMAT'] || 'html'
     export_filename = ENV['TASK_FILE'] || generate_filename(format)
 
-    task_scope = ForemanTasks::Task.search_for(filter).with_duration.order(:started_at => :desc)
+    task_scope = ForemanTasks::Task.search_for(filter).select_duration.order(:started_at => :desc)
     id_scope = task_scope.group(:id, :started_at)
 
     puts _("Exporting all tasks matching filter #{filter}")

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -37,7 +37,7 @@ module ForemanTasks
         end
 
         it 'supports ordering by duration' do
-          get :index, params: { :sort_by => 'duration' }
+          get :index, params: { :order => 'duration' }
           assert_response :success
           data = JSON.parse(response.body)
           assert_equal 'duration', data.dig('sort', 'by')
@@ -104,7 +104,7 @@ module ForemanTasks
         end
 
         it 'shows duration column' do
-          task = ForemanTasks::Task.with_duration.find(FactoryBot.create(:dynflow_task).id)
+          task = ForemanTasks::Task.select_duration.find(FactoryBot.create(:dynflow_task).id)
           get :show, params: { id: task.id }, session: set_session_user
           assert_response :success
           data = JSON.parse(response.body)
@@ -114,7 +114,7 @@ module ForemanTasks
 
       describe 'GET /api/tasks/index' do
         it 'shows duration column' do
-          task = ForemanTasks::Task.with_duration.find(FactoryBot.create(:dynflow_task).id)
+          task = ForemanTasks::Task.select_duration.find(FactoryBot.create(:dynflow_task).id)
           get :index, session: set_session_user
           assert_response :success
           data = JSON.parse(response.body)

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -93,7 +93,7 @@ module ForemanTasks
 
       describe 'index' do
         it 'shows duration column' do
-          task = ForemanTasks::Task.with_duration.find(FactoryBot.create(:some_task).id)
+          task = ForemanTasks::Task.select_duration.find(FactoryBot.create(:some_task).id)
           get(:index, params: {}, session: set_session_user)
           assert_response :success
           row = CSV.parse(response.body, headers: true).first
@@ -122,7 +122,7 @@ module ForemanTasks
 
         it 'shows duration column' do
           parent = ForemanTasks::Task.find(FactoryBot.create(:some_task).id)
-          child = ForemanTasks::Task.with_duration.find(FactoryBot.create(:some_task).id)
+          child = ForemanTasks::Task.select_duration.find(FactoryBot.create(:some_task).id)
           child.parent_task_id = parent.id
           child.save!
           get(:sub_tasks, params: { id: parent.id }, session: set_session_user)


### PR DESCRIPTION
This is somewhat related to https://github.com/theforeman/foreman/pull/10381.

~It can be merged independently, but if the PR in Foreman goes first,~ this is the follow up then.