### PR TITLE
Fixes #39404 -  tasks table autocomplete broken

### DIFF
--- a/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
+++ b/webpack/ForemanTasks/Components/TasksTable/TasksTableConstants.js
@@ -5,7 +5,7 @@ export const BULK_RESUME_PATH = 'bulk_resume';
 export const BULK_FORCE_CANCEL_PATH = 'bulk_stop';
 
 export const TASKS_SEARCH_PROPS = {
-  ...getControllerSearchProps('tasks'),
+  ...getControllerSearchProps('/foreman_tasks/tasks'),
   controller: 'foreman_tasks_tasks',
 };
 


### PR DESCRIPTION
Steps to Reproduce:

Go to Monitor → Tasks (/foreman_tasks/tasks).

Open a task with sub-tasks and go to Sub tasks (/foreman_tasks/tasks/<id>/sub_tasks).

Type in the search bar.

Actual behavior:

Autocomplete requests `/foreman_tasks/tasks/<id>/tasks/auto_complete_search`, returns 404, and no suggestions appear.

