### PR TITLE
Fixes #39324 - Preserve sub-second precision in task duration API response

### DIFF
--- a/app/views/foreman_tasks/api/tasks/show.json.rabl
+++ b/app/views/foreman_tasks/api/tasks/show.json.rabl
@@ -6,6 +6,6 @@ attributes :id, :label, :pending, :action
 attributes :username, :started_at, :ended_at, :state, :result, :progress
 
 # A workaround for https://github.com/ruby/json/issues/957
-node(:duration) { |t| t.duration&.in_seconds&.to_s if t.respond_to?(:duration) }
+node(:duration) { |t| t.duration&.to_f&.to_s if t.respond_to?(:duration) }
 attributes :input, :output, :humanized, :cli_example, :start_at
 node(:available_actions) { |t| { cancellable: t.execution_plan&.cancellable?, resumable: t.resumable? } }

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -108,7 +108,7 @@ module ForemanTasks
           get :show, params: { id: task.id }, session: set_session_user
           assert_response :success
           data = JSON.parse(response.body)
-          assert_equal task.duration.in_seconds.to_s, data['duration']
+          assert_equal task.duration.to_f.to_s, data['duration']
         end
       end
 
@@ -118,7 +118,7 @@ module ForemanTasks
           get :index, session: set_session_user
           assert_response :success
           data = JSON.parse(response.body)
-          assert_equal task.duration.in_seconds.to_s, data['results'][0]['duration']
+          assert_equal task.duration.to_f.to_s, data['results'][0]['duration']
         end
       end
 


### PR DESCRIPTION
The workaround for ruby/json#957 (commit 88faac6) replaced the plain
`duration` attribute with `.in_seconds.to_s` to avoid a `SystemStackError`
when serializing `ActiveSupport::Duration`. However, `in_seconds` is an
alias for `to_i`, which truncates sub-second precision.

Use `.to_f` instead — also returns a primitive type (Float), avoiding the
serialization recursion, but preserves the fractional seconds.

Before: `"duration": "60"`
After: `"duration": "60.123456"`