### PR TITLE
Refs #39674 - Use SeedHelper.format_errors in seeds

### DIFF
--- a/db/seeds.d/60-dynflow_proxy_feature.rb
+++ b/db/seeds.d/60-dynflow_proxy_feature.rb
@@ -1,2 +1,2 @@
 f = Feature.where(:name => 'Dynflow').first_or_create
-raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+raise "Unable to create proxy feature: #{SeedHelper.format_errors(f)}" if f.nil? || f.errors.any?

--- a/db/seeds.d/61-foreman_tasks_bookmarks.rb
+++ b/db/seeds.d/61-foreman_tasks_bookmarks.rb
@@ -7,6 +7,6 @@ Bookmark.without_auditing do
     next if Bookmark.where(:name => item[:name]).first
     next if SeedHelper.audit_modified? Bookmark, item[:name]
     b = Bookmark.create({ :controller => 'foreman_tasks_tasks', :public => true }.merge(item))
-    raise "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?
+    raise "Unable to create bookmark: #{SeedHelper.format_errors(b)}" if b.nil? || b.errors.any?
   end
 end


### PR DESCRIPTION
Refs #39674

The top-level `format_errors` seed helper in Foreman core is deprecated (since 3.4) and is being removed as part of Foreman #39667 (theforeman/foreman#11193). This switches the plugin seed scripts to call `SeedHelper.format_errors` directly.

`SeedHelper.format_errors` has been available since the helper was deprecated, so this change is backward compatible with all supported Foreman versions and can be merged independently of the core removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)