### PR TITLE
Fixes #39544 - Show error on task details page when task is paused

### DIFF
--- a/webpack/ForemanTasks/Components/TaskDetails/ExecutionDetails.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/ExecutionDetails.js
@@ -14,18 +14,23 @@ const ExecutionDetails = ({
   failedSteps,
   result,
 }) => {
-  const showingRunningSteps =
-    state === 'running' ||
-    state === 'pending' ||
-    state === 'paused' ||
-    runningSteps.length > 0;
+  const hasFailedSteps = failedSteps.length > 0;
+  const hasRunningSteps = runningSteps.length > 0;
+  const isActiveExecutionState =
+    state === 'running' || state === 'pending' || state === 'paused';
+
+  // Prefer Errors when failed steps exist (e.g. paused-after-error). Only fall
+  // back to the RunningSteps empty state for active tasks with no failures.
+  const showRunningSteps =
+    hasRunningSteps || (isActiveExecutionState && !hasFailedSteps);
+  const showErrors = hasFailedSteps || !showRunningSteps;
 
   return (
     <div
       id="execution-details-panel"
       data-ouia-component-id="execution-details-panel"
     >
-      {showingRunningSteps ? (
+      {showRunningSteps && (
         <RunningSteps
           executionPlan={executionPlan}
           result={result}
@@ -35,7 +40,8 @@ const ExecutionDetails = ({
           taskReload={taskReload}
           taskReloadStart={taskReloadStart}
         />
-      ) : (
+      )}
+      {showErrors && (
         <Errors executionPlan={executionPlan} failedSteps={failedSteps} />
       )}
     </div>

--- a/webpack/ForemanTasks/Components/TaskDetails/__tests__/ExecutionDetails.test.js
+++ b/webpack/ForemanTasks/Components/TaskDetails/__tests__/ExecutionDetails.test.js
@@ -28,9 +28,13 @@ describe('ExecutionDetails', () => {
     );
 
     expect(
-      document.querySelector('[data-ouia-component-id="execution-details-panel"]')
+      document.querySelector(
+        '[data-ouia-component-id="execution-details-panel"]'
+      )
     ).toBeInTheDocument();
-    expect(document.getElementById('execution-details-panel')).toBeInTheDocument();
+    expect(
+      document.getElementById('execution-details-panel')
+    ).toBeInTheDocument();
   });
 
   it('shows Errors pane when stopped with no running steps', () => {
@@ -44,7 +48,9 @@ describe('ExecutionDetails', () => {
       />
     );
 
-    expect(screen.getByRole('heading', { name: /^no errors found$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /^no errors found$/i })
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/the task finished with no errors or warnings/i)
     ).toBeInTheDocument();
@@ -127,9 +133,7 @@ describe('ExecutionDetails', () => {
         name: /action actions::katello::eventqueue::monitor is already active/i,
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/failed task errors/i)
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/failed task errors/i)).toBeInTheDocument();
     expect(screen.getByText('Exception:')).toBeInTheDocument();
   });
 
@@ -190,5 +194,48 @@ describe('ExecutionDetails', () => {
       screen.getByRole('heading', { name: 'Warning alert: Running step 1' })
     ).toBeInTheDocument();
     expect(screen.getByText('paused')).toBeInTheDocument();
+  });
+
+  it('shows Errors when state is paused with failed steps', () => {
+    render(
+      <ExecutionDetails
+        {...rtlBaseProps}
+        {...fixtureFailedExecutionDetail}
+        state="paused"
+        executionPlan={{ state: 'paused', cancellable: false }}
+        runningSteps={[]}
+      />
+    );
+
+    expect(
+      screen.getByRole('tab', {
+        name: /action actions::katello::eventqueue::monitor is already active/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/failed task errors/i)).toBeInTheDocument();
+    expect(screen.getByText('Exception:')).toBeInTheDocument();
+    expect(screen.queryByText(/no running steps/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Errors and RunningSteps when paused with both failed and running steps', () => {
+    render(
+      <ExecutionDetails
+        {...rtlBaseProps}
+        {...fixtureFailedExecutionDetail}
+        state="paused"
+        executionPlan={{ state: 'paused', cancellable: false }}
+        runningSteps={[
+          {
+            ...fixtureRunningExecutionDetail.runningSteps[0],
+            state: 'suspended',
+          },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Warning alert: Running step 1' })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/failed task errors/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #39544 - Show error on task details page when task is paused

<img width="1533" height="1117" alt="image" src="https://github.com/user-attachments/assets/2db83579-c9f4-4bc2-8310-c282d47a8531" />

