### PR TITLE
Fixes #39407 - remove the default margin for the button on vertical tabs

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Errors.scss
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Errors.scss
@@ -10,6 +10,10 @@
 
   .task-errors-tabs-split {
     flex: 0 0 min(33%, 20rem);
+
+    button {
+      margin-right: 0;
+    }
   }
 
 

--- a/webpack/ForemanTasks/Components/TaskDetails/Components/Errors.scss
+++ b/webpack/ForemanTasks/Components/TaskDetails/Components/Errors.scss
@@ -10,10 +10,6 @@
 
   .task-errors-tabs-split {
     flex: 0 0 min(33%, 20rem);
-
-    button {
-      margin-right: 0;
-    }
   }
 
 

--- a/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.scss
+++ b/webpack/ForemanTasks/Components/TaskDetails/TaskDetails.scss
@@ -4,7 +4,7 @@
     text-align: right;
   }
   a,
-  button {
+  #pf-tab-section-1-task-details-tabs > button {
     margin-right: 3px;
   }
   .container {


### PR DESCRIPTION
Before:
<img width="2482" height="1526" alt="image" src="https://github.com/user-attachments/assets/df5de558-a770-4a93-918d-ac6606d48562" />
After:
<img width="1429" height="931" alt="image" src="https://github.com/user-attachments/assets/ec49dcfa-f1f4-41bc-acfe-f8d82dfd3a73" />
